### PR TITLE
Create `roboflow[desktop]` installation method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ idna==2.10
 kiwisolver>=1.3.1
 matplotlib
 numpy>=1.18.5
-opencv-python>=4.1.2
+opencv-python-headless==4.8.0.74
 Pillow>=7.1.2
 pyparsing==2.4.7
 python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,6 @@ with open("./roboflow/__init__.py", "r") as f:
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-# we are using the packages in `requirements.txt` for now, 
-# not 100% ideal but will do
 with open("requirements.txt", "r") as fh:
     install_requires = fh.read().split('\n')
 
@@ -27,7 +25,9 @@ setuptools.setup(
     url="https://github.com/roboflow-ai/roboflow-python",
     install_requires=install_requires,
     packages=find_packages(exclude=("tests",)),
+    # create optional [desktop]
     extras_require={
+        "desktop": ["opencv-python"],
         "dev": ["flake8", "black==22.3.0", "isort", "responses", "twine", "wheel"],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     packages=find_packages(exclude=("tests",)),
     # create optional [desktop]
     extras_require={
-        "desktop": ["opencv-python"],
+        "desktop": ["opencv-python==4.8.0.74"],
         "dev": ["flake8", "black==22.3.0", "isort", "responses", "twine", "wheel"],
     },
     classifiers=[


### PR DESCRIPTION
This PR creates a new `roboflow[desktop]` installation method and removed `opencv-python` as a required dependency for `roboflow`. Instead, `roboflow` will use the lighter `opencv-python-headless`, and `roboflow[desktop]` will use `opencv-python`.