### PR TITLE
fix prediction parameter name

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -12,7 +12,7 @@ from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 from roboflow.util.general import write_line
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -413,7 +413,7 @@ class Project:
                 "?api_key=",
                 self.__api_key,
                 "&name=" + os.path.basename(annotation_path),
-                "&is_prediction=true" if is_prediction else "",
+                "&prediction=true" if is_prediction else "",
             ]
         )
 


### PR DESCRIPTION
# Description

Uploading annotations takes an optional parameter `is_prediction`, which had an innocuos effect as it was being passed with the wrong name to the actual backend API

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally
context - https://roboflow.slack.com/archives/C02KWK9U8PQ/p1692816353862449?thread_ts=1692756384.477109&cid=C02KWK9U8PQ

## Any specific deployment considerations

Will need a new release
