### PR TITLE
Update config.py

### DIFF
--- a/roboflow/config.py
+++ b/roboflow/config.py
@@ -17,7 +17,7 @@ def get_conditional_configuration_variable(key, default):
     # default configuration location
     conf_location = os.getenv(
         "ROBOFLOW_CONFIG_DIR",
-        default=os.getenv("HOME") + "/.config/roboflow/config.json",
+        default=f"os.getenv('HOME')/.config/roboflow/config.json",
     )
 
     # read config file for roboflow if logged in from python or CLI


### PR DESCRIPTION
Fixes "TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'"

# Description

Fixes "TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'"

I believe this Error appears in Windows when the path contains spaces.

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

I haven't tested it if not on my local system (Windows 11), it fixed the problem for me so I thought of submitting it to you who surely have a better understanding of the whole system and the eventual larger impacts this might have.

Hope it's useful!

