### PR TITLE
Bugfix/ Model upload logs

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -12,7 +12,7 @@ from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 from roboflow.util.general import write_line
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -593,14 +593,14 @@ class Version:
 
             if self.public:
                 print(
-                    f"View the status of your deployment at: {APP_URL}/{self.workspace}/{self.project}/deploy/{self.version}"
+                    f"View the status of your deployment at: {APP_URL}/{self.workspace}/{self.project}/{self.version}"
                 )
                 print(
                     f"Share your model with the world at: {UNIVERSE_URL}/{self.workspace}/{self.project}/model/{self.version}"
                 )
             else:
                 print(
-                    f"View the status of your deployment at: {APP_URL}/{self.workspace}/{self.project}/deploy/{self.version}"
+                    f"View the status of your deployment at: {APP_URL}/{self.workspace}/{self.project}/{self.version}"
                 )
 
         except Exception as e:

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -181,11 +181,11 @@ class Version:
             try:
                 import_module("ultralytics")
                 print_warn_for_wrong_dependencies_versions(
-                    [("ultralytics", ">=", "8.0.20")]
+                    [("ultralytics", "==", "8.0.134")]
                 )
             except ImportError as e:
                 print(
-                    "[WARNING] we noticed you are downloading a `yolov8` datasets but you don't have `ultralytics` installed. Roboflow `.deploy` supports only models trained with `ultralytics>=8.0.20`, to intall it `pip install ultralytics>=8.0.20`."
+                    "[WARNING] we noticed you are downloading a `yolov8` datasets but you don't have `ultralytics` installed. Roboflow `.deploy` supports only models trained with `ultralytics==8.0.134`, to intall it `pip install ultralytics==8.0.134`."
                 )
                 # silently fail
                 pass
@@ -434,7 +434,7 @@ class Version:
         # return the model object
         return self.model
 
-    # @warn_for_wrong_dependencies_versions([("ultralytics", ">=", "8.0.20")])
+    # @warn_for_wrong_dependencies_versions([("ultralytics", "==", "8.0.134")])
     def deploy(self, model_type: str, model_path: str) -> None:
         """Uploads provided weights file to Roboflow
 
@@ -464,7 +464,7 @@ class Version:
                 )
 
             print_warn_for_wrong_dependencies_versions(
-                [("ultralytics", ">=", "8.0.20")]
+                [("ultralytics", "==", "8.0.134")]
             )
 
         elif "yolov5" in model_type or "yolov7" in model_type:
@@ -730,7 +730,7 @@ class Version:
             try:
                 # get_wrong_dependencies_versions raises exception if ultralytics is not installed at all
                 if format == "yolov8" and not get_wrong_dependencies_versions(
-                    dependencies_versions=[("ultralytics", ">=", "8.0.30")]
+                    dependencies_versions=[("ultralytics", "==", "8.0.134")]
                 ):
                     content["train"] = "train/images"
                     content["val"] = "valid/images"

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -181,11 +181,11 @@ class Version:
             try:
                 import_module("ultralytics")
                 print_warn_for_wrong_dependencies_versions(
-                    [("ultralytics", "<=", "8.0.20")]
+                    [("ultralytics", ">=", "8.0.20")]
                 )
             except ImportError as e:
                 print(
-                    "[WARNING] we noticed you are downloading a `yolov8` datasets but you don't have `ultralytics` installed. Roboflow `.deploy` supports only models trained with `ultralytics<=8.0.20`, to intall it `pip install ultralytics<=8.0.20`."
+                    "[WARNING] we noticed you are downloading a `yolov8` datasets but you don't have `ultralytics` installed. Roboflow `.deploy` supports only models trained with `ultralytics>=8.0.20`, to intall it `pip install ultralytics>=8.0.20`."
                 )
                 # silently fail
                 pass
@@ -434,7 +434,7 @@ class Version:
         # return the model object
         return self.model
 
-    # @warn_for_wrong_dependencies_versions([("ultralytics", "<=", "8.0.20")])
+    # @warn_for_wrong_dependencies_versions([("ultralytics", ">=", "8.0.20")])
     def deploy(self, model_type: str, model_path: str) -> None:
         """Uploads provided weights file to Roboflow
 
@@ -464,7 +464,7 @@ class Version:
                 )
 
             print_warn_for_wrong_dependencies_versions(
-                [("ultralytics", "<=", "8.0.20")]
+                [("ultralytics", ">=", "8.0.20")]
             )
 
         elif "yolov5" in model_type or "yolov7" in model_type:


### PR DESCRIPTION
# Description

Corrects logging for the model upload feature. 
- Required ultralytics version is > 8.0.20 rather than <
- Deploy page URL is updated to correct path

Previous logs asked for ultralytics version < 8.0.20, even though we require a greater version. And they point to the old URL path of `../deploy/..`
<img width="1407" alt="image" src="https://github.com/roboflow/roboflow-python/assets/6319317/ebf22a50-3d47-44a9-9f16-32374240bdda">

New logs point to correct path
<img width="868" alt="image" src="https://github.com/roboflow/roboflow-python/assets/6319317/7e29a422-340a-4309-8e03-6e73603a5624">

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested model upload with local package.

## Any specific deployment considerations

None.
