### PR TITLE
`local` Parameter For Instance Segmentation Version

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -12,7 +12,7 @@ from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 from roboflow.util.general import write_line
 
-__version__ = "1.0.8"
+__version__ = "1.0.9"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -120,6 +120,7 @@ class Version:
                     self.id,
                     colors=self.colors,
                     preprocessing=self.preprocessing,
+                    local=local,
                 )
             elif self.type == TYPE_SEMANTIC_SEGMENTATION:
                 self.model = SemanticSegmentationModel(self.__api_key, self.id)

--- a/roboflow/models/instance_segmentation.py
+++ b/roboflow/models/instance_segmentation.py
@@ -3,13 +3,20 @@ from roboflow.models.inference import InferenceModel
 
 
 class InstanceSegmentationModel(InferenceModel):
-    def __init__(self, api_key, version_id, colors=None, preprocessing=None):
+    def __init__(
+        self, api_key, version_id, colors=None, preprocessing=None, local=None
+    ):
         """
         :param api_key: Your API key (obtained via your workspace API settings page)
         :param version_id: The ID of the dataset version to use for predicting
         """
         super(InstanceSegmentationModel, self).__init__(api_key, version_id)
-        self.api_url = f"{INSTANCE_SEGMENTATION_URL}/{self.dataset_id}/{self.version}"
+        if local is None:
+            self.api_url = (
+                f"{INSTANCE_SEGMENTATION_URL}/{self.dataset_id}/{self.version}"
+            )
+        else:
+            self.api_url = f"{local}/{self.dataset_id}/{self.version}"
         self.colors = {} if colors is None else colors
         self.preprocessing = {} if preprocessing is None else preprocessing
 


### PR DESCRIPTION
# Description

Added the `local` parameter functionality to instance segmentation giving the ability to infer using a local inference server instead of the hosted endpoint.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally with dev script
