### PR TITLE
Add search and search_all attributes

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -12,7 +12,7 @@ from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 from roboflow.util.general import write_line
 
-__version__ = "1.0.9"
+__version__ = "1.1.1"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -616,7 +616,7 @@ class Project:
 
         overall_success = success and annotation_success
         return overall_success
-    
+
     def search(
         self,
         like_image: str = None,
@@ -673,7 +673,7 @@ class Project:
         )
 
         return data.json()["results"]
-    
+
     def search_all(
         self,
         like_image: str = None,

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -616,6 +616,97 @@ class Project:
 
         overall_success = success and annotation_success
         return overall_success
+    
+    def search(
+        self,
+        like_image: str = None,
+        prompt: str = None,
+        offset: int = 0,
+        limit: int = 100,
+        tag: str = None,
+        class_name: str = None,
+        in_dataset: str = None,
+        batch: bool = False,
+        batch_id: str = None,
+        fields: list = ["id", "created", "name", "labels"],
+    ):
+        payload = {}
+
+        if like_image is not None:
+            payload["like_image"] = like_image
+
+        if prompt is not None:
+            payload["prompt"] = prompt
+
+        if offset is not None:
+            payload["offset"] = offset
+
+        if limit is not None:
+            payload["limit"] = limit
+
+        if tag is not None:
+            payload["tag"] = tag
+
+        if class_name is not None:
+            payload["class_name"] = class_name
+
+        if in_dataset is not None:
+            payload["in_dataset"] = in_dataset
+
+        if batch is not None:
+            payload["batch"] = batch
+
+        if batch_id is not None:
+            payload["batch_id"] = batch_id
+
+        payload["fields"] = fields
+
+        data = requests.post(
+            API_URL
+            + "/"
+            + self.__workspace
+            + "/"
+            + self.__project_name
+            + "/search?api_key="
+            + self.__api_key,
+            json=payload,
+        )
+
+        return data.json()["results"]
+    
+    def search_all(
+        self,
+        like_image: str = None,
+        prompt: str = None,
+        offset: int = 0,
+        limit: int = 100,
+        tag: str = None,
+        class_name: str = None,
+        in_dataset: str = None,
+        batch: bool = False,
+        batch_id: str = None,
+        fields: list = ["id", "created"],
+    ):
+        while True:
+            data = self.search(
+                like_image=like_image,
+                prompt=prompt,
+                offset=offset,
+                limit=limit,
+                tag=tag,
+                class_name=class_name,
+                in_dataset=in_dataset,
+                batch=batch,
+                batch_id=batch_id,
+                fields=fields,
+            )
+
+            yield data
+
+            if len(data) < limit:
+                break
+
+            offset += limit
 
     def __str__(self):
         # String representation of project


### PR DESCRIPTION
# Description

This PR introduces two new methods:

- `search`: Returns the search results for a dataset search query.
- `search_all`: Returns a generator that yields pages of search results. 

## Type of change

Please delete options that are not relevant.

-   [X] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

You can test this feature using the following code:

```
import roboflow

roboflow.login()

rf = roboflow.Roboflow()

# List all projects for your workspace
workspace = rf.workspace()

project = rf.project("mug-detector-23eqf")

# List all versions of a specific project
print(project.search(
    prompt="mug"
))

records = []

for page in project.search_all(
    prompt="mug"
):
    records.extend(page)

print(len(records))
```

You will need to specify your own dataset ID.

## Any specific deployment considerations

N/A

## Docs

I will update our quickstart docs on Gitbook once we release this feature.