### PR TITLE
Add version training support

### DIFF
--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -152,12 +152,13 @@ class Version:
 
         return True
 
-    def train(self, model_format: str) -> bool:
+    def train(self, speed: str = None, checkpoint: str = None) -> bool:
         """
-        Ask the Roboflow API to train a previously exported version's dataset in a given format.
+        Ask the Roboflow API to train a previously exported version's dataset.
 
         Args:
-            model_format: A format to use for downloading
+            speed: Whether to train quickly or accurately. Note: accurate training is a paid feature. Default speed is `fast`.
+            checkpoint: A string representing the checkpoint to use while training
 
         Returns:
             True
@@ -166,9 +167,17 @@ class Version:
             RuntimeError: If the Roboflow API returns an error with a helpful JSON body
             HTTPError: If the Network/Roboflow API fails and does not return JSON
         """
-        download_url = self.__get_download_url(model_format)
-        train_url = f"{download_url}/train"
-        response = requests.post(train_url, params={"api_key": self.__api_key})
+        workspace, project, *_ = self.id.rsplit("/")
+        url = f"{API_URL}/{workspace}/{project}/{self.version}/train"
+
+        data = {}
+        if speed:
+            data["speed"] = speed
+
+        if checkpoint:
+            data["checkpoint"] = checkpoint
+
+        response = requests.post(url, json=data, params={"api_key": self.__api_key})
         if not response.ok:
             try:
                 raise RuntimeError(response.json())

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -4,15 +4,10 @@ import os
 import sys
 
 import requests
-from PIL import Image
 
 from roboflow.config import API_URL, CLIP_FEATURIZE_URL, DEMO_KEYS
 from roboflow.core.project import Project
-from roboflow.util.active_learning_utils import (
-    check_box_size,
-    clip_encode,
-    count_comparisons,
-)
+from roboflow.util.active_learning_utils import check_box_size, count_comparisons
 from roboflow.util.clip_compare_utils import clip_encode
 from roboflow.util.two_stage_utils import ocr_infer
 

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import requests
+from PIL import Image
 
 from roboflow.config import API_URL, CLIP_FEATURIZE_URL, DEMO_KEYS
 from roboflow.core.project import Project

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -135,7 +135,7 @@ class ObjectDetectionModel:
         )
 
         # Check if image exists at specified path or URL or is an array
-        if hasattr(image_path, "__len__") == True:
+        if hasattr(image_path, "__len__"):
             pass
         else:
             self.__exception_check(image_path_check=image_path)

--- a/roboflow/util/clip_compare_utils.py
+++ b/roboflow/util/clip_compare_utils.py
@@ -1,5 +1,4 @@
 import base64
-import glob
 import io
 import json
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -41,7 +41,6 @@ class TestDownload(unittest.TestCase):
 
 
 class TestExport(unittest.TestCase):
-
     def setUp(self):
         super(TestExport, self).setUp()
         self.api_url = "https://api.roboflow.com/test-workspace/test-project/4/test-format"
@@ -50,7 +49,7 @@ class TestExport(unittest.TestCase):
     @responses.activate
     def test_export_returns_true_on_api_success(self):
         responses.add(responses.POST, self.api_url, status=204)
-        
+
         export = self.version.export("test-format")
         request = responses.calls[0].request
 
@@ -62,16 +61,51 @@ class TestExport(unittest.TestCase):
     @responses.activate
     def test_export_raises_error_on_bad_request(self):
         responses.add(responses.POST, self.api_url, status=400, json={ "error": "BROKEN!!"})
-        
+
         with self.assertRaises(RuntimeError):
             self.version.export("test-format")
 
     @responses.activate
     def test_export_raises_error_on_api_failure(self):
         responses.add(responses.POST, self.api_url, status=500)
-        
+
         with self.assertRaises(requests.exceptions.HTTPError):
             self.version.export("test-format")
+
+
+class TestTrain(unittest.TestCase):
+    def setUp(self):
+        super(TestTrain, self).setUp()
+        self.api_url = "https://api.roboflow.com/test-workspace/test-project/4/test-format/train"
+        self.version = get_version(project_name="Test Dataset", id="test-workspace/test-project/2", version_number="4")
+
+    @responses.activate
+    def test_train_returns_true_on_api_success(self):
+        responses.add(responses.POST, self.api_url, status=204)  # FIXME: this _may_ return data?
+
+        train = self.version.train("test-format")
+        request = responses.calls[0].request
+
+        self.assertTrue(train)
+        self.assertEqual(request.method, "POST")
+        self.assertRegex(request.url, rf"^{self.api_url}")
+        self.assertDictEqual(request.params, { "api_key": "test-api-key" })
+
+    # TODO: test sending request body, like fast vs accurate
+
+    @responses.activate
+    def test_train_raises_error_on_bad_request(self):
+        responses.add(responses.POST, self.api_url, status=400, json={ "error": "BROKEN!!"})
+
+        with self.assertRaises(RuntimeError):
+            self.version.train("test-format")
+
+    @responses.activate
+    def test_train_raises_error_on_api_failure(self):
+        responses.add(responses.POST, self.api_url, status=500)
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            self.version.train("test-format")
 
 
 @patch.object(os, "makedirs")


### PR DESCRIPTION
# Description

This adds support for the new Roboflow train API, allowing python package users to programmatically train a dataset version.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Unit tests

## Any specific deployment considerations

We should document this new functionality!

## Docs

-   [ ] Docs updated? What were the changes:
