### PR TITLE
Remove `wget` dependency and fix `JSONDecodeError` import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,6 @@ requests
 six
 supervision
 urllib3>=1.26.6
-wget
 tqdm>=4.41.0
 PyYAML>=5.3.1
-wget
 requests_toolbelt

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -8,7 +8,6 @@ from importlib import import_module
 
 import numpy as np
 import requests
-import wget
 import yaml
 from dotenv import load_dotenv
 from tqdm import tqdm
@@ -631,7 +630,20 @@ class Version:
             sys.stdout.flush()
 
         try:
-            wget.download(link, out=location + "/roboflow.zip", bar=bar_progress)
+            response = requests.get(link, stream=True)
+
+            # write the zip file to the desired location
+            with open(location + "/roboflow.zip", "wb") as f:
+                total_length = int(response.headers.get("content-length"))
+                for chunk in tqdm(
+                    response.iter_content(chunk_size=1024),
+                    desc=f"Downloading Dataset Version Zip in {location} to {format}:",
+                    total=int(total_length / 1024) + 1,
+                ):
+                    if chunk:
+                        f.write(chunk)
+                        f.flush()
+
         except Exception as e:
             print(f"Error when trying to download dataset @ {link}")
             raise e

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -213,7 +213,7 @@ class Version:
             else:
                 try:
                     raise RuntimeError(response.json())
-                except requests.exceptions.JSONDecodeError:
+                except json.JSONDecodeError:
                     response.raise_for_status()
 
         self.__download_zip(link, location, model_format)
@@ -242,7 +242,7 @@ class Version:
         if not response.ok:
             try:
                 raise RuntimeError(response.json())
-            except requests.exceptions.JSONDecodeError:
+            except json.JSONDecodeError:
                 response.raise_for_status()
 
         # the rest api returns 202 if the export is still in progress
@@ -272,7 +272,7 @@ class Version:
         else:
             try:
                 raise RuntimeError(response.json())
-            except requests.exceptions.JSONDecodeError:
+            except json.JSONDecodeError:
                 response.raise_for_status()
 
     def train(self, speed=None, checkpoint=None, plot_in_notebook=False) -> bool:
@@ -321,7 +321,7 @@ class Version:
         if not response.ok:
             try:
                 raise RuntimeError(response.json())
-            except requests.exceptions.JSONDecodeError:
+            except json.JSONDecodeError:
                 response.raise_for_status()
 
         status = "training"

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -16,9 +16,7 @@ from PIL import Image
 from roboflow.config import API_URL, OBJECT_DETECTION_MODEL, OBJECT_DETECTION_URL
 from roboflow.util.image_utils import check_image_url
 from roboflow.util.prediction import PredictionGroup
-from roboflow.util.versions import (
-    print_warn_for_wrong_dependencies_versions,
-)
+from roboflow.util.versions import print_warn_for_wrong_dependencies_versions
 
 
 class ObjectDetectionModel:

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -6,13 +6,11 @@ import os
 import random
 import sys
 import urllib
-from pathlib import Path
 
 import cv2
-import matplotlib.pyplot as plt
 import numpy as np
 import requests
-import wget
+import tqdm
 from PIL import Image
 
 from roboflow.config import API_URL, OBJECT_DETECTION_MODEL, OBJECT_DETECTION_URL
@@ -20,7 +18,6 @@ from roboflow.util.image_utils import check_image_url
 from roboflow.util.prediction import PredictionGroup
 from roboflow.util.versions import (
     print_warn_for_wrong_dependencies_versions,
-    warn_for_wrong_dependencies_versions,
 )
 
 
@@ -489,7 +486,19 @@ class ObjectDetectionModel:
             sys.stdout.write("\r" + progress_message)
             sys.stdout.flush()
 
-        wget.download(pt_weights_url, out=location + "/weights.pt", bar=bar_progress)
+        response = requests.get(pt_weights_url, stream=True)
+
+        # write the zip file to the desired location
+        with open(location + "/weights.pt", "wb") as f:
+            total_length = int(response.headers.get("content-length"))
+            for chunk in tqdm(
+                response.iter_content(chunk_size=1024),
+                desc=f"Downloading weights to {location}/weights.pt",
+                total=int(total_length / 1024) + 1,
+            ):
+                if chunk:
+                    f.write(chunk)
+                    f.flush()
 
         return
 


### PR DESCRIPTION
# Description

This PR removes the `wget` dependency from `roboflow-python` and replaces its use with `requests`. This change affects downloading model weights and datasets from Roboflow. Both the dataset download and weight export should be tested to validate this change.

Also `requests.exceptions.JSONDecodeError` is deprecated and has been replaced with `json.JSONDecodeError`.

## Type of change

-   [X] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

`pytest` was run to validate that all tests pass.

## Any specific deployment considerations

N/A

## Docs

N/A