### PR TITLE
Add Pythonic documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 1.1.5
+
+[stub]

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,11 +1,20 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
 cff-version: 1.2.0
-author: Roboflow
-message: If you use this software, please cite using the citation below.
-title: roboflow-python
-version: 1.1.4
-date-released: 2023-08-23
-license: MIT
-repository-code: https://github.com/roboflow/roboflow-python
+title: Roboflow Python Package
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Roboflow
+    email: support@roboflow.com
+repository-code: 'https://github.com/roboflow/roboflow-python'
+url: 'https://docs.roboflow.com'
+abstract: >-
+  The official Roboflow Python package.
 keywords:
   - computer vision
-  - roboflow
+  - image processing
+license: MIT

--- a/README.md
+++ b/README.md
@@ -1,4 +1,25 @@
-![roboflow-python-banner](https://github.com/roboflow/roboflow-python/assets/37276661/528ed065-d5ac-4f9a-942e-0d211b8d97de)
+<div align="center">
+  <p>
+    <a align="center" href="" target="_blank">
+      <img
+        width="100%"
+        src="https://github.com/roboflow/roboflow-python/assets/37276661/528ed065-d5ac-4f9a-942e-0d211b8d97de"
+      >
+    </a>
+  </p>
+
+  <br>
+
+  [notebooks](https://github.com/roboflow/notebooks) | [inference](https://github.com/roboflow/inference) | [autodistill](https://github.com/autodistill/autodistill) | [collect](https://github.com/roboflow/roboflow-collect)
+
+  <br>
+
+  [![version](https://badge.fury.io/py/roboflow.svg)](https://badge.fury.io/py/roboflow)
+  [![downloads](https://img.shields.io/pypi/dm/roboflow)](https://pypistats.org/packages/roboflow)
+  [![license](https://img.shields.io/pypi/l/roboflow)](https://github.com/roboflow/roboflow-python/blob/main/LICENSE.md)
+  [![python-version](https://img.shields.io/pypi/pyversions/roboflow)](https://badge.fury.io/py/roboflow)
+
+</div>
 
 # Roboflow Python Package
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Roboflow Python
-
 ![roboflow-python-banner](https://github.com/roboflow/roboflow-python/assets/37276661/528ed065-d5ac-4f9a-942e-0d211b8d97de)
+
+# Roboflow Python Package
 
 [Roboflow](https://roboflow.com) provides everything you need to build and deploy computer vision models. `roboflow-python` is the official Roboflow Python package. `roboflow-python` enables you to interact with models, datasets, and projects hosted on Roboflow.
 

--- a/docs/core/dataset.md
+++ b/docs/core/dataset.md
@@ -1,0 +1,1 @@
+:::roboflow.core.dataset

--- a/docs/core/model.md
+++ b/docs/core/model.md
@@ -1,0 +1,1 @@
+:::roboflow.core.model

--- a/docs/core/project.md
+++ b/docs/core/project.md
@@ -1,0 +1,1 @@
+:::roboflow.core.project

--- a/docs/core/version.md
+++ b/docs/core/version.md
@@ -1,0 +1,1 @@
+:::roboflow.core.version

--- a/docs/core/workspace.md
+++ b/docs/core/workspace.md
@@ -1,0 +1,1 @@
+:::roboflow.core.workspace

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,3 @@
-# Roboflow Python
-
 ![roboflow-python-banner](https://github.com/roboflow/roboflow-python/assets/37276661/528ed065-d5ac-4f9a-942e-0d211b8d97de)
 
 [Roboflow](https://roboflow.com) provides everything you need to build and deploy computer vision models. `roboflow-python` is the official Roboflow Python package. `roboflow-python` enables you to interact with models, datasets, and projects hosted on Roboflow.
@@ -8,10 +6,8 @@ With this Python package, you can:
 
 1. Create and manage projects;
 2. Upload images, annotations, and datasets to manage in Roboflow;
-3. Start training vision models on Roboflow;
+3. Start training vision models on Robfolow;
 4. Run inference on models hosted on Roboflow, or Roboflow models self-hosted via [Roboflow Inference](https://github.com/roboflow/inference), and more.
-
-The Python package is documented on the [official Roboflow documentation site](https://docs.roboflow.com/api-reference/introduction). If you are developing a feature for this Python package, or need a full Python library reference, refer to the [package developer documentation](https://roboflow.github.io/roboflow-python/).
 
 ## 💻 Installation
 
@@ -61,53 +57,32 @@ rf = roboflow.Roboflow(api_key="")
 
 </details>
 
-## Quickstart
+### Datasets
 
-Below are some common methods used with the Roboflow Python package, presented concisely for reference. For a full library reference, refer to the [Roboflow API reference documentation](https://docs.roboflow.com/api-reference).
+Download any of over 200,000 public computer vision datasets from [Roboflow Universe](universe.roboflow.com). Label and download your own datasets on app.roboflow.com.
 
 ```python
-import roboflow
+dataset = roboflow.download_dataset(dataset_url="universe.roboflow.com/...", model_format="yolov8")
+```
 
-roboflow.login()
+### Models
 
-rf = roboflow.Roboflow()
+Predict with any of over 50,000 public computer vision models. Train your own computer vision models on app.roboflow.com or train upload your model from open source models - see https://github.com/roboflow/notebooks
 
-# create a project
-rf.create_project(
-    project_name="project name",
-    project_type="project-type",
-    license="project-license" # "private" for private projects
-)
+```python
+img_url = "https://media.roboflow.com/quickstart/aerial_drone.jpeg?updatedAt=1678743716455"
+universe_model_url = "https://universe.roboflow.com/brad-dwyer/aerial-solar-panels/model/6"
 
-workspace = rf.workspace("WORKSPACE_URL")
-project = workspace.project("PROJECT_URL")
-version = project.version("VERSION_NUMBER")
-
-# upload a dataset
-project.upload_dataset(
-    dataset_path="./dataset/",
-    num_workers=10,
-    dataset_format="yolov8", # supports yolov8, yolov5, and Pascal VOC
-    project_license="MIT",
-    project_type="object-detection"
-)
-
-# upload model weights
-version.deploy(model_type="yolov8", model_path=f”{HOME}/runs/detect/train/”)
-
-# run inference
-model = version.model
-
-img_url = "https://media.roboflow.com/quickstart/aerial_drone.jpeg"
-
-predictions = model.predict(img_url, hosted=True).json()
-
-print(predictions)
+model = roboflow.load_model(model_url=universe_model_url)
+pred = model.predict(img_url, hosted=True)
+pred.plot()
 ```
 
 ## Library Structure
 
-The Roboflow Python library is structured using the same Workspace, Project, and Version ontology that you will see in the Roboflow application.
+The Roboflow Python library is structured by the core Roboflow application objects.
+
+Workspace (workspace.py) --> Project (project.py) --> Version (version.py)
 
 ```python
 import roboflow

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,17 @@
 ![roboflow-python-banner](https://github.com/roboflow/roboflow-python/assets/37276661/528ed065-d5ac-4f9a-942e-0d211b8d97de)
 
+# Roboflow Python Package
+
 [Roboflow](https://roboflow.com) provides everything you need to build and deploy computer vision models. `roboflow-python` is the official Roboflow Python package. `roboflow-python` enables you to interact with models, datasets, and projects hosted on Roboflow.
 
 With this Python package, you can:
 
 1. Create and manage projects;
 2. Upload images, annotations, and datasets to manage in Roboflow;
-3. Start training vision models on Robfolow;
+3. Start training vision models on Roboflow;
 4. Run inference on models hosted on Roboflow, or Roboflow models self-hosted via [Roboflow Inference](https://github.com/roboflow/inference), and more.
+
+The Python package is documented on the [official Roboflow documentation site](https://docs.roboflow.com/api-reference/introduction). If you are developing a feature for this Python package, or need a full Python library reference, refer to the [package developer documentation](https://roboflow.github.io/roboflow-python/).
 
 ## 💻 Installation
 
@@ -57,32 +61,53 @@ rf = roboflow.Roboflow(api_key="")
 
 </details>
 
-### Datasets
+## Quickstart
 
-Download any of over 200,000 public computer vision datasets from [Roboflow Universe](universe.roboflow.com). Label and download your own datasets on app.roboflow.com.
-
-```python
-dataset = roboflow.download_dataset(dataset_url="universe.roboflow.com/...", model_format="yolov8")
-```
-
-### Models
-
-Predict with any of over 50,000 public computer vision models. Train your own computer vision models on app.roboflow.com or train upload your model from open source models - see https://github.com/roboflow/notebooks
+Below are some common methods used with the Roboflow Python package, presented concisely for reference. For a full library reference, refer to the [Roboflow API reference documentation](https://docs.roboflow.com/api-reference).
 
 ```python
-img_url = "https://media.roboflow.com/quickstart/aerial_drone.jpeg?updatedAt=1678743716455"
-universe_model_url = "https://universe.roboflow.com/brad-dwyer/aerial-solar-panels/model/6"
+import roboflow
 
-model = roboflow.load_model(model_url=universe_model_url)
-pred = model.predict(img_url, hosted=True)
-pred.plot()
+roboflow.login()
+
+rf = roboflow.Roboflow()
+
+# create a project
+rf.create_project(
+    project_name="project name",
+    project_type="project-type",
+    license="project-license" # "private" for private projects
+)
+
+workspace = rf.workspace("WORKSPACE_URL")
+project = workspace.project("PROJECT_URL")
+version = project.version("VERSION_NUMBER")
+
+# upload a dataset
+project.upload_dataset(
+    dataset_path="./dataset/",
+    num_workers=10,
+    dataset_format="yolov8", # supports yolov8, yolov5, and Pascal VOC
+    project_license="MIT",
+    project_type="object-detection"
+)
+
+# upload model weights
+version.deploy(model_type="yolov8", model_path=f”{HOME}/runs/detect/train/”)
+
+# run inference
+model = version.model
+
+img_url = "https://media.roboflow.com/quickstart/aerial_drone.jpeg"
+
+predictions = model.predict(img_url, hosted=True).json()
+
+print(predictions)
 ```
 
 ## Library Structure
 
-The Roboflow Python library is structured by the core Roboflow application objects.
-
-Workspace (workspace.py) --> Project (project.py) --> Version (version.py)
+The Roboflow Python library is structured using the same Workspace, Project, and Version ontology that you will see in the Roboflow application.
 
 ```python
 import roboflow

--- a/docs/models/classification.md
+++ b/docs/models/classification.md
@@ -1,0 +1,1 @@
+:::roboflow.models.classification

--- a/docs/models/instance-segmentation.md
+++ b/docs/models/instance-segmentation.md
@@ -1,0 +1,1 @@
+:::roboflow.models.instance_segmentation

--- a/docs/models/object-detection.md
+++ b/docs/models/object-detection.md
@@ -1,0 +1,1 @@
+:::roboflow.models.object_detection

--- a/docs/models/semantic-segmentation.md
+++ b/docs/models/semantic-segmentation.md
@@ -1,0 +1,1 @@
+:::roboflow.models.semantic_segmentation

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,3 @@
+:root {
+    --md-primary-fg-color:#8315F9;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,65 @@
+site_name: Roboflow Python
+site_url: https://roboflow.github.io/roboflow-python
+site_author: Roboflow
+site_description: The official Roboflow Python package.
+repo_name: roboflow/roboflow-python
+repo_url: https://github.com/roboflow/roboflow-python
+edit_uri: https://github.com/roboflow/roboflow-python/tree/main/docs
+copyright: Roboflow 2023. All rights reserved.
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/roboflow
+    - icon: fontawesome/brands/youtube
+      link: https://www.youtube.com/roboflow
+    - icon: fontawesome/brands/linkedin
+      link: https://www.linkedin.com/company/roboflow-ai/mycompany/
+    - icon: fontawesome/brands/twitter
+      link: https://twitter.com/roboflow
+  analytics:
+    provider: google
+    property: G-P7ZG0Y19G5
+
+extra_css:
+  - styles.css
+
+nav:
+  - Home: index.md
+  - Quickstart: quickstart.md
+  - API reference:
+    - Core:
+      - Datasets: core/dataset.md
+      - Models: core/model.md
+      - Projects: core/project.md
+      - Workspaces: core/workspace.md
+      - Versions: core/version.md
+    - Models:
+      - Object Detection: models/object-detection.md
+      - Classification: models/classification.md
+      - Instance Segmentation: models/instance-segmentation.md
+      - Semantic Segmentation: models/semantic-segmentation.md
+  - Changelog: changelog.md
+
+theme:
+  name: 'material'
+  logo: https://media.roboflow.com/roboflow_logomark_white.png
+  favicon: https://media.roboflow.com/roboflow_logomark_white.png
+  font:
+    text: Roboto
+    code: Roboto Mono
+
+plugins:
+  - mkdocstrings
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - attr_list
+  - md_in_html
+  - pymdownx.tabbed:
+      alternate_style: true
+  - toc:
+      permalink: true

--- a/roboflow/core/dataset.py
+++ b/roboflow/core/dataset.py
@@ -1,4 +1,8 @@
 class Dataset:
+    """
+    A Roboflow Dataset.
+    """
+
     def __init__(self, name, version, model_format, location):
         self.name = name
         self.version = version

--- a/roboflow/core/model.py
+++ b/roboflow/core/model.py
@@ -1,4 +1,8 @@
 class Model:
+    """
+    A Roboflow model.
+    """
+
     def __init__(self, model):
         self.id = model["id"]
         self.endpoint = model["endpoint"]

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -43,6 +43,13 @@ class Project:
             api_key (str): private roboflow api key
             a_project (str): the project id
             model_format (str): the model format of the project
+
+        Example:
+            >>> import roboflow
+
+            >>> rf = roboflow.Roboflow(api_key="")
+
+            >>> project = rf.workspace().project("PROJECT_ID")
         """
         if api_key in DEMO_KEYS:
             self.__api_key = api_key
@@ -73,6 +80,15 @@ class Project:
 
         Returns:
             A list of all versions of the project.
+
+        Example:
+            >>> import roboflow
+
+            >>> rf = roboflow.Roboflow(api_key="")
+
+            >>> project = rf.workspace().project("PROJECT_ID")
+
+            >>> version_info = project.get_version_information()
         """
         dataset_info = requests.get(
             API_URL
@@ -93,7 +109,16 @@ class Project:
 
     def list_versions(self):
         """
-        Print out versions for that specific project
+        Print out versions for that specific project.
+
+        Example:
+            >>> import roboflow
+
+            >>> rf = roboflow.Roboflow(api_key="")
+
+            >>> project = rf.workspace().project("PROJECT_ID")
+
+            >>> project.list_versions()
         """
         version_info = self.get_version_information()
         print(version_info)
@@ -104,6 +129,15 @@ class Project:
 
         Returns:
             A list of Version objects.
+
+        Example:
+            >>> import roboflow
+
+            >>> rf = roboflow.Roboflow(api_key="")
+
+            >>> project = rf.workspace().project("PROJECT_ID")
+
+            >>> versions = project.versions()
         """
         version_info = self.get_version_information()
         version_array = []
@@ -126,7 +160,7 @@ class Project:
 
     def generate_version(self, settings):
         """
-        Generate a version of a dataset.
+        Generate a version of a dataset hosted on Roboflow.
 
         Args:
             settings: A Python dict with augmentation and preprocessing keys and specifications for generation. These settings mirror capabilities available via the Roboflow UI.
@@ -173,6 +207,15 @@ class Project:
 
         Returns:
             int: The version number that is being generated.
+
+        Example:
+            >>> import roboflow
+
+            >>> rf = roboflow.Roboflow(api_key="")
+
+            >>> project = rf.workspace().project("PROJECT_ID")
+
+            >>> versions = project.generate_version(settings={...})
         """
 
         if not {"augmentation", "preprocessing"} <= settings.keys():
@@ -225,14 +268,29 @@ class Project:
     ) -> bool:
         """
         Ask the Roboflow API to train a previously exported version's dataset.
+
         Args:
             speed: Whether to train quickly or accurately. Note: accurate training is a paid feature. Default speed is `fast`.
             checkpoint: A string representing the checkpoint to use while training
             plot: Whether to plot the training loss curve. Default is False.
+
         Returns:
             True
+
+        Raises:
             RuntimeError: If the Roboflow API returns an error with a helpful JSON body
             HTTPError: If the Network/Roboflow API fails and does not return JSON
+
+        Example:
+            >>> import roboflow
+
+            >>> rf = roboflow.Roboflow(api_key="")
+
+            >>> project = rf.workspace().project("PROJECT_ID")
+
+            >>> version = project.version(1)
+
+            >>> version.train()
         """
 
         new_version = self.generate_version(settings=new_version_settings)
@@ -539,6 +597,15 @@ class Project:
             batch_name (str): name of batch to upload to within project
             tag_names (list[str]): tags to be applied to an image
             is_prediction (bool): whether the annotation data is a prediction rather than ground truth
+
+        Example:
+            >>> import roboflow
+
+            >>> rf = roboflow.Roboflow(api_key="")
+
+            >>> project = rf.workspace().project("PROJECT_ID")
+
+            >>> project.upload(image_path="YOUR_IMAGE.jpg")
         """
 
         is_hosted = image_path.startswith("http://") or image_path.startswith(
@@ -693,6 +760,15 @@ class Project:
 
         Returns:
             A list of images that match the search criteria.
+
+        Example:
+            >>> import roboflow
+
+            >>> rf = roboflow.Roboflow(api_key="")
+
+            >>> project = rf.workspace().project("PROJECT_ID")
+
+            >>> results = project.search(query="cat", limit=10)
         """
         payload = {}
 
@@ -768,6 +844,19 @@ class Project:
 
         Returns:
             A list of images that match the search criteria.
+
+        Example:
+            >>> import roboflow
+
+            >>> rf = roboflow.Roboflow(api_key="")
+
+            >>> project = rf.workspace().project("PROJECT_ID")
+
+            >>> results = project.search_all(query="cat", limit=10)
+
+            >>> for result in results:
+
+            >>>     print(result)
         """
         while True:
             data = self.search(

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -31,7 +31,19 @@ class UploadError(Exception):
 
 
 class Project:
-    def __init__(self, api_key, a_project, model_format=None):
+    """
+    A Roboflow Project.
+    """
+
+    def __init__(self, api_key: str, a_project: str, model_format: str = None):
+        """
+        Create a Project object that represents a Project associated with a Workspace.
+
+        Args:
+            api_key (str): private roboflow api key
+            a_project (str): the project id
+            model_format (str): the model format of the project
+        """
         if api_key in DEMO_KEYS:
             self.__api_key = api_key
             self.model_format = model_format
@@ -56,8 +68,11 @@ class Project:
             self.__project_name = temp[1]
 
     def get_version_information(self):
-        """Helper function to get version information from the REST API.
-        :returns dictionary with information about all of the versions directly from the API.
+        """
+        Retrieve all versions of a project.
+
+        Returns:
+            A list of all versions of the project.
         """
         dataset_info = requests.get(
             API_URL
@@ -77,13 +92,18 @@ class Project:
         return dataset_info["versions"]
 
     def list_versions(self):
-        """Prints out versions for that specific project"""
+        """
+        Print out versions for that specific project
+        """
         version_info = self.get_version_information()
         print(version_info)
 
     def versions(self):
-        """function to return all versions in the project as Version objects.
-        :returns an array of Version() objects.
+        """
+        Return all versions in the project as Version objects.
+
+        Returns:
+            A list of Version objects.
         """
         version_info = self.get_version_information()
         version_array = []
@@ -106,50 +126,53 @@ class Project:
 
     def generate_version(self, settings):
         """
-        Settings, a python dict with augmentation and preprocessing keys and specifications for generation.
-        These settings mirror capabilities available via the Roboflow UI.
-        For example:
-             {
-                "augmentation": {
-                    "bbblur": { "pixels": 1.5 },
-                    "bbbrightness": { "brighten": true, "darken": false, "percent": 91 },
-                    "bbcrop": { "min": 12, "max": 71 },
-                    "bbexposure": { "percent": 30 },
-                    "bbflip": { "horizontal": true, "vertical": false },
-                    "bbnoise": { "percent": 50 },
-                    "bbninety": { "clockwise": true, "counter-clockwise": false, "upside-down": false },
-                    "bbrotate": { "degrees": 45 },
-                    "bbshear": { "horizontal": 45, "vertical": 45 },
-                    "blur": { "pixels": 1.5 },
-                    "brightness": { "brighten": true, "darken": false, "percent": 91 },
-                    "crop": { "min": 12, "max": 71 },
-                    "cutout": { "count": 26, "percent": 71 },
-                    "exposure": { "percent": 30 },
-                    "flip": { "horizontal": true, "vertical": false },
-                    "hue": { "degrees": 180 },
-                    "image": { "versions": 32 },
-                    "mosaic": true,
-                    "ninety": { "clockwise": true, "counter-clockwise": false, "upside-down": false },
-                    "noise": { "percent": 50 },
-                    "rgrayscale": { "percent": 50 },
-                    "rotate": { "degrees": 45 },
-                    "saturation": { "percent": 50 },
-                    "shear": { "horizontal": 45, "vertical": 45 }
-                },
-                "preprocessing": {
-                    "auto-orient": true,
-                    "contrast": { "type": "Contrast Stretching" },
-                    "filter-null": { "percent": 50 },
-                    "grayscale": true,
-                    "isolate": true,
-                    "remap": { "original_class_name": "new_class_name" },
-                    "resize": { "width": 200, "height": 200, "format": "Stretch to" },
-                    "static-crop": { "x_min": 10, "x_max": 90, "y_min": 10, "y_max": 90 },
-                    "tile": { "rows": 2, "columns": 2 }
-                }
-            }
+        Generate a version of a dataset.
 
-        Returns: The version number that is being generated
+        Args:
+            settings: A Python dict with augmentation and preprocessing keys and specifications for generation. These settings mirror capabilities available via the Roboflow UI.
+                    For example:
+                        {
+                            "augmentation": {
+                                "bbblur": { "pixels": 1.5 },
+                                "bbbrightness": { "brighten": true, "darken": false, "percent": 91 },
+                                "bbcrop": { "min": 12, "max": 71 },
+                                "bbexposure": { "percent": 30 },
+                                "bbflip": { "horizontal": true, "vertical": false },
+                                "bbnoise": { "percent": 50 },
+                                "bbninety": { "clockwise": true, "counter-clockwise": false, "upside-down": false },
+                                "bbrotate": { "degrees": 45 },
+                                "bbshear": { "horizontal": 45, "vertical": 45 },
+                                "blur": { "pixels": 1.5 },
+                                "brightness": { "brighten": true, "darken": false, "percent": 91 },
+                                "crop": { "min": 12, "max": 71 },
+                                "cutout": { "count": 26, "percent": 71 },
+                                "exposure": { "percent": 30 },
+                                "flip": { "horizontal": true, "vertical": false },
+                                "hue": { "degrees": 180 },
+                                "image": { "versions": 32 },
+                                "mosaic": true,
+                                "ninety": { "clockwise": true, "counter-clockwise": false, "upside-down": false },
+                                "noise": { "percent": 50 },
+                                "rgrayscale": { "percent": 50 },
+                                "rotate": { "degrees": 45 },
+                                "saturation": { "percent": 50 },
+                                "shear": { "horizontal": 45, "vertical": 45 }
+                            },
+                            "preprocessing": {
+                                "auto-orient": true,
+                                "contrast": { "type": "Contrast Stretching" },
+                                "filter-null": { "percent": 50 },
+                                "grayscale": true,
+                                "isolate": true,
+                                "remap": { "original_class_name": "new_class_name" },
+                                "resize": { "width": 200, "height": 200, "format": "Stretch to" },
+                                "static-crop": { "x_min": 10, "x_max": 90, "y_min": 10, "y_max": 90 },
+                                "tile": { "rows": 2, "columns": 2 }
+                            }
+                        }
+
+        Returns:
+            int: The version number that is being generated.
         """
 
         if not {"augmentation", "preprocessing"} <= settings.keys():
@@ -220,11 +243,16 @@ class Project:
 
         return new_model
 
-    def version(self, version_number, local=None):
-        """Retrieves information about a specific version, and throws it into an object.
-        :param version_number: the version number that you want to retrieve
-        :local: specifies the localhost address and port if pointing towards local inference engine
-        :return Version() object
+    def version(self, version_number: int, local: str = None):
+        """
+        Retrieves information about a specific version and returns a Version() object.
+
+        Args:
+            version_number (int): the version number that you want to retrieve
+            local (str): specifies the localhost address and port if pointing towards local inference engine
+
+        Returns:
+            Version() object
         """
 
         if self.__api_key in DEMO_KEYS:
@@ -269,17 +297,20 @@ class Project:
 
     def __image_upload(
         self,
-        image_path,
-        hosted_image=False,
-        split="train",
-        batch_name=DEFAULT_BATCH_NAME,
-        tag_names=[],
+        image_path: str,
+        hosted_image: bool = False,
+        split: str = "train",
+        batch_name: str = DEFAULT_BATCH_NAME,
+        tag_names: list = [],
         **kwargs,
     ):
-        """function to upload image to the specific project
-        :param image_path: path to image you'd like to upload.
-        :param hosted_image: if the image is hosted online, then this should be modified
-        :param split: the dataset split to upload the project to.
+        """
+        Upload an image to a specific project.
+
+        Args:
+            image_path (str): path to image you'd like to upload
+            hosted_image (bool): whether the image is hosted on Roboflow
+            split (str): the dataset split the image to
         """
 
         # If image is not a hosted image
@@ -367,7 +398,7 @@ class Project:
         else:
             if responsejson:
                 raise UploadError(
-                    f"Bad response: {response.status_code} - {responsejson}"
+                    f"Bad response: {response.status_code}: {responsejson}"
                 )
             else:
                 raise UploadError(f"Bad response: {response}")
@@ -375,9 +406,12 @@ class Project:
     def __annotation_upload(
         self, annotation_path: str, image_id: str, is_prediction: bool = False
     ):
-        """function to upload annotation to the specific project
-        :param annotation_path: path to annotation you'd like to upload
-        :param image_id: image id you'd like to upload that has annotations for it.
+        """
+        Upload an annotation to a specific project.
+
+        Args:
+            annotation_path (str): path to annotation you'd like to upload
+            image_id (str): image id you'd like to upload that has annotations for it.
         """
 
         # stop on empty string
@@ -449,18 +483,27 @@ class Project:
             if responsejson:
                 if responsejson.get("error"):
                     raise UploadError(
-                        f"save annotation for {image_id} / bad response: {response.status_code} - {responsejson['error']}"
+                        f"save annotation for {image_id} / bad response: {response.status_code}: {responsejson['error']}"
                     )
                 else:
                     raise UploadError(
-                        f"save annotation for {image_id} / bad response: {response.status_code} - {responsejson}"
+                        f"save annotation for {image_id} / bad response: {response.status_code}: {responsejson}"
                     )
             else:
                 raise UploadError(
                     f"save annotation for {image_id} bad response: {response}"
                 )
 
-    def check_valid_image(self, image_path):
+    def check_valid_image(self, image_path: str):
+        """
+        Check if an image is valid. Useful before attempting to upload an image to Roboflow.
+
+        Args:
+            image_path (str): path to image you'd like to check
+
+        Returns:
+            bool: whether the image is valid or not
+        """
         try:
             img = Image.open(image_path)
             valid = img.format in ACCEPTED_IMAGE_FORMATS
@@ -483,21 +526,19 @@ class Project:
         is_prediction: bool = False,
         **kwargs,
     ):
-        """Upload image function based on the RESTful API
+        """
+        Upload an image or annotation to the Roboflow API.
 
         Args:
-            image_path (str) - path to image you'd like to upload
-            annotation_path (str) - if you're upload annotation, path to it
-            hosted_image (bool) - whether the image is hosted
-            image_id (str) - id of the image
-            split (str) - to upload the image to
-            num_retry_uploads (int) - how many times to retry upload on failure
-            batch_name (str) - name of batch to upload to within project
-            tag_names (list[str]) - tags to be applied to an image
-            is_prediction (bool) - whether the annotation data is a prediction rather than ground truth
-
-        Returns:
-            None - returns nothing
+            image_path (str): path to image you'd like to upload
+            annotation_path (str): if you're upload annotation, path to it
+            hosted_image (bool): whether the image is hosted
+            image_id (str): id of the image
+            split (str): to upload the image to
+            num_retry_uploads (int): how many times to retry upload on failure
+            batch_name (str): name of batch to upload to within project
+            tag_names (list[str]): tags to be applied to an image
+            is_prediction (bool): whether the annotation data is a prediction rather than ground truth
         """
 
         is_hosted = image_path.startswith("http://") or image_path.startswith(
@@ -635,6 +676,24 @@ class Project:
         batch_id: str = None,
         fields: list = ["id", "created", "name", "labels"],
     ):
+        """
+        Search for images in a project.
+
+        Args:
+            like_image (str): name of an image in your dataset to use if you want to find images similar to that one
+            prompt (str): search prompt
+            offset (int): offset of results
+            limit (int): limit of results
+            tag (str): tag that an image must have
+            class_name (str): class name that an image must have
+            in_dataset (str): dataset that an image must be in
+            batch (bool): whether the image must be in a batch
+            batch_id (str): batch id that an image must be in
+            fields (list): fields to return in results (default: ["id", "created", "name", "labels"])
+
+        Returns:
+            A list of images that match the search criteria.
+        """
         payload = {}
 
         if like_image is not None:
@@ -692,6 +751,24 @@ class Project:
         batch_id: str = None,
         fields: list = ["id", "created"],
     ):
+        """
+        Create a paginated list of search results for use in searching the images in a project.
+
+        Args:
+            like_image (str): name of an image in your dataset to use if you want to find images similar to that one
+            prompt (str): search prompt
+            offset (int): offset of results
+            limit (int): limit of results
+            tag (str): tag that an image must have
+            class_name (str): class name that an image must have
+            in_dataset (str): dataset that an image must be in
+            batch (bool): whether the image must be in a batch
+            batch_id (str): batch id that an image must be in
+            fields (list): fields to return in results (default: ["id", "created", "name", "labels"])
+
+        Returns:
+            A list of images that match the search criteria.
+        """
         while True:
             data = self.search(
                 like_image=like_image,
@@ -714,6 +791,9 @@ class Project:
             offset += limit
 
     def __str__(self):
+        """
+        Show a string representation of a Project object.
+        """
         # String representation of project
         json_str = {"name": self.name, "type": self.type, "workspace": self.__workspace}
 

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -39,6 +39,10 @@ load_dotenv()
 
 
 class Version:
+    """
+    Class representing a Roboflow dataset version.
+    """
+
     def __init__(
         self,
         version_dict,
@@ -53,6 +57,9 @@ class Version:
         public,
         colors=None,
     ):
+        """
+        Initialize a Version object.
+        """
         if api_key in DEMO_KEYS:
             if api_key == "coco-128-sample":
                 self.__api_key = api_key
@@ -171,7 +178,17 @@ class Version:
         :param location: An optional path for saving the file
         :param overwrite: An optional flag to prevent dataset overwrite when dataset is already downloaded
 
-        :return: Dataset
+        Args:
+            model_format (str): A format to use for downloading
+            location (str): An optional path for saving the file
+            overwrite (bool): An optional flag to prevent dataset overwrite when dataset is already downloaded
+
+        Returns:
+            Dataset Object
+
+        Raises:
+            RuntimeError: If the Roboflow API returns an error with a helpful JSON body
+            HTTPError: If the Network/Roboflow API fails and does not return JSON
         """
 
         self.__wait_if_generating()
@@ -226,12 +243,18 @@ class Version:
     def export(self, model_format=None):
         """
         Ask the Roboflow API to generate a version's dataset in a given format so that it can be downloaded via the `download()` method.
+
         The export will be asynchronously generated and available for download after some amount of seconds - depending on dataset size.
 
-        :param model_format: A format to use for downloading
+        Args:
+            model_format (str): A format to use for downloading
 
-        :return: True
-        :raises RuntimeError / HTTPError:
+        Returns:
+            True
+
+        Raises:
+            RuntimeError: If the Roboflow API returns an error with a helpful JSON body
+            HTTPError: If the Network/Roboflow API fails and does not return JSON
         """
 
         model_format = self.__get_format_identifier(model_format)
@@ -279,12 +302,16 @@ class Version:
     def train(self, speed=None, checkpoint=None, plot_in_notebook=False) -> bool:
         """
         Ask the Roboflow API to train a previously exported version's dataset.
+
         Args:
             speed: Whether to train quickly or accurately. Note: accurate training is a paid feature. Default speed is `fast`.
             checkpoint: A string representing the checkpoint to use while training
             plot: Whether to plot the training results. Default is `False`.
+
         Returns:
             An instance of the trained model class
+
+        Raises:
             RuntimeError: If the Roboflow API returns an error with a helpful JSON body
             HTTPError: If the Network/Roboflow API fails and does not return JSON
         """
@@ -610,11 +637,10 @@ class Version:
         """
         Download a dataset's zip file from the given URL and save it in the desired location
 
-        :param location: link the URL of the remote zip file
-        :param location: filepath of the data directory to save the zip file to
-        :param format: the format identifier string
-
-        :return None:
+        Args:
+            link (str): link the URL of the remote zip file
+            location (str): filepath of the data directory to save the zip file to
+            format (str): the format identifier string
         """
         if not os.path.exists(location):
             os.makedirs(location)
@@ -640,13 +666,14 @@ class Version:
 
     def __extract_zip(self, location, format):
         """
-        This simply extracts the contents of a downloaded zip file and then deletes the zip
+        Extracts the contents of a downloaded ZIP file and then deletes the zipped file.
 
-        :param location: filepath of the data directory that contains the zip file
-        :param format: the format identifier string
+        Args:
+            location (str): filepath of the data directory that contains the ZIP file
+            format (str): the format identifier string
 
-        :return None:
-        :raises RuntimeError:
+        Raises:
+            RuntimeError: If there is an error unzipping the file
         """
         with zipfile.ZipFile(location + "/roboflow.zip", "r") as zip_ref:
             for member in tqdm(
@@ -664,7 +691,8 @@ class Version:
         """
         Get the local path to save a downloaded dataset to
 
-        :return local path string:
+        Returns:
+            str: the local path
         """
         version_slug = self.name.replace(" ", "-")
         filename = f"{version_slug}-{self.version}"
@@ -679,9 +707,11 @@ class Version:
         """
         Get the Roboflow API URL for downloading (and exporting downloadable zips)
 
-        :param format: the format identifier string
+        Args:
+            format (str): the format identifier string
 
-        :return Roboflow API URL string:
+        Returns:
+            str: the Roboflow API URL
         """
         workspace, project, *_ = self.id.rsplit("/")
         return f"{API_URL}/{workspace}/{project}/{self.version}/{format}"
@@ -689,12 +719,16 @@ class Version:
     def __get_format_identifier(self, format):
         """
         If `format` is none, fall back to the instance's `model_format` value.
+
         If a human readable format name was passed, return the identifier that should be used for Roboflow API calls
+
         Otherwise, assume that the passed in format is also the identifier
 
-        :param format: a human readable format string
+        Args:
+            format (str): a human readable format string
 
-        :return: format identifier string
+        Returns:
+            str: format identifier string
         """
         if not format:
             format = self.model_format
@@ -705,17 +739,16 @@ class Version:
             )
 
         friendly_formats = {"yolov5": "yolov5pytorch", "yolov7": "yolov7pytorch"}
+
         return friendly_formats.get(format, format)
 
     def __reformat_yaml(self, location: str, format: str):
         """
         Certain formats seem to require reformatting the downloaded YAML.
-        It'd be nice if the API did this, but we're doing it in python for now.
 
-        :param location: filepath of the data directory that contains the yaml file
-        :param format: the format identifier string
-
-        :return None:
+        Args:
+            location (str): filepath of the data directory that contains the yaml file
+            format (str): the format identifier string
         """
         data_path = os.path.join(location, "data.yaml")
 
@@ -743,7 +776,9 @@ class Version:
             amend_data_yaml(path=data_path, callback=data_yaml_callback)
 
     def __str__(self):
-        """string representation of version object."""
+        """
+        String representation of version object.
+        """
         json_value = {
             "name": self.name,
             "type": self.type,

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -25,6 +25,10 @@ from roboflow.util.two_stage_utils import ocr_infer
 
 
 class Workspace:
+    """
+    Manage a Roboflow workspace.
+    """
+
     def __init__(self, info, api_key, default_workspace, model_format):
         if api_key in DEMO_KEYS:
             self.__api_key = api_key
@@ -42,12 +46,17 @@ class Workspace:
             self.__api_key = api_key
 
     def list_projects(self):
-        """Lists projects out in the workspace"""
+        """
+        Print all projects in the workspace to the console.
+        """
         print(self.project_list)
 
     def projects(self):
-        """Returns all projects as Project() objects in the workspace
-        :return an array of project objects
+        """
+        Retrieve all projects in the workspace.
+
+        Returns:
+            List of Project objects.
         """
         projects_array = []
         for a_project in self.project_list:
@@ -57,6 +66,17 @@ class Workspace:
         return projects_array
 
     def project(self, project_name):
+        """
+        Retrieve a Project() object that represents a project in the workspace.
+
+        This object can be used to retrieve the model through which to run inference.
+
+        Args:
+            project_name (str): name of the project
+
+        Returns:
+            Project Object
+        """
         sys.stdout.write("\r" + "loading Roboflow project...")
         sys.stdout.write("\n")
         sys.stdout.flush()
@@ -86,6 +106,18 @@ class Workspace:
         return Project(self.__api_key, dataset_info, self.model_format)
 
     def create_project(self, project_name, project_type, project_license, annotation):
+        """
+        Create a project in a Roboflow workspace.
+
+        Args:
+            project_name (str): name of the project
+            project_type (str): type of the project
+            project_license (str): license of the project (set to `private` for private projects, only available for paid customers)
+            annotation (str): annotation of the project
+
+        Returns:
+            Project Object
+        """
         data = {
             "name": project_name,
             "type": project_type,
@@ -108,12 +140,15 @@ class Workspace:
         self, dir: str = "", image_ext: str = ".png", target_image: str = ""
     ) -> dict:
         """
-        @params:
-            dir: (str) = name reference to a directory of images for comparison
-            image_ext: (str) = file format for expected images (don't include the . before the file type name)
-            target_image: (str) = name reference for target image to compare individual images from directory against
+        Compare all images in a directory to a target image using CLIP
 
-            returns: (dict) = a key:value mapping of image_name:comparison_score_to_target
+        Args:
+            dir (str): name reference to a directory of images for comparison
+            image_ext (str): file format for expected images (don't include the . before the file type name)
+            target_image (str): name reference for target image to compare individual images from directory against
+
+        Returns:
+            dict: a key:value mapping of image_name:comparison_score_to_target
         """
 
         # list to store comparison results in
@@ -135,14 +170,18 @@ class Workspace:
         second_stage_model_name: str = "",
         second_stage_model_version: int = 0,
     ) -> dict:
-        """for each prediction in the first stage detection, perform detection with the second stage model
-        @params:
-            image: (str) = name of the image to be processed
-            first_stage_model: (str) = URL path to the first stage detection model
-            first_stage_model_version: (int) = version number for the first stage model
-            second_stage_mode: (str) = URL path to the second stage detection model
-            second_stage_model_version: (int) = version number for the second stage model
-            returns: (dict) = a json obj containing
+        """
+        For each prediction in a first stage detection, perform detection with the second stage model
+
+        Args:
+            image (str): name of the image to be processed
+            first_stage_model_name (str): name of the first stage detection model
+            first_stage_model_version (int): version number for the first stage model
+            second_stage_mode (str): name of the second stage detection model
+            second_stage_model_version (int): version number for the second stage model
+
+        Returns:
+            dict: a json obj containing the results of the second stage detection
         """
         results = []
 
@@ -203,13 +242,16 @@ class Workspace:
         first_stage_model_name: str = "",
         first_stage_model_version: int = 0,
     ) -> dict:
-        """for each prediction in the first stage object detection, perform OCR as second stage
-        @params:
-            image: (str) = name of the image to be processed
-            first_stage_model: (str) = URL path to the first stage detection model
-            first_stage_model_version: (int) = version number for the first stage model
+        """
+        For each prediction in the first stage object detection, perform OCR as second stage.
 
-            returns: (dict) = a json obj containing
+        Args:
+            image (str): name of the image to be processed
+            first_stage_model_name (str): name of the first stage detection model
+            first_stage_model_version (int): version number for the first stage model
+
+        Returns:
+            dict: a json obj containing the results of the second stage detection
         """
         results = []
 
@@ -250,13 +292,24 @@ class Workspace:
 
     def upload_dataset(
         self,
-        dataset_path,
-        project_name,
-        num_workers=10,
-        dataset_format="yolov8",
-        project_license="MIT",
-        project_type="object-detection",
+        dataset_path: str,
+        project_name: str,
+        num_workers: int = 10,
+        dataset_format: str = "yolov8",
+        project_license: str = "MIT",
+        project_type: str = "object-detection",
     ):
+        """
+        Upload a dataset to Roboflow.
+
+        Args:
+            dataset_path (str): path to the dataset
+            project_name (str): name of the project
+            num_workers (int): number of workers to use for parallel uploads
+            dataset_format (str): format of the dataset (`voc`, `yolov8`, `yolov5`)
+            project_license (str): license of the project (set to `private` for private projects, only available for paid customers)
+            project_type (str): type of the project (only `object-detection` is supported)
+        """
         if project_type != "object-detection":
             raise ("upload_dataset only supported for object-detection projects")
 
@@ -294,7 +347,14 @@ class Workspace:
             )
             print(f"Created project {dataset_upload_project.id}")
 
-        def upload_file(img_file, split):
+        def upload_file(img_file: str, split: str):
+            """
+            Upload an image or annotation to a project.
+
+            Args:
+                img_file (str): path to the image
+                split (str): split to which the the image should be added (train, valid, test)
+            """
             label_file = img_file.replace(".jpg", ".xml")
             dataset_upload_project.upload(
                 image_path=img_file, annotation_path=label_file, split=split

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -2,8 +2,6 @@ import concurrent.futures
 import glob
 import json
 import os
-import random
-import re
 import sys
 
 import requests

--- a/roboflow/models/classification.py
+++ b/roboflow/models/classification.py
@@ -13,22 +13,34 @@ from roboflow.util.prediction import PredictionGroup
 
 
 class ClassificationModel:
+    """
+    Run inference on a classification model hosted on Roboflow or served through Roboflow Inference.
+    """
+
     def __init__(
         self,
-        api_key,
-        id,
-        name=None,
-        version=None,
-        local=False,
-        colors=None,
-        preprocessing=None,
+        api_key: str,
+        id: str,
+        name: str = None,
+        version: int = None,
+        local: bool = False,
+        colors: dict = None,
+        preprocessing: dict = None,
     ):
         """
-        :param api_key: private roboflow api key
-        :param id: the workspace/project id
-        :param name: is the name of thep project
-        :param version: version number
-        :return ClassificationModel Object
+        Create a ClassificationModel object through which you can run inference.
+
+        Args:
+            api_key (str): private roboflow api key
+            id (str): the workspace/project id
+            name (str): is the name of the project
+            version (int): version number
+            local (bool): whether the image is local or hosted
+            colors (dict): colors to use for the image
+            preprocessing (dict): preprocessing to use for the image
+
+        Returns:
+            ClassificationModel Object
         """
         # Instantiate different API URL parameters
         self.__api_key = api_key
@@ -45,10 +57,14 @@ class ClassificationModel:
 
     def predict(self, image_path, hosted=False):
         """
+        Run inference on an image.
 
-        :param image_path: path to the image you'd like to perform prediction on
-        :param hosted: whether the image you're providing is hosted online
-        :return: PredictionGroup object
+        Args:
+            image_path (str): path to the image you'd like to perform prediction on
+            hosted (bool): whether the image you're providing is hosted on Roboflow
+
+        Returns:
+            PredictionGroup Object
         """
         self.__generate_url()
         self.__exception_check(image_path_check=image_path)
@@ -89,8 +105,11 @@ class ClassificationModel:
 
     def load_model(self, name, version):
         """
-        :param name: is the name of the model you'd like to load
-        :param version: version number
+        Load a model.
+
+        Args:
+            name (str): is the name of the model you'd like to load
+            version (int): version number
         """
         # Load model based on user defined characteristics
         self.name = name
@@ -99,7 +118,10 @@ class ClassificationModel:
 
     def __generate_url(self):
         """
-        :return: roboflow API url
+        Generate a Roboflow API URL on which to run inference.
+
+        Returns:
+            url (str): the url on which to run inference
         """
 
         # Generates URL based on all parameters
@@ -116,7 +138,13 @@ class ClassificationModel:
 
     def __exception_check(self, image_path_check=None):
         """
-        :param image_path_check: checks to see if the image exists.
+        Check to see if an image exists.
+
+        Args:
+            image_path_check (str): path to the image to check
+
+        Raises:
+            Exception: if image does not exist
         """
         # Checks if image exists
         if image_path_check is not None:

--- a/roboflow/models/classification.py
+++ b/roboflow/models/classification.py
@@ -65,6 +65,17 @@ class ClassificationModel:
 
         Returns:
             PredictionGroup Object
+
+        Example:
+            >>> import roboflow
+
+            >>> rf = roboflow.Roboflow(api_key="")
+
+            >>> project = rf.workspace().project("PROJECT_ID")
+
+            >>> model = project.version("1").model
+
+            >>> prediction = model.predict("YOUR_IMAGE.jpg")
         """
         self.__generate_url()
         self.__exception_check(image_path_check=image_path)

--- a/roboflow/models/inference.py
+++ b/roboflow/models/inference.py
@@ -82,6 +82,17 @@ class InferenceModel:
 
         Raises:
             Exception: Image path is not valid
+
+        Example:
+            >>> import roboflow
+
+            >>> rf = roboflow.Roboflow(api_key="")
+
+            >>> project = rf.workspace().project("PROJECT_ID")
+
+            >>> model = project.version("1").model
+
+            >>> prediction = model.predict("YOUR_IMAGE.jpg")
         """
         params, request_kwargs, image_dims = self.__get_image_params(image_path)
 

--- a/roboflow/models/inference.py
+++ b/roboflow/models/inference.py
@@ -19,8 +19,11 @@ class InferenceModel:
         **kwargs,
     ):
         """
-        :param api_key: Your API key (obtained via your workspace API settings page)
-        :param version_id: The ID of the dataset version to use for predicting
+        Create an InferenceModel object through which you can run inference.
+
+        Args:
+            api_key (str): private roboflow api key
+            version_id (str): the ID of the dataset version to use for inference
         """
         self.__api_key = api_key
         self.id = version_id
@@ -32,10 +35,16 @@ class InferenceModel:
 
     def __get_image_params(self, image_path):
         """
-        :param image_path: Path to image (can be local path or hosted URL)
+        Get parameters about an image (i.e. dimensions) for use in an inference request.
 
-        :return: Tuple containing a dict of querystring params and a dict of requests kwargs
-        :raises Exception: Image path is not valid
+        Args:
+            image_path (str): path to the image you'd like to perform prediction on
+
+        Returns:
+            Tuple containing a dict of querystring params and a dict of requests kwargs
+
+        Raises:
+            Exception: Image path is not valid
         """
         validate_image_path(image_path)
 
@@ -61,13 +70,18 @@ class InferenceModel:
 
     def predict(self, image_path, prediction_type=None, **kwargs):
         """
-        Infers detections based on image from a specified model and image path
+        Infers detections based on image from a specified model and image path.
 
-        :param image_path: Path to image (can be local path or hosted URL)
-        :param **kwargs: Any additional kwargs will be turned into querystring params
+        Args:
+            image_path (str): path to the image you'd like to perform prediction on
+            prediction_type (str): type of prediction to perform
+            **kwargs: Any additional kwargs will be turned into querystring params
 
-        :return: PredictionGroup - a group of predictions based on Roboflow JSON response
-        :raises Exception: Image path is not valid
+        Returns:
+            PredictionGroup Object
+
+        Raises:
+            Exception: Image path is not valid
         """
         params, request_kwargs, image_dims = self.__get_image_params(image_path)
 

--- a/roboflow/models/instance_segmentation.py
+++ b/roboflow/models/instance_segmentation.py
@@ -38,7 +38,7 @@ class InstanceSegmentationModel(InferenceModel):
     def predict(self, image_path, confidence=40):
         """
         Infers detections based on image from a specified model and image path.
-        
+
         Args:
             image_path (str): path to the image you'd like to perform prediction on
             confidence (int): confidence threshold for predictions, on a scale from 0-100

--- a/roboflow/models/instance_segmentation.py
+++ b/roboflow/models/instance_segmentation.py
@@ -3,12 +3,27 @@ from roboflow.models.inference import InferenceModel
 
 
 class InstanceSegmentationModel(InferenceModel):
+    """
+    Run inference on a instance segmentation model hosted on Roboflow or served through Roboflow Inference.
+    """
+
     def __init__(
-        self, api_key, version_id, colors=None, preprocessing=None, local=None
+        self,
+        api_key: str,
+        version_id: str,
+        colors: dict = None,
+        preprocessing: dict = None,
+        local: bool = None,
     ):
         """
-        :param api_key: Your API key (obtained via your workspace API settings page)
-        :param version_id: The ID of the dataset version to use for predicting
+        Create a InstanceSegmentationModel object through which you can run inference.
+
+        Args:
+            api_key (str): private roboflow api key
+            version_id (str): the workspace/project id
+            colors (dict): colors to use for the image
+            preprocessing (dict): preprocessing to use for the image
+            local (bool): whether the image is local or hosted
         """
         super(InstanceSegmentationModel, self).__init__(api_key, version_id)
         if local is None:
@@ -22,12 +37,13 @@ class InstanceSegmentationModel(InferenceModel):
 
     def predict(self, image_path, confidence=40):
         """
-        Infers detections based on image from a specified model and image path
+        Infers detections based on image from a specified model and image path.
+        Args:
+            image_path (str): path to the image you'd like to perform prediction on
+            confidence (int): confidence threshold for predictions, on a scale from 0-100
 
-        :param image_path: Path to image (can be local path or hosted URL)
-        :param confidence: A threshold for the returned predictions on a scale of 0-100. A lower number will return more predictions. A higher number will return fewer, high-certainty predictions.
-
-        :return: PredictionGroup - a group of predictions based on Roboflow JSON response
+        Returns:
+            PredictionGroup Object
         """
         return super(InstanceSegmentationModel, self).predict(
             image_path,

--- a/roboflow/models/instance_segmentation.py
+++ b/roboflow/models/instance_segmentation.py
@@ -38,12 +38,24 @@ class InstanceSegmentationModel(InferenceModel):
     def predict(self, image_path, confidence=40):
         """
         Infers detections based on image from a specified model and image path.
+        
         Args:
             image_path (str): path to the image you'd like to perform prediction on
             confidence (int): confidence threshold for predictions, on a scale from 0-100
 
         Returns:
             PredictionGroup Object
+
+        Example:
+            >>> import roboflow
+
+            >>> rf = roboflow.Roboflow(api_key="")
+
+            >>> project = rf.workspace().project("PROJECT_ID")
+
+            >>> model = project.version("1").model
+
+            >>> prediction = model.predict("YOUR_IMAGE.jpg")
         """
         return super(InstanceSegmentationModel, self).predict(
             image_path,

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -18,13 +18,14 @@ from PIL import Image
 from roboflow.config import API_URL, OBJECT_DETECTION_MODEL, OBJECT_DETECTION_URL
 from roboflow.util.image_utils import check_image_url
 from roboflow.util.prediction import PredictionGroup
-from roboflow.util.versions import (
-    print_warn_for_wrong_dependencies_versions,
-    warn_for_wrong_dependencies_versions,
-)
+from roboflow.util.versions import print_warn_for_wrong_dependencies_versions
 
 
 class ObjectDetectionModel:
+    """
+    Run inference on an object detection model hosted on Roboflow or served through Roboflow Inference.
+    """
+
     def __init__(
         self,
         api_key,
@@ -42,26 +43,29 @@ class ObjectDetectionModel:
         preprocessing=None,
     ):
         """
-        From Roboflow Docs:
+        Create a ObjectDetectionModel object through which you can run inference.
 
-        :param api_key: Your API key (obtained via your workspace API settings page)
-        :param name: The url-safe version of the dataset name.  You can find it in the web UI by looking at
-        the URL on the main project view or by clicking the "Get curl command" button in the train results section of
-        your dataset version after training your model.
-        :param local: Address of the local server address if running a local Roboflow deployment server. ex. http://localhost:9001/
-        :param version: The version number identifying the version of of your dataset
-        :param classes: Restrict the predictions to only those of certain classes. Provide as a comma-separated string.
-        :param overlap: The maximum percentage (on a scale of 0-100) that bounding box predictions of the same class are
-        allowed to overlap before being combined into a single box.
-        :param confidence: A threshold for the returned predictions on a scale of 0-100. A lower number will return
-        more predictions. A higher number will return fewer high-certainty predictions
-        :param stroke: The width (in pixels) of the bounding box displayed around predictions (only has an effect when
-        format is image)
-        :param labels: Whether or not to display text labels on the predictions (only has an effect when format is
-        image).
-        :param format: json - returns an array of JSON predictions. (See response format tab).
-                       image - returns an image with annotated predictions as a binary blob with a Content-Type
-                       of image/jpeg.
+        Args:
+            api_key (str): Your API key (obtained via your workspace API settings page).
+            name (str): The url-safe version of the dataset name. You can find it in the web UI by looking at
+                        the URL on the main project view or by clicking the "Get curl command" button in the train
+                        results section of your dataset version after training your model.
+            local (str): Address of the local server address if running a local Roboflow deployment server.
+                        Ex. http://localhost:9001/
+            version (str): The version number identifying the version of your dataset.
+            classes (str): Restrict the predictions to only those of certain classes. Provide as a comma-separated string.
+            overlap (int): The maximum percentage (on a scale of 0-100) that bounding box predictions of the same class are
+                        allowed to overlap before being combined into a single box.
+            confidence (int): A threshold for the returned predictions on a scale of 0-100. A lower number will return
+                            more predictions. A higher number will return fewer high-certainty predictions.
+            stroke (int): The width (in pixels) of the bounding box displayed around predictions (only has an effect when
+                        format is image).
+            labels (bool): Whether or not to display text labels on the predictions (only has an effect when format is
+                        image).
+            format (str): The format of the output.
+                        - 'json': returns an array of JSON predictions (See response format tab).
+                        - 'image': returns an image with annotated predictions as a binary blob with a Content-Type
+                                    of image/jpeg.
         """
         # Instantiate different API URL parameters
         # To be moved to predict
@@ -102,9 +106,12 @@ class ObjectDetectionModel:
         format=None,
     ):
         """
-        Loads a Model based on a Model Endpoint
+        Loads a Model from on a model endpoint.
 
-        :param model_endpoint: This is the endpoint that is loaded into the api_url
+        Args:
+            name (str): The url-safe version of the dataset name
+            version (str): The version number identifying the version of your dataset.
+            local (bool): Whether the model is hosted locally or on Roboflow
         """
         # To load a model manually, they must specify a dataset slug
         self.name = name
@@ -132,12 +139,15 @@ class ObjectDetectionModel:
         labels=False,
     ):
         """
-        Infers detections based on image from specified model and image path
+        Infers detections based on image from specified model and image path.
 
-        :param image_path: Path to image or image array (can be local or hosted)
-        :param hosted: If image located on a hosted server, hosted should be True
-        :param format: output format from this method
-        :return: PredictionGroup --> a group of predictions based on Roboflow JSON response
+        Args:
+            image_path (str): path to the image you'd like to perform prediction on
+            hosted (bool): whether the image you're providing is hosted on Roboflow
+            format (str): The format of the output.
+
+        Returns:
+            PredictionGroup Object
         """
         # Generate url before predicting
         self.__generate_url(
@@ -281,15 +291,16 @@ class ObjectDetectionModel:
         web_cam_res=(416, 416),
     ):
         """
-        Infers detections based on webcam feed from specified model
+        Infers detections based on webcam feed from specified model.
 
-        :param webcam_id: Webcam ID (default 0)
-        :param inference_engine_url: Inference engine address to use (default https://detect.roboflow.com)
-        :param in_jupyter: Whether or not to display the webcam within Jupyter notebook (default True)
-        :param confidence: Confidence threshold for detections
-        :param overlap: Overlap threshold for detections
-        :param stroke: Stroke width for bounding box
-        :param labels: Whether to show labels on bounding box
+        Args:
+            webcam_id (int): Webcam ID (default 0)
+            inference_engine_url (str): Inference engine address to use (default https://detect.roboflow.com)
+            within_jupyter (bool): Whether or not to display the webcam within Jupyter notebook (default True)
+            confidence (int): Confidence threshold for detections
+            overlap (int): Overlap threshold for detections
+            stroke (int): Stroke width for bounding box
+            labels (bool): Whether to show labels on bounding box
         """
 
         os.environ["OPENCV_VIDEOIO_PRIORITY_MSMF"] = "0"
@@ -462,6 +473,14 @@ class ObjectDetectionModel:
             view(stopButton)
 
     def download(self, format="pt", location="."):
+        """
+        Download the weights associated with a model.
+
+        Args:
+            format (str): The format of the output.
+                        - 'pt': returns a PyTorch weights file
+            location (str): The location to save the weights file to
+        """
         supported_formats = ["pt"]
         if format not in supported_formats:
             raise Exception(
@@ -512,6 +531,9 @@ class ObjectDetectionModel:
         format=None,
         inference_engine_url=None,
     ):
+        """
+        Generate the URL to run inference on.
+        """
         # Reassign parameters if any parameters are changed
         if local is not None:
             if not local:

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -148,6 +148,17 @@ class ObjectDetectionModel:
 
         Returns:
             PredictionGroup Object
+
+        Example:
+            >>> import roboflow
+
+            >>> rf = roboflow.Roboflow(api_key="")
+
+            >>> project = rf.workspace().project("PROJECT_ID")
+
+            >>> model = project.version("1").model
+
+            >>> prediction = model.predict("YOUR_IMAGE.jpg")
         """
         # Generate url before predicting
         self.__generate_url(

--- a/roboflow/models/semantic_segmentation.py
+++ b/roboflow/models/semantic_segmentation.py
@@ -3,22 +3,31 @@ from roboflow.models.inference import InferenceModel
 
 
 class SemanticSegmentationModel(InferenceModel):
-    def __init__(self, api_key, version_id):
+    """
+    Run inference on a semantic segmentation model hosted on Roboflow or served through Roboflow Inference.
+    """
+
+    def __init__(self, api_key: str, version_id: str):
         """
-        :param api_key: Your API key (obtained via your workspace API settings page)
-        :param version_id: The ID of the dataset version to use for predicting
+        Create a SemanticSegmentationModel object through which you can run inference.
+
+        Args:
+            api_key (str): private roboflow api key
+            version_id (str): the workspace/project id
         """
         super(SemanticSegmentationModel, self).__init__(api_key, version_id)
         self.api_url = f"{SEMANTIC_SEGMENTATION_URL}/{self.dataset_id}/{self.version}"
 
-    def predict(self, image_path, confidence=50):
+    def predict(self, image_path: str, confidence: int = 50):
         """
-        Infers detections based on image from a specified model and image path
+        Infers detections based on image from a specified model and image path.
 
-        :param image_path: Path to image (can be local path or hosted URL)
-        :param confidence: A threshold for the returned predictions on a scale of 0-100. A lower number will return more predictions. A higher number will return fewer, high-certainty predictions.
+        Args:
+            image_path (str): path to the image you'd like to perform prediction on
+            confidence (int): confidence threshold for predictions, on a scale from 0-100
 
-        :return: PredictionGroup - a group of predictions based on Roboflow JSON response
+        Returns:
+            PredictionGroup Object
         """
         return super(SemanticSegmentationModel, self).predict(
             image_path,

--- a/roboflow/models/semantic_segmentation.py
+++ b/roboflow/models/semantic_segmentation.py
@@ -28,6 +28,17 @@ class SemanticSegmentationModel(InferenceModel):
 
         Returns:
             PredictionGroup Object
+
+        Example:
+            >>> import roboflow
+
+            >>> rf = roboflow.Roboflow(api_key="")
+
+            >>> project = rf.workspace().project("PROJECT_ID")
+
+            >>> model = project.version("1").model
+
+            >>> prediction = model.predict("YOUR_IMAGE.jpg")
         """
         return super(SemanticSegmentationModel, self).predict(
             image_path,

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     },
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.6",


### PR DESCRIPTION
# Description

This PR adds Pythonic documentation to the `roboflow-python` package.

In this PR, I have:

- Reformatted docstrings in the main package (everything other than `util`) to ensure they are consistent.
- Added new docstrings where required.
- Removed informal language from docstrings.
- Added type hints across the main package (although there may be more left to add).
- Added documentation powered by `mkdocs` for use by package developers. There is no way to see all of the Python methods available without digging into the source code right now.
- Updated the quickstart in the README.

This PR does not include any functoinality changes.

## Type of change

- [X] Documentation change

## How has this change been tested, please provide a testcase or example of how you tested the change?

To test this change, install `mkdocs` then run `mkdocs serve` in the main project directory.

## Any specific deployment considerations

James will need to run `mkdocs gh-deploy` to deploy the docs.