### PR TITLE
update annotation upload to reference correct project name

### DIFF
--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -373,7 +373,7 @@ class Project:
         self.annotation_upload_url = "".join(
             [
                 API_URL + "/dataset/",
-                self.name,
+                self.__project_name,
                 "/annotate/",
                 image_id,
                 "?api_key=",
@@ -381,12 +381,14 @@ class Project:
                 "&name=" + os.path.basename(annotation_path),
             ]
         )
+
         # Get annotation response
         annotation_response = requests.post(
             self.annotation_upload_url,
             data=annotation_string,
             headers={"Content-Type": "text/plain"},
         )
+
         # Return annotation response
         return annotation_response
 


### PR DESCRIPTION
# Description

Referenced `self.name` instead of `self.__project_name`. During original testing these coincidently were the same but can sometimes differ when we do string sanitation.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)