### PR TITLE
Allow video inference `fps` value to pass through to API

### DIFF
--- a/roboflow/models/inference.py
+++ b/roboflow/models/inference.py
@@ -269,7 +269,7 @@ class InferenceModel:
             models.append(SUPPORTED_ADDITIONAL_MODELS[model])
 
         payload = json.dumps(
-            {"input_url": signed_url, "infer_fps": 5, "models": models}
+            {"input_url": signed_url, "infer_fps": fps, "models": models}
         )
 
         headers = {"Content-Type": "application/json"}

--- a/roboflow/models/video.py
+++ b/roboflow/models/video.py
@@ -135,7 +135,7 @@ class VideoInferenceModel(InferenceModel):
             models.append(SUPPORTED_ADDITIONAL_MODELS[model])
 
         payload = json.dumps(
-            {"input_url": signed_url, "infer_fps": 5, "models": models}
+            {"input_url": signed_url, "infer_fps": fps, "models": models}
         )
 
         response = requests.request("POST", url, headers=headers, data=payload)


### PR DESCRIPTION
# Description

This PR updates the video inference API wrappers in the `roboflow` package to adhere to the `fps` that the user passes.

## Type of change

-   [X] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

This change can be tested using the following code:

```python
from roboflow import Roboflow

rf = Roboflow(api_key="API_KEY")
project = rf.workspace().project("logistics-sz9jr")
model = project.version(2).model

job_id, signed_url = model.predict_video(
    "video.mp4",
    fps=1,
    prediction_type="batch-video",
)

results = model.poll_until_video_results(job_id)

print(results)

job_id, signed_url = model.predict_video(
    "video.mp4",
    fps=5,
    prediction_type="batch-video",
)

results = model.poll_until_video_results(job_id)

print(results)
```

And ensuring that the FPS intervals are 1 FPS for the first video and 5 fps for the second video.

## Any specific deployment considerations

N/A

## Docs

N/A