### PR TITLE
`nocache=true` for Model Upload API

### DIFF
--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -570,7 +570,7 @@ class Version:
                         )
 
         res = requests.get(
-            f"{API_URL}/{self.workspace}/{self.project}/{self.version}/uploadModel?api_key={self.__api_key}&modelType={model_type}"
+            f"{API_URL}/{self.workspace}/{self.project}/{self.version}/uploadModel?api_key={self.__api_key}&modelType={model_type}&nocache=true"
         )
         try:
             if res.status_code == 429:


### PR DESCRIPTION
# Description
Added `nocache=true` query param to the model upload api call to ensure we have the latest data for the model version.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
