### PR TITLE
Pt download2

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -12,7 +12,7 @@ from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 from roboflow.util.general import write_line
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -433,32 +433,6 @@ class Version:
         # return the model object
         return self.model
 
-    def get_pt_weights(self, location="."):
-        workspace, project, *_ = self.id.rsplit("/")
-
-        # get pt url
-        pt_api_url = f"{API_URL}/{workspace}/{project}/{self.version}/ptFile"
-
-        r = requests.get(pt_api_url, params={"api_key": self.__api_key})
-
-        r.raise_for_status()
-
-        pt_weights_url = r.json()["weightsUrl"]
-
-        def bar_progress(current, total, width=80):
-            progress_message = (
-                "Downloading weights to "
-                + location
-                + "/weights.pt"
-                + ": %d%% [%d / %d] bytes" % (current / total * 100, current, total)
-            )
-            sys.stdout.write("\r" + progress_message)
-            sys.stdout.flush()
-
-        wget.download(pt_weights_url, out=location + "/weights.pt", bar=bar_progress)
-
-        return
-
     # @warn_for_wrong_dependencies_versions([("ultralytics", "<=", "8.0.20")])
     def deploy(self, model_type: str, model_path: str) -> None:
         """Uploads provided weights file to Roboflow

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -461,7 +461,7 @@ class ObjectDetectionModel:
         else:
             view(stopButton)
 
-    def download(self, location=".", format="pt"):
+    def download(self, format="pt", location="."):
         supported_formats = ["pt"]
         if format not in supported_formats:
             raise Exception(

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -26,6 +26,7 @@ from roboflow.util.versions import (
     warn_for_wrong_dependencies_versions,
 )
 
+
 class ObjectDetectionModel:
     def __init__(
         self,
@@ -466,7 +467,9 @@ class ObjectDetectionModel:
     def download(self, location=".", format="pt"):
         supported_formats = ["pt"]
         if format not in supported_formats:
-            raise Exception(f"Unsupported format {format}. Must be one of {supported_formats}")
+            raise Exception(
+                f"Unsupported format {format}. Must be one of {supported_formats}"
+            )
 
         workspace, project, version = self.id.rsplit("/")
 

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -3,8 +3,8 @@ import copy
 import io
 import json
 import os
-import sys
 import random
+import sys
 import urllib
 from pathlib import Path
 
@@ -15,10 +15,7 @@ import requests
 import wget
 from PIL import Image
 
-from roboflow.config import (
-    OBJECT_DETECTION_MODEL,
-    API_URL,
-)
+from roboflow.config import API_URL, OBJECT_DETECTION_MODEL
 from roboflow.util.image_utils import check_image_url
 from roboflow.util.prediction import PredictionGroup
 from roboflow.util.versions import (


### PR DESCRIPTION
# Description

This moves and renames a single method, as a follow-up of #137 

`Version.get_pt_weights` is replaced by `model.download()`, which makes more sense: download a model's weights is an operation that should belong to the model (version already has a `download()` method to download images)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally against the production api