### PR TITLE
Make uploading large datasets more robust

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -12,7 +12,7 @@ from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 from roboflow.util.general import write_line
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -530,20 +530,22 @@ class Project:
                 tag_names=tag_names,
                 **kwargs,
             )
+            upload_response_data = None
             # Get JSON response values
             try:
+                upload_response_data = response.json()
                 if "duplicate" in response.json().keys():
-                    if response.json()["duplicate"]:
+                    if upload_response_data["duplicate"]:
                         success = True
                         warnings.warn("Duplicate image not uploaded:  " + image_path)
                 else:
                     success, image_id = (
-                        response.json()["success"],
-                        response.json()["id"],
+                        upload_response_data["success"],
+                        upload_response_data["id"],
                     )
 
                 if not success:
-                    warnings.warn(f"Server rejected image: {response.json()}")
+                    warnings.warn(f"Server rejected image: {upload_response_data or response}")
 
             except Exception:
                 # Image fails to upload
@@ -552,7 +554,7 @@ class Project:
             # Give user warning that image failed to upload
             if not success:
                 warnings.warn(
-                    "Upload api failed with response: " + str(response.json())
+                    "Upload api failed with response: " + str(upload_response_data or response)
                 )
                 if num_retry_uploads > 0:
                     warnings.warn(

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -545,7 +545,9 @@ class Project:
                     )
 
                 if not success:
-                    warnings.warn(f"Server rejected image: {upload_response_data or response}")
+                    warnings.warn(
+                        f"Server rejected image: {upload_response_data or response}"
+                    )
 
             except Exception:
                 # Image fails to upload
@@ -554,7 +556,8 @@ class Project:
             # Give user warning that image failed to upload
             if not success:
                 warnings.warn(
-                    "Upload api failed with response: " + str(upload_response_data or response)
+                    "Upload api failed with response: "
+                    + str(upload_response_data or response)
                 )
                 if num_retry_uploads > 0:
                     warnings.warn(

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -25,8 +25,11 @@ def custom_formatwarning(msg, *args, **kwargs):
 
 warnings.formatwarning = custom_formatwarning
 
+
 class UploadError(Exception):
     pass
+
+
 class Project:
     def __init__(self, api_key, a_project, model_format=None):
         if api_key in DEMO_KEYS:
@@ -357,11 +360,15 @@ class Project:
                     raise UploadError(f"Server rejected image: {responsejson}")
                 return responsejson.get("id")
             else:
-                warnings.warn(f"upload image {image_path} 200 OK, weird response: {response}")
+                warnings.warn(
+                    f"upload image {image_path} 200 OK, weird response: {response}"
+                )
                 return None
         else:
             if responsejson:
-                raise UploadError(f"Bad response: {response.status_code} - {responsejson}")
+                raise UploadError(
+                    f"Bad response: {response.status_code} - {responsejson}"
+                )
             else:
                 raise UploadError(f"Bad response: {response}")
 
@@ -423,21 +430,35 @@ class Project:
         if response.status_code == 200:
             if responsejson:
                 if responsejson.get("error"):
-                    raise UploadError(f"Failed to save annotation for {image_id}: {responsejson['error']}")
+                    raise UploadError(
+                        f"Failed to save annotation for {image_id}: {responsejson['error']}"
+                    )
                 elif not responsejson.get("success"):
-                    raise UploadError(f"Failed to save annotation for {image_id}: {responsejson}")
+                    raise UploadError(
+                        f"Failed to save annotation for {image_id}: {responsejson}"
+                    )
             else:
-                warnings.warn(f"save annotation {annotation_path} 200 OK, weird response: {response}")
-        elif response.status_code == 409 and "already annotated" in (responsejson or {}).get("error", {}).get("message"):
+                warnings.warn(
+                    f"save annotation {annotation_path} 200 OK, weird response: {response}"
+                )
+        elif response.status_code == 409 and "already annotated" in (
+            responsejson or {}
+        ).get("error", {}).get("message"):
             print(f"image already annotated: {annotation_path}")
         else:
             if responsejson:
-                if responsejson.get('error'):
-                    raise UploadError(f"save annotation for {image_id} / bad response: {response.status_code} - {responsejson['error']}")
+                if responsejson.get("error"):
+                    raise UploadError(
+                        f"save annotation for {image_id} / bad response: {response.status_code} - {responsejson['error']}"
+                    )
                 else:
-                    raise UploadError(f"save annotation for {image_id} / bad response: {response.status_code} - {responsejson}")
+                    raise UploadError(
+                        f"save annotation for {image_id} / bad response: {response.status_code} - {responsejson}"
+                    )
             else:
-                raise UploadError(f"save annotation for {image_id} bad response: {response}")
+                raise UploadError(
+                    f"save annotation for {image_id} bad response: {response}"
+                )
 
     def check_valid_image(self, image_path):
         try:
@@ -555,7 +576,10 @@ class Project:
         annotation_success = False
         if image_path is not None:
             try:
-                image_id = retry(num_retry_uploads, Exception, self.__image_upload,
+                image_id = retry(
+                    num_retry_uploads,
+                    Exception,
+                    self.__image_upload,
                     image_path,
                     hosted_image=hosted_image,
                     split=split,
@@ -565,17 +589,24 @@ class Project:
                 )
                 success = True
             except BaseException as e:
-                print(f'{image_path} ERROR uploading image after {num_retry_uploads} retries: {e}', file=sys.stderr)
+                print(
+                    f"{image_path} ERROR uploading image after {num_retry_uploads} retries: {e}",
+                    file=sys.stderr,
+                )
                 return
 
         # Upload only annotations to image based on image Id (no image)
         if annotation_path is not None and image_id is not None and success:
             # Get annotation upload response
             try:
-                self.__annotation_upload(annotation_path, image_id, is_prediction=is_prediction)
+                self.__annotation_upload(
+                    annotation_path, image_id, is_prediction=is_prediction
+                )
                 annotation_success = True
             except BaseException as e:
-                print(f'{annotation_path} ERROR saving annotation: {e}', file=sys.stderr)
+                print(
+                    f"{annotation_path} ERROR saving annotation: {e}", file=sys.stderr
+                )
                 return False
             # Give user warning that annotation failed to upload
             if not annotation_success:

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -428,6 +428,8 @@ class Project:
                     raise UploadError(f"Failed to save annotation for {image_id}: {responsejson}")
             else:
                 warnings.warn(f"save annotation {annotation_path} 200 OK, weird response: {response}")
+        elif response.status_code == 409 and "already annotated" in (responsejson or {}).get("error", {}).get("message"):
+            print(f"image already annotated: {annotation_path}")
         else:
             if responsejson:
                 if responsejson.get('error'):

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -5,7 +5,6 @@ import os
 import sys
 import urllib
 import warnings
-from roboflow.util.general import retry
 
 import cv2
 import requests
@@ -14,6 +13,7 @@ from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 from roboflow.config import API_URL, DEFAULT_BATCH_NAME, DEMO_KEYS
 from roboflow.core.version import Version
+from roboflow.util.general import retry
 
 ACCEPTED_IMAGE_FORMATS = ["PNG", "JPEG"]
 

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -5,6 +5,7 @@ import os
 import sys
 import urllib
 import warnings
+from roboflow.util.general import retry
 
 import cv2
 import requests
@@ -24,7 +25,8 @@ def custom_formatwarning(msg, *args, **kwargs):
 
 warnings.formatwarning = custom_formatwarning
 
-
+class UploadError(Exception):
+    pass
 class Project:
     def __init__(self, api_key, a_project, model_format=None):
         if api_key in DEMO_KEYS:
@@ -342,9 +344,26 @@ class Project:
             )
             # Get response
             response = requests.post(upload_url)
-        # Return response
-
-        return response
+        responsejson = None
+        try:
+            responsejson = response.json()
+        except:
+            pass
+        if response.status_code == 200:
+            if responsejson:
+                if "duplicate" in responsejson.keys():
+                    print(f"Duplicate image not uploaded: {image_path}")
+                elif not responsejson.get("success"):
+                    raise UploadError(f"Server rejected image: {responsejson}")
+                return responsejson.get("id")
+            else:
+                warnings.warn(f"upload image {image_path} 200 OK, weird response: {response}")
+                return None
+        else:
+            if responsejson:
+                raise UploadError(f"Bad response: {response.status_code} - {responsejson}")
+            else:
+                raise UploadError(f"Bad response: {response}")
 
     def __annotation_upload(
         self, annotation_path: str, image_id: str, is_prediction: bool = False
@@ -378,10 +397,6 @@ class Project:
                 "result": "File not found or uploading to non-classification type project with invalid string"
             }
 
-        # Set annotation upload url
-
-        project_name = self.id.rsplit("/")[1]
-
         self.annotation_upload_url = "".join(
             [
                 API_URL + "/dataset/",
@@ -395,15 +410,32 @@ class Project:
             ]
         )
 
-        # Get annotation response
-        annotation_response = requests.post(
+        response = requests.post(
             self.annotation_upload_url,
             data=annotation_string,
             headers={"Content-Type": "text/plain"},
         )
-
-        # Return annotation response
-        return annotation_response
+        responsejson = None
+        try:
+            responsejson = response.json()
+        except:
+            pass
+        if response.status_code == 200:
+            if responsejson:
+                if responsejson.get("error"):
+                    raise UploadError(f"Failed to save annotation for {image_id}: {responsejson['error']}")
+                elif not responsejson.get("success"):
+                    raise UploadError(f"Failed to save annotation for {image_id}: {responsejson}")
+            else:
+                warnings.warn(f"save annotation {annotation_path} 200 OK, weird response: {response}")
+        else:
+            if responsejson:
+                if responsejson.get('error'):
+                    raise UploadError(f"save annotation for {image_id} / bad response: {response.status_code} - {responsejson['error']}")
+                else:
+                    raise UploadError(f"save annotation for {image_id} / bad response: {response.status_code} - {responsejson}")
+            else:
+                raise UploadError(f"save annotation for {image_id} bad response: {response}")
 
     def check_valid_image(self, image_path):
         try:
@@ -420,7 +452,7 @@ class Project:
         image_path: str = None,
         annotation_path: str = None,
         hosted_image: bool = False,
-        image_id: int = None,
+        image_id: str = None,
         split: str = "train",
         num_retry_uploads: int = 0,
         batch_name: str = DEFAULT_BATCH_NAME,
@@ -434,7 +466,7 @@ class Project:
             image_path (str) - path to image you'd like to upload
             annotation_path (str) - if you're upload annotation, path to it
             hosted_image (bool) - whether the image is hosted
-            image_id (int) - id of the image
+            image_id (str) - id of the image
             split (str) - to upload the image to
             num_retry_uploads (int) - how many times to retry upload on failure
             batch_name (str) - name of batch to upload to within project
@@ -519,95 +551,30 @@ class Project:
     ):
         success = False
         annotation_success = False
-        # User gives image path
         if image_path is not None:
-            # Upload Image Response
-            response = self.__image_upload(
-                image_path,
-                hosted_image=hosted_image,
-                split=split,
-                batch_name=batch_name,
-                tag_names=tag_names,
-                **kwargs,
-            )
-            upload_response_data = None
-            # Get JSON response values
             try:
-                upload_response_data = response.json()
-                if "duplicate" in response.json().keys():
-                    if upload_response_data["duplicate"]:
-                        success = True
-                        warnings.warn("Duplicate image not uploaded:  " + image_path)
-                else:
-                    success, image_id = (
-                        upload_response_data["success"],
-                        upload_response_data["id"],
-                    )
-
-                if not success:
-                    warnings.warn(
-                        f"Server rejected image: {upload_response_data or response}"
-                    )
-
-            except Exception:
-                # Image fails to upload
-                warnings.warn(f"Bad response: {response}")
-                success = False
-            # Give user warning that image failed to upload
-            if not success:
-                warnings.warn(
-                    "Upload api failed with response: "
-                    + str(upload_response_data or response)
+                image_id = retry(num_retry_uploads, Exception, self.__image_upload,
+                    image_path,
+                    hosted_image=hosted_image,
+                    split=split,
+                    batch_name=batch_name,
+                    tag_names=tag_names,
+                    **kwargs,
                 )
-                if num_retry_uploads > 0:
-                    warnings.warn(
-                        "Image, "
-                        + image_path
-                        + ", failed to upload! Retrying for this many times: "
-                        + str(num_retry_uploads)
-                    )
-                    self.single_upload(
-                        image_path=image_path,
-                        annotation_path=annotation_path,
-                        hosted_image=hosted_image,
-                        image_id=image_id,
-                        split=split,
-                        num_retry_uploads=num_retry_uploads - 1,
-                        **kwargs,
-                    )
-                    return
-                else:
-                    warnings.warn(
-                        "Image, "
-                        + image_path
-                        + ", failed to upload! You can specify num_retry_uploads to retry a number of times."
-                    )
+                success = True
+            except BaseException as e:
+                print(f'{image_path} ERROR uploading image after {num_retry_uploads} retries: {e}', file=sys.stderr)
+                return
 
         # Upload only annotations to image based on image Id (no image)
         if annotation_path is not None and image_id is not None and success:
             # Get annotation upload response
-            annotation_response = self.__annotation_upload(
-                annotation_path, image_id, is_prediction=is_prediction
-            )
-            # Check if upload was a success
             try:
-                response_data = annotation_response.json()
-                if "success" in response_data.keys():
-                    annotation_success = True
-                elif "error" in response_data.keys():
-                    warnings.warn(
-                        f"Uploading annotation data for image failed: {str(response_data['error'])}"
-                    )
-                    annotation_success = False
-                else:
-                    warnings.warn(
-                        f"Uploading annotation data for image failed: {str(response_data)}"
-                    )
-                    annotation_success = False
-            except:
-                warnings.warn(f"Bad response: {response.status_code}")
-                annotation_success = False
-
+                self.__annotation_upload(annotation_path, image_id, is_prediction=is_prediction)
+                annotation_success = True
+            except BaseException as e:
+                print(f'{annotation_path} ERROR saving annotation: {e}', file=sys.stderr)
+                return False
             # Give user warning that annotation failed to upload
             if not annotation_success:
                 warnings.warn(

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -282,7 +282,7 @@ class Workspace:
 
             dataset_path = dataset_path + "_voc"
 
-        if project_name in self.project_list:
+        if project_name in [p['name'] for p in self.project_list]:
             dataset_upload_project = self.project(project_name)
         else:
             dataset_upload_project = self.create_project(

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -282,7 +282,7 @@ class Workspace:
 
             dataset_path = dataset_path + "_voc"
 
-        if project_name in [p['name'] for p in self.project_list]:
+        if project_name in [p["name"] for p in self.project_list]:
             dataset_upload_project = self.project(project_name)
         else:
             dataset_upload_project = self.create_project(

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -308,7 +308,7 @@ class Workspace:
                     tqdm(
                         executor.map(upload_file, file_list, [split] * len(file_list)),
                         total=len(file_list),
-                        file=sys.stdout
+                        file=sys.stdout,
                     )
                 )
 

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -284,6 +284,7 @@ class Workspace:
 
         if project_name in [p["name"] for p in self.project_list]:
             dataset_upload_project = self.project(project_name)
+            print(f"Uploading to existing project {dataset_upload_project.id}")
         else:
             dataset_upload_project = self.create_project(
                 project_name,
@@ -291,6 +292,7 @@ class Workspace:
                 annotation=project_name,
                 project_type=project_type,
             )
+            print(f"Created project {dataset_upload_project.id}")
 
         def upload_file(img_file, split):
             label_file = img_file.replace(".jpg", ".xml")
@@ -306,6 +308,7 @@ class Workspace:
                     tqdm(
                         executor.map(upload_file, file_list, [split] * len(file_list)),
                         total=len(file_list),
+                        file=sys.stdout
                     )
                 )
 

--- a/roboflow/util/general.py
+++ b/roboflow/util/general.py
@@ -6,9 +6,10 @@ def write_line(line):
     sys.stdout.write("\n")
     sys.stdout.flush()
 
+
 def retry(max_retries, retry_on, func, *args, **kwargs):
     if not retry_on:
-        retry_on = (Exception, )
+        retry_on = (Exception,)
     retries = 0
     while retries <= max_retries:
         try:

--- a/roboflow/util/general.py
+++ b/roboflow/util/general.py
@@ -5,3 +5,18 @@ def write_line(line):
     sys.stdout.write("\r" + line)
     sys.stdout.write("\n")
     sys.stdout.flush()
+
+def retry(max_retries, retry_on, func, *args, **kwargs):
+    if not retry_on:
+        retry_on = (Exception, )
+    retries = 0
+    while retries <= max_retries:
+        try:
+            return func(*args, **kwargs)
+        except BaseException as e:
+            if isinstance(e, retry_on):
+                retries += 1
+                if retries > max_retries:
+                    raise
+            else:
+                raise


### PR DESCRIPTION
# Description

Fixes #163 

The upload API may sometimes have some hiccups giving 502 errors with some html in the response.

The pip package handles errors, but doing `response.json()` when handling an error will itself throw an error, and that can break uploading a big dataset.

This PR makes uploading more robust when using `workspace.upload_dataset`

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Uploaded big dataset using a snippet like

**testupload.py** 
```python
#! /Users/tony/.pyenv/shims/python

from roboflow import Roboflow

# export API_URL=https://api.roboflow.one
# export APP_URL=https://app.roboflow.one
# python testupload.py 2>stderr.log | tee stdout.log 

# import roboflow
# roboflow.login(force=True)

rf = Roboflow()
workspace = rf.workspace("tonyprivate2")
dataset_path = '/Users/tony/Downloads/ppe.voc'
workspace.upload_dataset(dataset_path=dataset_path, num_workers=10, project_name="ppe", dataset_format="voc")
```

Obs: if you separate stdout from stderr with something like `python testupload.py 2>stderr.log | tee stdout.log`you get only the bad failures in stderr.

