### PR TITLE
Change `download()` to not overwrite files by default

### DIFF
--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -164,7 +164,7 @@ class Version:
                 sys.stdout.flush()
             return
 
-    def download(self, model_format=None, location=None, overwrite: bool = True):
+    def download(self, model_format=None, location=None, overwrite: bool = False):
         """
         Download and extract a ZIP of a version's dataset in a given format
 
@@ -175,7 +175,7 @@ class Version:
         Args:
             model_format (str): A format to use for downloading
             location (str): An optional path for saving the file
-            overwrite (bool): An optional flag to prevent dataset overwrite when dataset is already downloaded
+            overwrite (bool): An optional flag to overwrite an existing dataset if the dataset has already downloaded
 
         Returns:
             Dataset Object


### PR DESCRIPTION
# Description

This PR changes the `download()` method to set the `overwrite` flag to `False` by default. This will ensure that a dataset is not re-downloaded every time the `download()` method is run.

This addresses #108.

## Type of change

-   [X] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Run the following snippet twice:

```python
!pip install roboflow

from roboflow import Roboflow
rf = Roboflow(api_key="")
project = rf.workspace("capjamesg").project("streamlit-logo-detection")
dataset = project.version(1).download("coco")
```

When you run the code for the first time, a `Downloading Dataset Version Zip in` message should appear as the dataset is downloaded. On the second run, `Downloading Dataset Version Zip in` should not appear.

## Any specific deployment considerations

N/A

## Docs

N/A