### PR TITLE
python version to >=3.8 from 3.6 in setup.py and readme

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
       - name: 🛎️ Checkout

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,6 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter"
     },
-    "python.formatting.provider": "none"
+    "python.formatting.provider": "none",
+    "python.testing.pytestEnabled": false
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ The Python package is documented on the [official Roboflow documentation site](h
 
 ## 💻 Installation
 
-You will need to have `Python 3.6` or higher set up to use the Roboflow Python package.
+You will need to have `Python 3.8` or higher set up to use the Roboflow Python package.
 
 Run the following command to install the Roboflow Python package:
 

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -12,7 +12,7 @@ from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 from roboflow.util.general import write_line
 
-__version__ = "1.1.6"
+__version__ = "1.1.7"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
# Description

Updated python version requirements to >=3.8 from 3.6 in setup.py and Readme. Python 3.8 is now the earliest version Roboflow supports because it’s the earliest version supported by our dependencies. Here’s [the discussion](https://github.com/roboflow/supervision/pull/180) from when supervision dropped support for 3.7 a few months ago.

## Type of change

-   [X] This change requires a documentation update