### PR TITLE
Bump version to `1.1.12`

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -13,7 +13,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel
 from roboflow.util.general import write_line
 
-__version__ = "1.1.11"
+__version__ = "1.1.12"
 
 
 def check_key(api_key, model, notebook, num_retries=0):


### PR DESCRIPTION
# Description

The last release Action failed because there had already been a release pushed with the `1.1.12` identifier. This PR bumps the latest version to `1.1.12` so we can release #205. 

## Type of change

Versioning change.

## How has this change been tested, please provide a testcase or example of how you tested the change?

N/A

## Any specific deployment considerations

I will publish a new release of the package after this PR is merged.

## Docs

N/A