### PR TITLE
Add input continue warning for wrong ultralytics version in model deploy

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -12,7 +12,7 @@ from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 from roboflow.util.general import write_line
 
-__version__ = "1.1.5"
+__version__ = "1.1.6"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -490,7 +490,7 @@ class Version:
                 )
 
             print_warn_for_wrong_dependencies_versions(
-                [("ultralytics", "==", "8.0.134")]
+                [("ultralytics", "==", "8.0.134")], ask_to_continue=True
             )
 
         elif "yolov5" in model_type or "yolov7" in model_type:

--- a/roboflow/util/versions.py
+++ b/roboflow/util/versions.py
@@ -1,5 +1,6 @@
 from importlib import import_module
 from typing import List, Tuple
+import sys
 
 from packaging.version import Version
 
@@ -42,13 +43,19 @@ def get_wrong_dependencies_versions(
 
 
 def print_warn_for_wrong_dependencies_versions(
-    dependencies_versions: List[Tuple[str, str, str]]
+    dependencies_versions: List[Tuple[str, str, str]], ask_to_continue: bool = False
 ):
     wrong_dependencies_versions = get_wrong_dependencies_versions(dependencies_versions)
     for dependency, order, version, module_version in wrong_dependencies_versions:
         print(
             f"Dependency {dependency}{order}{version} is required but found version={module_version}, to fix: `pip install {dependency}{order}{version}`"
         )
+        if ask_to_continue:
+            answer = input(
+                f"Would you like to continue with the wrong version of {dependency}? y/n: "
+            )
+            if answer.lower() != "y":
+                sys.exit(1)
 
 
 def warn_for_wrong_dependencies_versions(

--- a/roboflow/util/versions.py
+++ b/roboflow/util/versions.py
@@ -1,6 +1,6 @@
+import sys
 from importlib import import_module
 from typing import List, Tuple
-import sys
 
 from packaging.version import Version
 


### PR DESCRIPTION
# Description

Adds input warning that requires `y` input to continue with wrong package version. Introduces this to the ultralytics version check in the version `deploy` method. This will help resolve some model upload compatibility issues.