### PR TITLE
add dataset download overwrite flag

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -8,7 +8,7 @@ from roboflow.config import API_URL, APP_URL, DEMO_KEYS
 from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 
-__version__ = "0.2.24"
+__version__ = "0.2.25"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -144,12 +144,13 @@ class Version:
                 sys.stdout.flush()
             return
 
-    def download(self, model_format=None, location=None):
+    def download(self, model_format=None, location=None, overwrite: bool = True):
         """
         Download and extract a ZIP of a version's dataset in a given format
 
         :param model_format: A format to use for downloading
         :param location: An optional path for saving the file
+        :param overwrite: An optional flag to prevent dataset overwrite when dataset is already downloaded
 
         :return: Dataset
         """
@@ -165,6 +166,8 @@ class Version:
 
         if location is None:
             location = self.__get_download_location()
+        if os.path.exists(location) and not overwrite:
+            return Dataset(self.name, self.version, model_format, os.path.abspath(location))
 
         if self.__api_key == "coco-128-sample":
             link = "https://app.roboflow.com/ds/n9QwXwUK42?key=NnVCe2yMxP"

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -167,7 +167,9 @@ class Version:
         if location is None:
             location = self.__get_download_location()
         if os.path.exists(location) and not overwrite:
-            return Dataset(self.name, self.version, model_format, os.path.abspath(location))
+            return Dataset(
+                self.name, self.version, model_format, os.path.abspath(location)
+            )
 
         if self.__api_key == "coco-128-sample":
             link = "https://app.roboflow.com/ds/n9QwXwUK42?key=NnVCe2yMxP"


### PR DESCRIPTION
# Description

This change adds a dataset download overwrite flag. By default, it is set to `True` to keep the current default behavior. When set to `False,` the dataset won't get downloaded if it is already available locally. 

The motivation for that change is my current work on [PR](https://github.com/ultralytics/ultralytics/pull/295) to YOLOv8. The code there is structured so that it would re-download the dataset multiple times.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

I can change the docs if we already have documentation for that method somwhare.
