### PR TITLE
Fix for json_response["image"] in prediction.py

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -8,7 +8,7 @@ from roboflow.config import API_URL, APP_URL, DEMO_KEYS
 from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 
-__version__ = "0.2.23"
+__version__ = "0.2.24"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/util/prediction.py
+++ b/roboflow/util/prediction.py
@@ -488,8 +488,10 @@ class PredictionGroup:
         """
         prediction_list = []
 
+        # LOADING PHOTO TAKES TIME - PASS VARIABLES IF POSSIBLE
         image_loaded = Image.open(image_path)
         dimensions = image_loaded.size
+        # LOADING PHOTO TAKES TIME - PASS VARIABLES IF POSSIBLE
 
         if prediction_type in [OBJECT_DETECTION_MODEL, INSTANCE_SEGMENTATION_MODEL]:
             for prediction in json_response["predictions"]:

--- a/roboflow/util/prediction.py
+++ b/roboflow/util/prediction.py
@@ -488,8 +488,8 @@ class PredictionGroup:
         """
         prediction_list = []
 
-        image_loaded = cv2.imread(image_path)
-        dimensions = image_loaded.shape
+        image_loaded = Image.open(image_path)
+        dimensions = image_loaded.size
 
         if prediction_type in [OBJECT_DETECTION_MODEL, INSTANCE_SEGMENTATION_MODEL]:
             for prediction in json_response["predictions"]:

--- a/roboflow/util/prediction.py
+++ b/roboflow/util/prediction.py
@@ -488,20 +488,29 @@ class PredictionGroup:
         """
         prediction_list = []
 
+        image_loaded = cv2.imread(image_path)
+        dimensions = image_loaded.shape
+
         if prediction_type in [OBJECT_DETECTION_MODEL, INSTANCE_SEGMENTATION_MODEL]:
             for prediction in json_response["predictions"]:
                 prediction = Prediction(
                     prediction, image_path, prediction_type=prediction_type
                 )
                 prediction_list.append(prediction)
+                if "image" not in json_response:
+                    json_response["image"] = {'width': dimensions[0], 'height': dimensions[1]}
             img_dims = json_response["image"]
         elif prediction_type == CLASSIFICATION_MODEL:
             prediction = Prediction(json_response, image_path, prediction_type)
             prediction_list.append(prediction)
-            img_dims = {}
+            if "image" not in json_response:
+                    json_response["image"] = {'width': dimensions[0], 'height': dimensions[1]}
+            img_dims = json_response["image"]
         elif prediction_type == SEMANTIC_SEGMENTATION_MODEL:
             prediction = Prediction(json_response, image_path, prediction_type)
             prediction_list.append(prediction)
+            if "image" not in json_response:
+                    json_response["image"] = {'width': dimensions[0], 'height': dimensions[1]}
             img_dims = json_response["image"]
 
         # Seperate list and return as a prediction group


### PR DESCRIPTION
# Description

There was an issue because we changed our data structure recently. The resulted in json_response["image"] not existing.

Used PIL to get image dimensions and reconstructed img_dims.

_No dependency changes_

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested on two TRT scripts and with three different models. Have yet to test it on an edge device, but this fix should not be device specific.

## Any specific deployment considerations

Reading image for image dimensions takes time, if there is a more efficient way to get img_dims or if we are already pulling dims somewhere else in the script. We should pass the variable instead of creating another variable. 
