### PR TITLE
fix readme link to contributing.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Within the version object, you can download the dataset version in any model for
 
 ## 🏆 Contributing
 
-We would love your input on how we can improve the Roboflow Python package! Please see our [contributing guide](https://github.com/roboflow/roboflow-python) to get started. Thank you 🙏 to all our contributors!
+We would love your input on how we can improve the Roboflow Python package! Please see our [contributing guide](https://github.com/roboflow/roboflow-python/blob/main/CONTRIBUTING.md) to get started. Thank you 🙏 to all our contributors!
 
 <br>
 


### PR DESCRIPTION
# Description

The link to the contributing guide in the readme leads to the main repo. This change updates the link to be the [CONTRIBUTING](https://github.com/roboflow/roboflow-python/blob/main/CONTRIBUTING.md) page.

## Docs

-   [x] README.md: link to CONTRIBUTING.md was updated

