### PR TITLE
Increase version to 1.1.8

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -13,7 +13,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel
 from roboflow.util.general import write_line
 
-__version__ = "1.1.7"
+__version__ = "1.1.8"
 
 
 def check_key(api_key, model, notebook, num_retries=0):


### PR DESCRIPTION
# Description

This PR increases the `roboflow-python` version to 1.1.18.

## Type of change

-   [X] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

This release contains code tested in all individual accepted PRs since the last release.

## Any specific deployment considerations

I will need @tonylampada's help publishing the change.

## Docs

N/A