### PR TITLE
Fix an error in depedencies' version parsing

### DIFF
--- a/roboflow/util/versions.py
+++ b/roboflow/util/versions.py
@@ -1,6 +1,8 @@
 from importlib import import_module
 from typing import List, Tuple
 
+from packaging.version import Version
+
 
 def get_wrong_dependencies_versions(
     dependencies_versions: List[Tuple[str, str, str]]
@@ -18,8 +20,6 @@ def get_wrong_dependencies_versions(
         List[Tuple[str, str, str]]: List of dependencies with wrong version, [("<package_name>", "<version_number_to_check", "<current_version>")]
     """
     wrong_dependencies_versions = []
-    # from e.g. "1.12.0" -> 1120
-    parse_version_to_int = lambda x: int(x.replace(".", ""))
     order_funcs = {
         "==": lambda x, y: x == y,
         ">=": lambda x, y: x >= y,
@@ -32,9 +32,8 @@ def get_wrong_dependencies_versions(
             raise ValueError(
                 f"order={order} not supported, please use `{', '.join(order_funcs.keys())}`"
             )
-        is_okay = order_funcs[order](
-            parse_version_to_int(module_version), parse_version_to_int(version)
-        )
+
+        is_okay = order_funcs[order](Version(module_version), Version(version))
         if not is_okay:
             wrong_dependencies_versions.append(
                 (dependency, order, version, module_version)

--- a/tests/util/test_versions.py
+++ b/tests/util/test_versions.py
@@ -1,8 +1,6 @@
 from importlib import import_module
 from roboflow.util.versions import get_wrong_dependencies_versions
 import unittest
-import sys
-from pathlib import Path
 
 class TestVersions(unittest.TestCase):
 
@@ -14,11 +12,13 @@ class TestVersions(unittest.TestCase):
             ("tests.util.dummy_module", "<=", "0.2.0"),
             ("tests.util.dummy_module", "<=", "1.0.0"),
             ("tests.util.dummy_module", ">=", "0.1.0"),
-            ("tests.util.dummy_module", ">=", "0.6.0")
+            ("tests.util.dummy_module", ">=", "0.6.0"),
+            ("tests.util.dummy_module", ">=", "0.1.34")
+
 
         ]
         # true if dep is correc
-        expected_results = [True, False, True, True, False]
+        expected_results = [True, False, True, True, False, True]
 
         for (test, expected_result) in zip(tests, expected_results):
             wrong_dependencies_versions = get_wrong_dependencies_versions([test])


### PR DESCRIPTION
# Description

The current way I was converting to a version to a number was 

```
int(x.replace(".", ""))
```

this is not correct, if we have two version `0.2.0` and `0.1.34`, they will be converted to `20` and `134` respectively creating an issue. 

I've switched to the built-in `packaging.version` package to parse the version number