### PR TITLE
Fix for issue #128 and #149

### DIFF
--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -486,7 +486,7 @@ class Project:
             images = os.listdir(image_path)
             for image in images:
                 path = image_path + "/" + image
-                if self.check_valid_image(image):
+                if self.check_valid_image(path):
                     self.single_upload(
                         image_path=path,
                         annotation_path=annotation_path,

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -43,11 +43,11 @@ class TestDownload(unittest.TestCase):
     def test_download_returns_dataset(self, *_):
         responses.add(responses.GET, self.api_url, json={"export": { "link": None }})
         responses.add(responses.GET, self.generating_url, json={"version": {"generating": False, "progress": 1.0}})
-        dataset = self.version.download("coco", location="/my-spot")
+        dataset = self.version.download("coco", location=os.path.abspath(os.sep + "my-spot"))
         self.assertEqual(dataset.name, self.version.name)
         self.assertEqual(dataset.version, self.version.version)
         self.assertEqual(dataset.model_format, "coco")
-        self.assertEqual(dataset.location, "/my-spot")
+        self.assertEqual(dataset.location, os.path.abspath(os.sep + "my-spot"))
 
 
 class TestExport(unittest.TestCase):


### PR DESCRIPTION
# Description

Changed the input to self.check_valid_image() in line 489 of [project.py](https://github.com/roboflow/roboflow-python/blob/main/roboflow/core/project.py) from image to path as the function is meant to take image path but it was taking image variable as input. This fixes #128.

But after making the changes when I ran `python -m unittest`, "test_download_returns_dataset" was failing as the assertEqual() function was checking Linux style paths and not Windows style paths. Hence I created #149.

But I fixed #149 by changing the second arguments of line 46 and 50 of [test_version.py](https://github.com/roboflow/roboflow-python/blob/main/tests/test_version.py) such that the download path is asserted according to the OS environment. I used os.path.abspath as I saw that the download function in [version.py](https://github.com/roboflow/roboflow-python/blob/605fd458cd03ecaef6f46aa58c36150f74b56f83/roboflow/core/version.py#L203) is also using abspath for download location. Now all test cases are passing in the Windows environment.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally with dev script

## Any specific deployment considerations

No
