### PR TITLE
Release `v1.1.5`

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -12,7 +12,7 @@ from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 from roboflow.util.general import write_line
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 
 
 def check_key(api_key, model, notebook, num_retries=0):


### PR DESCRIPTION
This PR updates the version number to `v1.1.5` in preparation of releasing the latest changes via PyPi.