### PR TITLE
Removes TestPyPi from Publish Action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,5 @@ check_code_quality:
 	
 publish:
 	python setup.py sdist bdist_wheel
-	twine upload -r testpypi dist/* -u ${PYPI_USERNAME} -p ${PYPI_TEST_PASSWORD} --verbose 
 	twine check dist/*
 	twine upload dist/* -u ${PYPI_USERNAME} -p ${PYPI_PASSWORD} --verbose 

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -8,7 +8,7 @@ from roboflow.config import API_URL, APP_URL, DEMO_KEYS
 from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 
-__version__ = "0.2.33"
+__version__ = "0.2.34"
 
 
 def check_key(api_key, model, notebook, num_retries=0):


### PR DESCRIPTION
# Description

Removes TestPyPi from Publish Action as we often do that manually ahead of time
