### PR TITLE
Silently fail to print the warning in version.download if Ultralytics not installed

### DIFF
--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -166,7 +166,9 @@ class Version:
                     [("ultralytics", "<=", "8.0.20")]
                 )
             except ImportError as e:
-                print("[WARNING] we noticed you are downloading a `yolov8` datasets but you don't have `ultralytics` installed. Roboflow `.deploy` supports only models trained with `ultralytics<=8.0.20`, to intall it `pip install ultralytics<=8.0.20`.")
+                print(
+                    "[WARNING] we noticed you are downloading a `yolov8` datasets but you don't have `ultralytics` installed. Roboflow `.deploy` supports only models trained with `ultralytics<=8.0.20`, to intall it `pip install ultralytics<=8.0.20`."
+                )
                 # silently fail
                 pass
 

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -166,7 +166,7 @@ class Version:
                     [("ultralytics", "<=", "8.0.20")]
                 )
             except ImportError as e:
-                print("[WARNING] we noticed you are downloading a `yolov8` datasets but you don't have `ultralytics` installed. You will need to install it to call `.deploy` later, you can use: `pip install ultralytics<=8.0.20`.")
+                print("[WARNING] we noticed you are downloading a `yolov8` datasets but you don't have `ultralytics` installed. Roboflow `.deploy` supports only models trained with `ultralytics<=8.0.20`, to intall it `pip install ultralytics<=8.0.20`.")
                 # silently fail
                 pass
 

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -29,6 +29,7 @@ from roboflow.util.versions import (
     print_warn_for_wrong_dependencies_versions,
     warn_for_wrong_dependencies_versions,
 )
+from importlib import import_module
 
 load_dotenv()
 
@@ -158,10 +159,15 @@ class Version:
         self.__wait_if_generating()
 
         if model_format == "yolov8":
-            # we assume the user will want to use yolov8, for now we only support ultralytics=="8.11.0"
-            print_warn_for_wrong_dependencies_versions(
-                [("ultralytics", "<=", "8.0.20")]
-            )
+            # if ultralytics is installed, we will assume users will want to use yolov8 and we check for the supported version
+            try:
+                import_module("ultralytics")
+                print_warn_for_wrong_dependencies_versions(
+                    [("ultralytics", "<=", "8.0.20")]
+                )
+            except ImportError as e:
+                # silently fail
+                pass
 
         model_format = self.__get_format_identifier(model_format)
 

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -3,6 +3,7 @@ import os
 import sys
 import time
 import zipfile
+from importlib import import_module
 
 import requests
 import wget
@@ -29,7 +30,6 @@ from roboflow.util.versions import (
     print_warn_for_wrong_dependencies_versions,
     warn_for_wrong_dependencies_versions,
 )
-from importlib import import_module
 
 load_dotenv()
 

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -166,6 +166,7 @@ class Version:
                     [("ultralytics", "<=", "8.0.20")]
                 )
             except ImportError as e:
+                print("[WARNING] we noticed you are downloading a `yolov8` datasets but you don't have `ultralytics` installed. You will need to install it to call `.deploy` later, you can use: `pip install ultralytics<=8.0.20`.")
                 # silently fail
                 pass
 


### PR DESCRIPTION
# Description

If `ultralytics` is not installed in `version.download`, the `print_warn_for_wrong_dependencies_versions` will throw an `ImportError`, since there are no `ultralytics` modules.

We now catch it and `pass` without printing anything. This makes sense because if the user tries to use `.deploy` later, we will inform him he needs to have `ultralytics` installed. 

I could also print a warning instead of `pass` it, down for suggestions