### PR TITLE
Classification annotation upload

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -8,7 +8,7 @@ from roboflow.config import API_URL, APP_URL, DEMO_KEYS
 from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 
-__version__ = "0.2.29"
+__version__ = "0.2.31"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -339,13 +339,27 @@ class Project:
 
         return response
 
-    def __annotation_upload(self, annotation_path, image_id):
+    def __annotation_upload(self, annotation_path: str, image_id: str):
         """function to upload annotation to the specific project
         :param annotation_path: path to annotation you'd like to upload
         :param image_id: image id you'd like to upload that has annotations for it.
         """
-        # Get annotation string
-        annotation_string = open(annotation_path, "r").read()
+
+        # check if annotation file exists
+        if os.path.exists(annotation_path):
+            print("-> found given annotation file")
+            annotation_string = open(annotation_path, "r").read()
+
+        # if not annotation file, check if user wants to upload regular as classification annotation
+        elif self.type == "classification" and type(annotation_path) == str:
+            print(f"-> using {annotation_path} as classname for classification project")
+            annotation_string = annotation_path
+
+        # don't attempt upload otherwise
+        else:
+            print("file not found and project type not classification")
+            return {"result": "file not found and project type not classification"}
+
         # Set annotation upload url
         self.annotation_upload_url = "".join(
             [

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -345,20 +345,29 @@ class Project:
         :param image_id: image id you'd like to upload that has annotations for it.
         """
 
+        # stop on empty string
+        if len(annotation_path) == 0:
+            print("Please provide a non-empty string for annotation_path.")
+            return {"result": "Please provide a non-empty string for annotation_path."}
+
         # check if annotation file exists
-        if os.path.exists(annotation_path):
+        elif os.path.exists(annotation_path):
             print("-> found given annotation file")
             annotation_string = open(annotation_path, "r").read()
 
         # if not annotation file, check if user wants to upload regular as classification annotation
-        elif self.type == "classification" and type(annotation_path) == str:
+        elif self.type == "classification":
             print(f"-> using {annotation_path} as classname for classification project")
             annotation_string = annotation_path
 
         # don't attempt upload otherwise
         else:
-            print("file not found and project type not classification")
-            return {"result": "file not found and project type not classification"}
+            print(
+                "File not found or uploading to non-classification type project with invalid string"
+            )
+            return {
+                "result": "File not found or uploading to non-classification type project with invalid string"
+            }
 
         # Set annotation upload url
         self.annotation_upload_url = "".join(
@@ -555,7 +564,12 @@ class Project:
                 annotation_success = False
             # Give user warning that annotation failed to upload
             if not annotation_success:
-                warnings.warn("Annotation, " + annotation_path + ", failed to upload!")
+                warnings.warn(
+                    "Annotation, "
+                    + annotation_path
+                    + "failed to upload!\n Upload correct annotation file to image_id: "
+                    + image_id
+                )
         else:
             annotation_success = True
 


### PR DESCRIPTION
# Description

Updated annotation upload logic to support passing a class name as a raw string to classification projects.

## Type of change
-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

test cases:
- empty string
- string is filepath that doesn't exist
- string is alphabet characters

For some reason using a number in a string such as `"1"` fails on upload and not sure why. Will need separate resolution.

-   [x] Docs updated? What were the changes: need to update docs to support classification string
