### PR TITLE
fix: 🐛 check for rlogin is None

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -114,6 +114,9 @@ def login(workspace=None, force=False):
 
     if r_login.status_code == 200:
         r_login = r_login.json()
+        if r_login is None:
+            raise ValueError("Invalid API key. "
+                             "Please check your API key and try again.")
 
         # make config directory if it doesn't exist
         if not os.path.exists(os.path.dirname(conf_location)):


### PR DESCRIPTION
# Description

I notice that if I type random string or invalid key it was creating folder and AttributeError occured. I added check in the begin and if response is NONE, I added ValueError for prevent unneeded process and stop the login 

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Current Error 

```python
>>> import roboflow
>>> roboflow.login()
visit https://app.roboflow.com/auth-cli to get your authentication token.
Paste the authentication token here:
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/onuralp/roboflow/roboflow-python/roboflow/__init__.py", line 126, in login
    default_workspace_id = list(r_login["workspaces"].keys())[0]
AttributeError: 'NoneType' object has no attribute 'keys'
```

Fixed Version (Controlled Error)

```python
>>> import roboflow
>>> roboflow.login()
visit https://app.roboflow.com/auth-cli to get your authentication token.
Paste the authentication token here:
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/onuralp/roboflow/roboflow-python/roboflow/__init__.py", line 118, in login
    raise ValueError("Invalid API key. "
ValueError: Invalid API key. Please check your API key and try again.
```