### PR TITLE
fix env variable for windows

### DIFF
--- a/roboflow/config.py
+++ b/roboflow/config.py
@@ -17,7 +17,7 @@ def get_conditional_configuration_variable(key, default):
     # default configuration location
     conf_location = os.getenv(
         "ROBOFLOW_CONFIG_DIR",
-        default=os.getenv("HOME") + "/.config/roboflow/config.json",
+        default=os.path.expanduser('~') + "/.config/roboflow/config.json",
     )
 
     # read config file for roboflow if logged in from python or CLI


### PR DESCRIPTION
# Description

File "C:/Users/<username>/.conda/envs/ML/lib/site-packages/roboflow/config.py", line 20, in get_conditional_configuration_variable
    default=os.getenv("HOME") + "/.config/roboflow/config.json",
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'

* if this change wont be approved, I would need to make this little change after I run `pip install roboflow` QQ
* no dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?
it make me run roboflow successfully in windows, and it also have same result as the wsl-ubuntu-20.04 
![image](https://user-images.githubusercontent.com/54034701/229186483-033a6f49-5f4f-4950-8329-344b60a8e238.png)

## Any specific deployment considerations

no

## Docs
no
