### PR TITLE
fix typo in config.py

### DIFF
--- a/roboflow/config.py
+++ b/roboflow/config.py
@@ -61,7 +61,7 @@ SEMANTIC_SEGMENTATION_URL = get_conditional_configuration_variable(
     "SEMANTIC_SEGMENTATION_URL", "https://segment.roboflow.com"
 )
 OBJECT_DETECTION_URL = get_conditional_configuration_variable(
-    "SEMANTIC_SEGMENTATION_URL", "https://detect.roboflow.com"
+    "OBJECT_DETECTION_URL", "https://detect.roboflow.com"
 )
 
 CLIP_FEATURIZE_URL = get_conditional_configuration_variable(


### PR DESCRIPTION
I think the config for the `OBJECT_DETECTION_URL` is reading the wrong env variable
