### PR TITLE
project.py fixes for uploading hosted images

### DIFF
--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -427,7 +427,7 @@ class Project:
 
             upload_url = "".join(
                 [
-                    API_URL + "/dataset/" + self.project_name + "/upload",
+                    API_URL + "/dataset/" + project_name + "/upload",
                     "?api_key=" + self.__api_key,
                     "&name=" + os.path.basename(image_path),
                     "&split=" + split,
@@ -623,7 +623,7 @@ class Project:
             )
 
         if is_file:
-            is_image = self.check_valid_image(image_path) or is_hosted
+            is_image = is_hosted or self.check_valid_image(image_path)
 
             if not is_image:
                 raise RuntimeError(


### PR DESCRIPTION
Two small changes:
(1) When passing in a URL (for hosted image)'self.check_valid_image(path)' doesn't need to run, so we put 'is_hosted' before in the 'or' statement. (2) When pushing to the API for upload, we had 'self.project_name' which doesn't exists. It should be 'project_name' which is calculated a few lines prior.

# Description
Hosted image upload was failing. I fixed 2 things:
(1) When passing in a URL (for hosted image)'self.check_valid_image(path)' doesn't need to run, so we put 'is_hosted' before in the 'or' statement. (2) When pushing to the API for upload, we had 'self.project_name' which doesn't exists. It should be 'project_name' which is calculated a few lines prior.

## Type of change

-   [ x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Running an upload via python for a hosted image:
project.upload("https://jacketmediaco.com/wp-content/uploads/2016/02/GoogleTruck.jpg", hosted_image=True)

## Any specific deployment considerations

None. I don't think many people used this because It didnt work.

## Docs

I will be updating the roboflow docs: https://docs.roboflow.com/datasets/adding-data/upload-data-from-aws-gcp-and-azure