### PR TITLE
Adding verbosity option in version downloads

### DIFF
--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -170,6 +170,7 @@ class Version:
         :param model_format: A format to use for downloading
         :param location: An optional path for saving the file
         :param overwrite: An optional flag to prevent dataset overwrite when dataset is already downloaded
+        :param verbose: An optional flag to enable or disable verbose output
 
         :return: Dataset
         """
@@ -613,6 +614,7 @@ class Version:
         :param location: link the URL of the remote zip file
         :param location: filepath of the data directory to save the zip file to
         :param format: the format identifier string
+        :param verbose: enable or disable verbose output
 
         :return None:
         """
@@ -647,6 +649,7 @@ class Version:
 
         :param location: filepath of the data directory that contains the zip file
         :param format: the format identifier string
+        :param verbose: enable or disable verbose output
 
         :return None:
         :raises RuntimeError:


### PR DESCRIPTION
# Description

Fixes #164 by adding a verbosity customization `verbose` option to the `version.download()` function. The default is set to true, and thus will not affect any users not wishing to disable verbose outputs.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Yes. Tested version downloads with the verbose option set true, false, and unset and performed as expected. 

Also tested the entire traditional export code snippet from the Roboflow UI, performed as expected with no changes to behavior. 

## Any specific deployment considerations

None

## Docs

-   [x] Docs updated? What were the changes:
Added info on the verbose option