### PR TITLE
🧪 ready for colab tests

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -8,7 +8,7 @@ from roboflow.config import API_URL, APP_URL, DEMO_KEYS
 from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 
-__version__ = "0.2.29"
+__version__ = "0.2.30"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -570,7 +570,7 @@ class Version:
             if format in ["yolov5pytorch", "yolov7pytorch", "yolov8"]:
                 content["train"] = location + content["train"].lstrip("..")
                 content["val"] = location + content["val"].lstrip("..")
-            if not get_wrong_dependencies_versions([("ultralytics", ">=", "8.0.30")]):
+            if not get_wrong_dependencies_versions([("ultralytics", ">=", "8.0.30")], pass_uninstalled=True):
                 content["train"] = "train/images"
                 content["val"] = "valid/images"
                 content["test"] = "test/images"

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -560,7 +560,7 @@ class Version:
 
         :return None:
         """
-        data_path = os.path.join(location, 'data.yaml')
+        data_path = os.path.join(location, "data.yaml")
 
         def callback(content: dict) -> dict:
             if format == "mt-yolov6":

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -28,8 +28,8 @@ from roboflow.models.object_detection import ObjectDetectionModel
 from roboflow.models.semantic_segmentation import SemanticSegmentationModel
 from roboflow.util.annotations import amend_data_yaml
 from roboflow.util.versions import (
+    get_wrong_dependencies_versions,
     print_warn_for_wrong_dependencies_versions,
-    get_wrong_dependencies_versions
 )
 
 load_dotenv()

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -570,7 +570,9 @@ class Version:
             if format in ["yolov5pytorch", "yolov7pytorch", "yolov8"]:
                 content["train"] = location + content["train"].lstrip("..")
                 content["val"] = location + content["val"].lstrip("..")
-            if not get_wrong_dependencies_versions([("ultralytics", ">=", "8.0.30")], pass_uninstalled=True):
+            if not get_wrong_dependencies_versions(
+                [("ultralytics", ">=", "8.0.30")], pass_uninstalled=True
+            ):
                 content["train"] = "train/images"
                 content["val"] = "valid/images"
                 content["test"] = "test/images"

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -26,9 +26,10 @@ from roboflow.models.classification import ClassificationModel
 from roboflow.models.instance_segmentation import InstanceSegmentationModel
 from roboflow.models.object_detection import ObjectDetectionModel
 from roboflow.models.semantic_segmentation import SemanticSegmentationModel
+from roboflow.util.annotations import amend_data_yaml
 from roboflow.util.versions import (
     print_warn_for_wrong_dependencies_versions,
-    warn_for_wrong_dependencies_versions,
+    get_wrong_dependencies_versions
 )
 
 load_dotenv()
@@ -549,7 +550,7 @@ class Version:
         friendly_formats = {"yolov5": "yolov5pytorch", "yolov7": "yolov7pytorch"}
         return friendly_formats.get(format, format)
 
-    def __reformat_yaml(self, location, format):
+    def __reformat_yaml(self, location: str, format: str):
         """
         Certain formats seem to require reformatting the downloaded YAML.
         It'd be nice if the API did this, but we're doing it in python for now.
@@ -559,28 +560,23 @@ class Version:
 
         :return None:
         """
-        if format in ["yolov5pytorch", "yolov7pytorch", "yolov8"]:
-            with open(location + "/data.yaml") as file:
-                new_yaml = yaml.safe_load(file)
-            new_yaml["train"] = location + new_yaml["train"].lstrip("..")
-            new_yaml["val"] = location + new_yaml["val"].lstrip("..")
+        data_path = os.path.join(location, 'data.yaml')
 
-            os.remove(location + "/data.yaml")
+        def callback(content: dict) -> dict:
+            if format == "mt-yolov6":
+                content["train"] = location + content["train"].lstrip(".")
+                content["val"] = location + content["val"].lstrip(".")
+                content["test"] = location + content["test"].lstrip(".")
+            if format in ["yolov5pytorch", "yolov7pytorch", "yolov8"]:
+                content["train"] = location + content["train"].lstrip("..")
+                content["val"] = location + content["val"].lstrip("..")
+            if not get_wrong_dependencies_versions([("ultralytics", ">=", "8.0.30")]):
+                content["train"] = "train/images"
+                content["val"] = "valid/images"
+                content["test"] = "test/images"
+            return content
 
-            with open(location + "/data.yaml", "w") as outfile:
-                yaml.dump(new_yaml, outfile)
-
-        if format == "mt-yolov6":
-            with open(location + "/data.yaml") as file:
-                new_yaml = yaml.safe_load(file)
-            new_yaml["train"] = location + new_yaml["train"].lstrip(".")
-            new_yaml["val"] = location + new_yaml["val"].lstrip(".")
-            new_yaml["test"] = location + new_yaml["test"].lstrip(".")
-
-            os.remove(location + "/data.yaml")
-
-            with open(location + "/data.yaml", "w") as outfile:
-                yaml.dump(new_yaml, outfile)
+        amend_data_yaml(path=data_path, callback=callback)
 
     def __str__(self):
         """string representation of version object."""

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -570,12 +570,16 @@ class Version:
             if format in ["yolov5pytorch", "yolov7pytorch", "yolov8"]:
                 content["train"] = location + content["train"].lstrip("..")
                 content["val"] = location + content["val"].lstrip("..")
-            if not get_wrong_dependencies_versions(
-                [("ultralytics", ">=", "8.0.30")], pass_uninstalled=True
-            ):
-                content["train"] = "train/images"
-                content["val"] = "valid/images"
-                content["test"] = "test/images"
+            try:
+                # get_wrong_dependencies_versions raises exception if ultralytics is not installed at all
+                if not get_wrong_dependencies_versions(
+                    dependencies_versions=[("ultralytics", ">=", "8.0.30")]
+                ):
+                    content["train"] = "train/images"
+                    content["val"] = "valid/images"
+                    content["test"] = "test/images"
+            except ModuleNotFoundError:
+                pass
             return content
 
         amend_data_yaml(path=data_path, callback=callback)

--- a/roboflow/util/annotations.py
+++ b/roboflow/util/annotations.py
@@ -1,0 +1,13 @@
+import os
+import yaml
+
+from typing import Callable
+
+
+def amend_data_yaml(path: str, callback: Callable[[dict], dict]):
+    with open(path) as source:
+        content = yaml.safe_load(source)
+    content = callback(content)
+    os.remove(path)
+    with open(path, "w") as target:
+        yaml.dump(content, target)

--- a/roboflow/util/annotations.py
+++ b/roboflow/util/annotations.py
@@ -1,7 +1,7 @@
 import os
-import yaml
-
 from typing import Callable
+
+import yaml
 
 
 def amend_data_yaml(path: str, callback: Callable[[dict], dict]):

--- a/roboflow/util/versions.py
+++ b/roboflow/util/versions.py
@@ -5,7 +5,7 @@ from packaging.version import Version
 
 
 def get_wrong_dependencies_versions(
-    dependencies_versions: List[Tuple[str, str, str]], pass_uninstalled: bool = False
+    dependencies_versions: List[Tuple[str, str, str]]
 ) -> List[Tuple[str, str, str, str]]:
     """
     Get a list of mismatching dependencies with current version installed.
@@ -15,7 +15,6 @@ def get_wrong_dependencies_versions(
 
     Args:
         dependencies_versions (List[Tuple[str, str]]): List of dependencies we want to check, [("<package_name>", "<version_number_to_check")]
-        pass_uninstalled (bool): By default get_wrong_dependencies_versions will throw exception if <package_name> is not installed. You can pass_uninstalled packages by setting this parameter to True.
 
     Returns:
         List[Tuple[str, str, str]]: List of dependencies with wrong version, [("<package_name>", "<version_number_to_check", "<current_version>")]
@@ -27,23 +26,18 @@ def get_wrong_dependencies_versions(
         "<=": lambda x, y: x <= y,
     }
     for dependency, order, version in dependencies_versions:
-        try:
-            module = import_module(dependency)
-            module_version = module.__version__
-            if order not in order_funcs:
-                raise ValueError(
-                    f"order={order} not supported, please use `{', '.join(order_funcs.keys())}`"
-                )
+        module = import_module(dependency)
+        module_version = module.__version__
+        if order not in order_funcs:
+            raise ValueError(
+                f"order={order} not supported, please use `{', '.join(order_funcs.keys())}`"
+            )
 
-            is_okay = order_funcs[order](Version(module_version), Version(version))
-            if not is_okay:
-                wrong_dependencies_versions.append(
-                    (dependency, order, version, module_version)
-                )
-        except Exception as e:
-            if pass_uninstalled:
-                continue
-            raise e
+        is_okay = order_funcs[order](Version(module_version), Version(version))
+        if not is_okay:
+            wrong_dependencies_versions.append(
+                (dependency, order, version, module_version)
+            )
     return wrong_dependencies_versions
 
 


### PR DESCRIPTION
# Description

PR solves problems related to https://github.com/ultralytics/ultralytics/issues/873. Along with the `8.0.30` release, the YOLOv8 team changed the dataset loader default behavior. Currently, or dataset does not work with any `ultralytics` version higher than `8.0.29`.

After downloading we detect that the currently installed version of `ultralytics` is higher than `8.0.29` and amend `data.yaml`

```
test: test/images
train: train/images
val: valid/images
```

## Investigation

- In short, on Feb 6th YOLOv8 team released version `8.0.30` (here is the whole [diff](https://github.com/ultralytics/ultralytics/pull/832/files#diff-15f6dd1ea95b187a5b50c885f567bad50d006f1af1180508497a038247e9df58)) and that broke integration between Roboflow datasets and training and validation code. 
- There is [one change](https://github.com/ultralytics/ultralytics/pull/832/files#diff-15f6dd1ea95b187a5b50c885f567bad50d006f1af1180508497a038247e9df58L214) that is especially important in that context: path = `Path(extract_dir or data.get('path') or '')` -> `path = Path(extract_dir or data.get('path') or Path(data.get('yaml_file', '')).parent)`. To put it simply, that line resolves the dataset prefix path and, together with information located in `data.yaml` allow the YOLOv8 package to locate your images and labels on the machine. With that change, YOLOv8 team changed the default behavior.
   - Before the change prefix was pretty much hardcoded, and in the case of Google, Colab was `/content/datasets` .
   - After change prefix is the parent directory of `data.yaml`
- The problem is that data in our `data.yaml` does not work with that new approach. Let's assume that you download `football-pitch-segmentation-1`  dataset from Roboflow to  `/content`. Now the file structure looks a bit like this:

```
content/
└── football-pitch-segmentation-1/
    ├── train
    │   ├── images
    │   └── labels
    ├── test
    │   ├── images
    │   └── labels
    ├── val
    │   ├── images
    │   └── labels
    └── data.yaml
```

- Now after the change path is resolved to `/content/football-pitch-segmentation-1`. But the suffix for the train directory in our `data.yaml` is equal to `football-pitch-segmentation-1/train/images`, and that leads to an incorrect images path: `/content/football-pitch-segmentation-1/football-pitch-segmentation-1/train/images`.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

I conducted a series of tests to confirm that the Roboflow dataset can be used with YOLOv8 both for training and validating. 

| environment | `ultralytics` version |
|:-----------:|:---------------------:|
| colab       | `8.0.29`              |
| colab       | `8.0.30`              |
| colab       | `8.0.39` - current    |
| local [mac] | `8.0.29`              |
| local [mac] | `8.0.30`              |
| local [mac] | `8.0.39` - current    |
