### PR TITLE
Classification Inference Fix - PredictionGroup

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -8,7 +8,7 @@ from roboflow.config import API_URL, APP_URL, DEMO_KEYS
 from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 
-__version__ = "0.2.32"
+__version__ = "0.2.33"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/models/classification.py
+++ b/roboflow/models/classification.py
@@ -47,6 +47,7 @@ class ClassificationModel:
             # Create buffer
             buffered = io.BytesIO()
             image.save(buffered, quality=90, format="JPEG")
+            img_dims = image.size
             # Base64 encode image
             img_str = base64.b64encode(buffered.getvalue())
             img_str = img_str.decode("ascii")
@@ -66,7 +67,7 @@ class ClassificationModel:
             raise Exception(resp.text)
 
         return PredictionGroup.create_prediction_group(
-            resp.json(), image_path=image_path, prediction_type=CLASSIFICATION_MODEL
+            resp.json(), image_dims=img_dims, image_path=image_path, prediction_type=CLASSIFICATION_MODEL
         )
 
     def load_model(self, name, version):

--- a/roboflow/models/classification.py
+++ b/roboflow/models/classification.py
@@ -67,7 +67,10 @@ class ClassificationModel:
             raise Exception(resp.text)
 
         return PredictionGroup.create_prediction_group(
-            resp.json(), image_dims=img_dims, image_path=image_path, prediction_type=CLASSIFICATION_MODEL
+            resp.json(),
+            image_dims=img_dims,
+            image_path=image_path,
+            prediction_type=CLASSIFICATION_MODEL,
         )
 
     def load_model(self, name, version):


### PR DESCRIPTION
# Description

Had to add image_dims to the return statement for classification inference. The PredictionGroup requires that parameter and I would rather not delete it as it might be a legacy / active para in the PredictionGroup function.

Easiest fix was to add image.size to the classification predict function and pass that in the return to maintain the next function.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested on multiple two stage scripts. Confirmed that it does fix the classification inference issue.

## Docs

There is no change to the docs necessary and the call method will stay the same.