### PR TITLE
Add new commands to the CLI

### DIFF
--- a/CLI-COMMANDS.md
+++ b/CLI-COMMANDS.md
@@ -1,0 +1,23 @@
+## Available commands
+
+```bash
+roboflow --help
+usage: roboflow [-h] {login,download,upload,import,infer,project,workspace} ...
+
+Welcome to the roboflow CLI: computer vision at your fingertips 🪄
+
+options:
+  -h, --help            show this help message and exit
+
+subcommands:
+  {login,download,upload,import,infer,project,workspace}
+    login               Log in to Roboflow
+    download            Download a dataset version from your workspace or Roboflow Universe.
+    upload              Upload a single image to a dataset
+    import              Import a dataset from a local folder
+    infer               perform inference on an image
+    project             project related commands. type 'roboflow project' to see detailed command help
+    workspace           workspace related commands. type 'roboflow workspace' to see detailed command help
+```
+
+## Authentication

--- a/CLI-COMMANDS.md
+++ b/CLI-COMMANDS.md
@@ -1,7 +1,10 @@
-## Available commands
+## See available commands
 
 ```bash
-roboflow --help
+$ roboflow --help
+```
+
+```
 usage: roboflow [-h] {login,download,upload,import,infer,project,workspace} ...
 
 Welcome to the roboflow CLI: computer vision at your fingertips 🪄
@@ -21,3 +24,80 @@ subcommands:
 ```
 
 ## Authentication
+
+You need to authenticate first
+
+```bash
+$ roboflow login
+```
+
+```
+visit https://app.roboflow.com/auth-cli to get your authentication token.
+Paste the authentication token here:
+```
+Open that link on your browser, get the token, paste it on the terminal.
+The credentials get saved to `~/.config/roboflow/config.json`
+
+## Display help usage for other commands
+
+"How do I download stuff?"
+
+```bash
+$ roboflow download --help
+```
+```
+usage: roboflow download [-h] [-f FORMAT] [-l LOCATION] datasetUrl
+
+positional arguments:
+  datasetUrl   Dataset URL (e.g., `roboflow-100/cells-uyemf/2`)
+
+options:
+  -h, --help   show this help message and exit
+  -f FORMAT    Specify the format to download the version. Available options: [coco, yolov5pytorch, yolov7pytorch, my-yolov6, darknet,
+               voc, tfrecord, createml, clip, multiclass, coco-segmentation, yolo5-obb, png-mask-semantic, yolov8]
+  -l LOCATION  Location to download the dataset
+```
+
+"How do I import a dataset into my workspace?"
+
+```bash
+$ roboflow import --help
+```
+
+```
+usage: roboflow import [-h] [-w WORKSPACE] [-p PROJECT] [-c CONCURRENCY] [-f FORMAT] folder
+
+positional arguments:
+  folder          filesystem path to a folder that contains your dataset
+
+options:
+  -h, --help      show this help message and exit
+  -w WORKSPACE    specify a workspace url or id (will use default workspace if not specified)
+  -p PROJECT      project will be created if it does not exist
+  -c CONCURRENCY  how many image uploads to perform concurrently (default: 10)
+  -f FORMAT       dataset format. Valid options are [voc, yolov8, yolov5, auto] (use auto for autodetect)
+```
+
+## Example: download dataset
+
+Download [Joseph's chess dataset](https://universe.roboflow.com/joseph-nelson/chess-pieces-new/dataset/25) from Roboflow Universe in VOC format:
+
+```bash
+$ roboflow download -f voc -l ~/tmp/chess joseph-nelson/chess-pieces-new/25
+```
+```
+loading Roboflow workspace...
+loading Roboflow project...
+Downloading Dataset Version Zip in /Users/tony/tmp/chess to voc:: 100%|██████████████████████████| 19178/19178 [00:01<00:00, 10424.62it/s]
+
+Extracting Dataset Version Zip to /Users/tony/tmp/chess in voc:: 100%|██████████████████████████████| 1391/1391 [00:00<00:00, 8992.30it/s]
+```
+```bash
+$ ls -lh ~/tmp/chess
+total 16
+-rw-r--r--@    1 tony  staff   1.8K Jan  5 10:32 README.dataset.txt
+-rw-r--r--@    1 tony  staff   562B Jan  5 10:32 README.roboflow.txt
+drwxr-xr-x@   60 tony  staff   1.9K Jan  5 10:32 test
+drwxr-xr-x@ 1214 tony  staff    38K Jan  5 10:32 train
+drwxr-xr-x@  118 tony  staff   3.7K Jan  5 10:32 valid
+```

--- a/CLI-COMMANDS.md
+++ b/CLI-COMMANDS.md
@@ -1,3 +1,6 @@
+# The roboflow-python command line
+This has the same capabilities of the [roboflow node cli](https://www.npmjs.com/package/roboflow-cli) so that our users don't need to install two different tools.
+
 ## See available commands
 
 ```bash
@@ -100,4 +103,125 @@ total 16
 drwxr-xr-x@   60 tony  staff   1.9K Jan  5 10:32 test
 drwxr-xr-x@ 1214 tony  staff    38K Jan  5 10:32 train
 drwxr-xr-x@  118 tony  staff   3.7K Jan  5 10:32 valid
+```
+
+## Example: list workspaces
+List the workspaces you have access to
+
+```bash
+$ roboflow workspace list
+```
+
+```
+tonyprivate
+  link: https://app.roboflow.com/tonyprivate
+  id: tonyprivate
+
+wolfodorpythontests
+  link: https://app.roboflow.com/wolfodorpythontests
+  id: wolfodorpythontests
+
+test minimize
+  link: https://app.roboflow.com/test-minimize
+  id: test-minimize
+```
+
+## Example: get workspace details
+
+```bash
+$ roboflow workspace get tonyprivate
+```
+
+```
+{
+  "workspace": {
+    "name": "tonyprivate",
+    "url": "tonyprivate",
+    "members": 4,
+    "projects": [
+      {
+        "id": "tonyprivate/annotation-upload",
+        "type": "object-detection",
+        "name": "annotation-upload",
+        "created": 1685199749.708,
+        "updated": 1695910515.48,
+        "images": 1,
+        (...)
+      }
+    ]
+  }
+}
+```
+
+## Example: list projects
+
+```bash
+roboflow project list -w tonyprivate
+```
+```
+annotation-upload
+  link: https://app.roboflow.com/tonyprivate/annotation-upload
+  id: tonyprivate/annotation-upload
+  type: object-detection
+  versions: 0
+  images: 1
+  classes: dict_keys(['0', 'Rabbits1', 'Rabbits2', 'minion1', 'minion0', '5075E'])
+
+hand-gestures
+  link: https://app.roboflow.com/tonyprivate/hand-gestures-fsph8
+  id: tonyprivate/hand-gestures-fsph8
+  type: object-detection
+  versions: 5
+  images: 387
+  classes: dict_keys(['zero', 'four', 'one', 'two', 'five', 'three', 'Guard'])
+```
+
+## Example: get project details
+
+```bash
+roboflow project get -w tonyprivate annotation-upload
+```
+```
+{
+  "workspace": {
+    "name": "tonyprivate",
+    "url": "tonyprivate",
+    "members": 4
+  },
+  "project": {
+    "id": "tonyprivate/annotation-upload",
+    "type": "object-detection",
+    "name": "annotation-upload",
+    "created": 1685199749.708,
+    "updated": 1695910515.48,
+    "images": 1,
+    (...)
+  },
+  "versions": []
+}
+```
+
+## Example: run inference
+
+If your project has a trained model (or you are using a dataset from Roboflow Universe that has a trained model), you can run inference from the command line.
+
+Let's use [Rock-Paper-Scissors sample public dataset]([url](https://universe.roboflow.com/roboflow-58fyf/rock-paper-scissors-sxsw/model/11)) from Roboflow universe
+
+(In my case, `~/scissors.png` is me holding two fingers to the camera, you can use your own image file ;-))
+
+```bash
+roboflow infer -w roboflow-58fyf -m rock-paper-scissors-sxsw/11 ~/scissors.png
+```
+```
+{
+  "x": 1230.0,
+  "y": 814.5,
+  "width": 840.0,
+  "height": 1273.0,
+  "confidence": 0.8817358016967773,
+  "class": "Scissors",
+  "class_id": 2,
+  "image_path": "/Users/tony/scissors.png",
+  "prediction_type": "ObjectDetectionModel"
+}
 ```

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ check_code_quality:
 	# stop the build if there are Python syntax errors or undefined names
 	flake8 $(check_dirs) --count --select=E9,F63,F7,F82 --show-source --statistics
 	# exit-zero treats all errors as warnings. E203 for black, E501 for docstring, W503 for line breaks before logical operators
-	flake8 $(check_dirs) --count --max-line-length=160 --exit-zero  --ignore=D --extend-ignore=E203,E501,W503  --statistics
+	flake8 $(check_dirs) --count --max-line-length=120 --exit-zero  --ignore=D --extend-ignore=E203,E501,W503  --statistics
 
 publish:
 	python setup.py sdist bdist_wheel

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ check_code_quality:
 	# stop the build if there are Python syntax errors or undefined names
 	flake8 $(check_dirs) --count --select=E9,F63,F7,F82 --show-source --statistics
 	# exit-zero treats all errors as warnings. E203 for black, E501 for docstring, W503 for line breaks before logical operators
-	flake8 $(check_dirs) --count --max-line-length=88 --exit-zero  --ignore=D --extend-ignore=E203,E501,W503  --statistics
+	flake8 $(check_dirs) --count --max-line-length=160 --exit-zero  --ignore=D --extend-ignore=E203,E501,W503  --statistics
 
 publish:
 	python setup.py sdist bdist_wheel

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ pip install roboflow
   ```
 </details>
 
+<details>
+  <summary>Command line tool</summary>
+
+  By installing roboflow python package you can use some of its functionality in the command line (without having to write python code).
+  See [CLI-COMMANDS.md](CLI-COMMANDS.md)
+</details>
+
+
 ## 🚀 Getting Started
 
 To use the Roboflow Python package, you first need to authenticate with your Roboflow account. You can do this by running the following command:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [tool.flake8]
 exclude = ".venv"
 max-complexity = 10
-max-line-length = 160
+max-line-length = 120
 extend-ignore = """
     W503,
     E203,
@@ -17,8 +17,11 @@ per-file-ignores = """
     __init__.py: F401
 """
 
+[tool.black]
+line-length = 120
+
 [tool.isort]
-line_length = 160
+line_length = 120
 profile = "black"
 
 [tool.bandit]
@@ -115,7 +118,7 @@ exclude = [
 ]
 
 # Same as Black.
-line-length = 160
+line-length = 120
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [tool.flake8]
 exclude = ".venv"
 max-complexity = 10
-max-line-length = 88
+max-line-length = 160
 extend-ignore = """
     W503,
     E203,
@@ -18,7 +18,7 @@ per-file-ignores = """
 """
 
 [tool.isort]
-line_length = 88
+line_length = 160
 profile = "black"
 
 [tool.bandit]
@@ -115,7 +115,7 @@ exclude = [
 ]
 
 # Same as Black.
-line-length = 88
+line-length = 160
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -12,6 +12,7 @@ from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel
 from roboflow.util.general import write_line
+from roboflow.adapters import rfapi
 
 __version__ = "1.1.14"
 
@@ -278,9 +279,7 @@ class Roboflow:
         if self.api_key in DEMO_KEYS:
             return Workspace({}, self.api_key, the_workspace, self.model_format)
 
-        list_projects = requests.get(
-            API_URL + "/" + the_workspace + "?api_key=" + self.api_key
-        ).json()
+        list_projects = rfapi.get_workspace(self.api_key, the_workspace)
 
         return Workspace(list_projects, self.api_key, the_workspace, self.model_format)
 

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -253,10 +253,11 @@ class Roboflow:
 
         if self.api_key in DEMO_KEYS:
             return Workspace({}, self.api_key, the_workspace, self.model_format)
+        workspace_api_key = load_roboflow_api_key(the_workspace)
+        api_key = workspace_api_key or self.api_key
 
-        list_projects = rfapi.get_workspace(self.api_key, the_workspace)
-
-        return Workspace(list_projects, self.api_key, the_workspace, self.model_format)
+        list_projects = rfapi.get_workspace(api_key, the_workspace)
+        return Workspace(list_projects, api_key, the_workspace, self.model_format)
 
     def project(self, project_name, the_workspace=None):
         """Function that takes in the name of the project and returns the project object

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -11,7 +11,7 @@ from roboflow.adapters import rfapi
 from roboflow.config import API_URL, APP_URL, DEMO_KEYS, load_roboflow_api_key
 from roboflow.core.project import Project
 from roboflow.core.workspace import Workspace
-from roboflow.models import CLIPModel, GazeModel
+from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
 __version__ = "1.1.14"
@@ -20,15 +20,10 @@ __version__ = "1.1.14"
 def check_key(api_key, model, notebook, num_retries=0):
     if not isinstance(api_key, str):
         raise RuntimeError(
-            "API Key is of Incorrect Type \n Expected Type: "
-            + str(type(""))
-            + "\n Input Type: "
-            + str(type(api_key))
+            "API Key is of Incorrect Type \n Expected Type: " + str(type("")) + "\n Input Type: " + str(type(api_key))
         )
 
-    if any(
-        c for c in api_key if c.islower()
-    ):  # check if any of the api key characters are lowercase
+    if any(c for c in api_key if c.islower()):  # check if any of the api key characters are lowercase
         if api_key in DEMO_KEYS:
             # passthrough for public download of COCO-128 for the time being
             return api_key
@@ -47,10 +42,7 @@ def check_key(api_key, model, notebook, num_retries=0):
                     num_retries += 1
                     return check_key(api_key, model, notebook, num_retries)
                 else:
-                    raise RuntimeError(
-                        "There was an error validating the api key with Roboflow"
-                        " server."
-                    )
+                    raise RuntimeError("There was an error validating the api key with Roboflow" " server.")
             else:
                 r = response.json()
                 return r
@@ -89,10 +81,7 @@ def login(workspace=None, force=False):
     )
 
     if os.path.isfile(conf_location) and not force:
-        write_line(
-            "You are already logged into Roboflow. To make a different login,"
-            "run roboflow.login(force=True)."
-        )
+        write_line("You are already logged into Roboflow. To make a different login," "run roboflow.login(force=True).")
         return None
         # we could eventually return the workspace object here
         # return Roboflow().workspace()
@@ -102,13 +91,7 @@ def login(workspace=None, force=False):
     if workspace is None:
         write_line("visit " + APP_URL + "/auth-cli to get your authentication token.")
     else:
-        write_line(
-            "visit "
-            + APP_URL
-            + "/auth-cli/?workspace="
-            + workspace
-            + " to get your authentication token."
-        )
+        write_line("visit " + APP_URL + "/auth-cli/?workspace=" + workspace + " to get your authentication token.")
 
     token = getpass("Paste the authentication token here: ")
 
@@ -117,9 +100,7 @@ def login(workspace=None, force=False):
     if r_login.status_code == 200:
         r_login = r_login.json()
         if r_login is None:
-            raise ValueError(
-                "Invalid API key. Please check your API key and try again."
-            )
+            raise ValueError("Invalid API key. Please check your API key and try again.")
 
         # make config directory if it doesn't exist
         if not os.path.exists(os.path.dirname(conf_location)):
@@ -166,9 +147,7 @@ def initialize_roboflow(the_workspace=None):
     )
 
     if not os.path.isfile(conf_location):
-        raise RuntimeError(
-            "To use this method, you must first login - run roboflow.login()"
-        )
+        raise RuntimeError("To use this method, you must first login - run roboflow.login()")
     else:
         if the_workspace is None:
             active_workspace = Roboflow().workspace()
@@ -197,9 +176,7 @@ def load_model(model_url):
         project = path_parts[2]
         version = int(path_parts[-1])
     else:
-        raise (
-            "Model URL must be from either app.roboflow.com or universe.roboflow.com"
-        )
+        raise ("Model URL must be from either app.roboflow.com or universe.roboflow.com")
 
     project = operate_workspace.project(project)
     version = project.version(version)
@@ -227,9 +204,7 @@ def download_dataset(dataset_url, model_format, location=None):
         version = int(path_parts[-1])
         the_workspace = path_parts[1]
     else:
-        raise (
-            "Model URL must be from either app.roboflow.com or universe.roboflow.com"
-        )
+        raise ("Model URL must be from either app.roboflow.com or universe.roboflow.com")
     operate_workspace = initialize_roboflow(the_workspace=the_workspace)
 
     project = operate_workspace.project(project)
@@ -297,15 +272,7 @@ class Roboflow:
             else:
                 the_workspace = self.current_workspace
 
-        dataset_info = requests.get(
-            API_URL
-            + "/"
-            + the_workspace
-            + "/"
-            + project_name
-            + "?api_key="
-            + self.api_key
-        )
+        dataset_info = requests.get(API_URL + "/" + the_workspace + "/" + project_name + "?api_key=" + self.api_key)
 
         # Throw error if dataset isn't valid/user doesn't have
         #   permissions to access the dataset

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -14,7 +14,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.14"
+__version__ = "1.1.15"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -9,8 +9,30 @@ from roboflow.config import API_URL, DEFAULT_BATCH_NAME
 from roboflow.util import image_utils
 
 
-class UploadError(Exception):
+class RoboflowError(Exception):
     pass
+
+
+class UploadError(RoboflowError):
+    pass
+
+
+def get_workspace(api_key, workspace_url):
+    url = f"{API_URL}/{workspace_url}/?api_key={api_key}"
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise RoboflowError(response.text)
+    result = response.json()
+    return result
+
+
+def get_project(api_key, workspace_url, project_url):
+    url = f"{API_URL}/{workspace_url}/{project_url}?api_key={api_key}"
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise RoboflowError(response.text)
+    result = response.json()
+    return result
 
 
 def upload_image(

--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -18,7 +18,7 @@ class UploadError(RoboflowError):
 
 
 def get_workspace(api_key, workspace_url):
-    url = f"{API_URL}/{workspace_url}/?api_key={api_key}"
+    url = f"{API_URL}/{workspace_url}?api_key={api_key}"
     response = requests.get(url)
     if response.status_code != 200:
         raise RoboflowError(response.text)

--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -60,9 +60,7 @@ def upload_image(
         image_name = os.path.basename(image_path)
         imgjpeg = image_utils.file2jpeg(image_path)
 
-        upload_url = _local_upload_url(
-            api_key, project_url, batch_name, tag_names, kwargs
-        )
+        upload_url = _local_upload_url(api_key, project_url, batch_name, tag_names, kwargs)
         m = MultipartEncoder(
             fields={
                 "name": image_name,
@@ -70,9 +68,7 @@ def upload_image(
                 "file": ("imageToUpload", imgjpeg, "image/jpeg"),
             }
         )
-        response = requests.post(
-            upload_url, data=m, headers={"Content-Type": m.content_type}
-        )
+        response = requests.post(upload_url, data=m, headers={"Content-Type": m.content_type})
 
     else:
         # Hosted image upload url
@@ -91,9 +87,7 @@ def upload_image(
         else:
             raise UploadError(f"Bad response: {response}")
     if not responsejson:  # fail fast
-        raise UploadError(
-            f"upload image {image_path} 200 OK, unexpected response: {response}"
-        )
+        raise UploadError(f"upload image {image_path} 200 OK, unexpected response: {response}")
     if not (responsejson.get("success") or responsejson.get("duplicate")):
         raise UploadError(f"Server rejected image: {responsejson}")
     return responsejson
@@ -116,15 +110,11 @@ def save_annotation(
         image_id (str): image id you'd like to upload that has annotations for it.
     """
 
-    upload_url = _save_annotation_url(
-        api_key, project_url, annotation_name, image_id, is_prediction
-    )
+    upload_url = _save_annotation_url(api_key, project_url, annotation_name, image_id, is_prediction)
 
     response = requests.post(
         upload_url,
-        data=json.dumps(
-            {"annotationFile": annotation_string, "labelmap": annotation_labelmap}
-        ),
+        data=json.dumps({"annotationFile": annotation_string, "labelmap": annotation_labelmap}),
         headers={"Content-Type": "application/json"},
     )
     responsejson = None
@@ -149,10 +139,7 @@ def save_annotation(
 
 
 def _save_annotation_url(api_key, project_url, name, image_id, is_prediction):
-    url = (
-        f"{API_URL}/dataset/{project_url}/annotate/{image_id}?api_key={api_key}"
-        f"&name={name}"
-    )
+    url = f"{API_URL}/dataset/{project_url}/annotate/{image_id}?api_key={api_key}" f"&name={name}"
     if is_prediction:
         url += "&prediction=true"
     return url
@@ -166,10 +153,7 @@ def _hosted_upload_url(api_key, project_url, image_path, split):
 
 
 def _local_upload_url(api_key, project_url, batch_name, tag_names, kwargs):
-    url = (
-        f"{API_URL}/dataset/{project_url}/upload?api_key={api_key}"
-        f"&batch={batch_name}"
-    )
+    url = f"{API_URL}/dataset/{project_url}/upload?api_key={api_key}" f"&batch={batch_name}"
     for key, value in kwargs.items():
         url += f"&{str(key)}={str(value)}"
     for tag in tag_names:

--- a/roboflow/config.py
+++ b/roboflow/config.py
@@ -76,6 +76,8 @@ RF_WORKSPACES = get_conditional_configuration_variable("workspaces", default={})
 
 
 def load_roboflow_api_key(workspace_url=None):
+    if os.getenv("RF_API_KEY") is not None:
+        return os["RF_API_KEY"]
     RF_WORKSPACES = get_conditional_configuration_variable("workspaces", default={})
     workspaces_by_url = {w["url"]: w for w in RF_WORKSPACES.values()}
     default_workspace_url = get_conditional_configuration_variable("RF_WORKSPACE", default=None)
@@ -84,5 +86,3 @@ def load_roboflow_api_key(workspace_url=None):
     workspace = workspace or get_conditional_configuration_variable("RF_WORKSPACE", default=None)
     if workspace:
         return workspace.get("apiKey", None)
-    if os.getenv("RF_API_KEY") is not None:
-        return os["RF_API_KEY"]

--- a/roboflow/config.py
+++ b/roboflow/config.py
@@ -75,21 +75,14 @@ DEFAULT_BATCH_NAME = "Pip Package Upload"
 RF_WORKSPACES = get_conditional_configuration_variable("workspaces", default={})
 
 
-def load_roboflow_api_key(workspace=None):
-    workspace = workspace or get_conditional_configuration_variable("RF_WORKSPACE", default=None)
+def load_roboflow_api_key(workspace_url=None):
     RF_WORKSPACES = get_conditional_configuration_variable("workspaces", default={})
-
-    # DEFAULT_WORKSPACE = get_conditional_configuration_variable("default_workspace", default=None)  # noqa: E501 // docs
-    if workspace is None:
-        RF_API_KEY = None
-    else:
-        RF_API_KEY = None
-        for k in RF_WORKSPACES.keys():
-            _workspace = RF_WORKSPACES[k]
-            if _workspace["url"] == workspace:
-                RF_API_KEY = _workspace["apiKey"]
-    # ENV API_KEY OVERRIDE
+    workspaces_by_url = {w["url"]: w for w in RF_WORKSPACES.values()}
+    default_workspace_url = get_conditional_configuration_variable("RF_WORKSPACE", default=None)
+    default_workspace = workspaces_by_url.get(default_workspace_url, None)
+    workspace = workspaces_by_url.get(workspace_url, default_workspace)
+    workspace = workspace or get_conditional_configuration_variable("RF_WORKSPACE", default=None)
+    if workspace:
+        return workspace.get("apiKey", None)
     if os.getenv("RF_API_KEY") is not None:
-        RF_API_KEY = os.getenv("RF_API_KEY")
-
-    return RF_API_KEY
+        return os["RF_API_KEY"]

--- a/roboflow/config.py
+++ b/roboflow/config.py
@@ -50,9 +50,7 @@ PREDICTION_OBJECT = os.getenv("PREDICTION_OBJECT", "Prediction")
 
 API_URL = get_conditional_configuration_variable("API_URL", "https://api.roboflow.com")
 APP_URL = get_conditional_configuration_variable("APP_URL", "https://app.roboflow.com")
-UNIVERSE_URL = get_conditional_configuration_variable(
-    "UNIVERSE_URL", "https://universe.roboflow.com"
-)
+UNIVERSE_URL = get_conditional_configuration_variable("UNIVERSE_URL", "https://universe.roboflow.com")
 
 INSTANCE_SEGMENTATION_URL = get_conditional_configuration_variable(
     "INSTANCE_SEGMENTATION_URL", "https://outline.roboflow.com"
@@ -60,13 +58,9 @@ INSTANCE_SEGMENTATION_URL = get_conditional_configuration_variable(
 SEMANTIC_SEGMENTATION_URL = get_conditional_configuration_variable(
     "SEMANTIC_SEGMENTATION_URL", "https://segment.roboflow.com"
 )
-OBJECT_DETECTION_URL = get_conditional_configuration_variable(
-    "OBJECT_DETECTION_URL", "https://detect.roboflow.com"
-)
+OBJECT_DETECTION_URL = get_conditional_configuration_variable("OBJECT_DETECTION_URL", "https://detect.roboflow.com")
 
-CLIP_FEATURIZE_URL = get_conditional_configuration_variable(
-    "CLIP_FEATURIZE_URL", "CLIP FEATURIZE URL NOT IN ENV"
-)
+CLIP_FEATURIZE_URL = get_conditional_configuration_variable("CLIP_FEATURIZE_URL", "CLIP FEATURIZE URL NOT IN ENV")
 OCR_URL = get_conditional_configuration_variable("OCR_URL", "OCR URL NOT IN ENV")
 
 DEMO_KEYS = ["coco-128-sample", "chess-sample-only-api-key"]

--- a/roboflow/config.py
+++ b/roboflow/config.py
@@ -75,19 +75,19 @@ DEFAULT_BATCH_NAME = "Pip Package Upload"
 RF_WORKSPACES = get_conditional_configuration_variable("workspaces", default={})
 
 
-def load_roboflow_api_key():
-    RF_WORKSPACE = get_conditional_configuration_variable("RF_WORKSPACE", default=None)
+def load_roboflow_api_key(workspace=None):
+    workspace = workspace or get_conditional_configuration_variable("RF_WORKSPACE", default=None)
     RF_WORKSPACES = get_conditional_configuration_variable("workspaces", default={})
 
     # DEFAULT_WORKSPACE = get_conditional_configuration_variable("default_workspace", default=None)  # noqa: E501 // docs
-    if RF_WORKSPACE is None:
+    if workspace is None:
         RF_API_KEY = None
     else:
         RF_API_KEY = None
         for k in RF_WORKSPACES.keys():
-            workspace = RF_WORKSPACES[k]
-            if workspace["url"] == RF_WORKSPACE:
-                RF_API_KEY = workspace["apiKey"]
+            _workspace = RF_WORKSPACES[k]
+            if _workspace["url"] == workspace:
+                RF_API_KEY = _workspace["apiKey"]
     # ENV API_KEY OVERRIDE
     if os.getenv("RF_API_KEY") is not None:
         RF_API_KEY = os.getenv("RF_API_KEY")

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -85,13 +85,7 @@ class Project:
             >>> version_info = project.get_version_information()
         """
         dataset_info = requests.get(
-            API_URL
-            + "/"
-            + self.__workspace
-            + "/"
-            + self.__project_name
-            + "?api_key="
-            + self.__api_key
+            API_URL + "/" + self.__workspace + "/" + self.__project_name + "?api_key=" + self.__api_key
         )
 
         # Throw error if dataset isn't valid/user doesn't have permissions to access the dataset # noqa: E501 // docs
@@ -221,8 +215,7 @@ class Project:
             )
 
         r = requests.post(
-            f"{API_URL}/{self.__workspace}/{self.__project_name}/"
-            f"generate?api_key={self.__api_key}",
+            f"{API_URL}/{self.__workspace}/{self.__project_name}/" f"generate?api_key={self.__api_key}",
             json=settings,
         )
 
@@ -233,13 +226,7 @@ class Project:
 
         # if the generation succeeds, return the version that is being generated
         if r.status_code == 200:
-            sys.stdout.write(
-                "\r"
-                + r_json["message"]
-                + " for new version "
-                + str(r_json["version"])
-                + "."
-            )
+            sys.stdout.write("\r" + r_json["message"] + " for new version " + str(r_json["version"]) + ".")
             sys.stdout.write("\n")
             sys.stdout.flush()
             return int(r_json["version"])
@@ -291,9 +278,7 @@ class Project:
 
         new_version = self.generate_version(settings=new_version_settings)
         new_version = self.version(new_version)
-        new_model = new_version.train(
-            speed=speed, checkpoint=checkpoint, plot_in_notebook=plot_in_notebook
-        )
+        new_model = new_version.train(speed=speed, checkpoint=checkpoint, plot_in_notebook=plot_in_notebook)
 
         return new_model
 
@@ -405,9 +390,7 @@ class Project:
             >>> project.upload(image_path="YOUR_IMAGE.jpg")
         """  # noqa: E501 // docs
 
-        is_hosted = image_path.startswith("http://") or image_path.startswith(
-            "https://"
-        )
+        is_hosted = image_path.startswith("http://") or image_path.startswith("https://")
 
         is_file = os.path.isfile(image_path) or is_hosted
         is_dir = os.path.isdir(image_path)
@@ -424,9 +407,7 @@ class Project:
             if not is_image:
                 raise RuntimeError(
                     "The image you provided {} is not a supported file format. We"
-                    " currently support: {}.".format(
-                        image_path, ", ".join(ACCEPTED_IMAGE_FORMATS)
-                    )
+                    " currently support: {}.".format(image_path, ", ".join(ACCEPTED_IMAGE_FORMATS))
                 )
 
             self.single_upload(
@@ -607,13 +588,7 @@ class Project:
         payload["fields"] = fields
 
         data = requests.post(
-            API_URL
-            + "/"
-            + self.__workspace
-            + "/"
-            + self.__project_name
-            + "/search?api_key="
-            + self.__api_key,
+            API_URL + "/" + self.__workspace + "/" + self.__project_name + "/search?api_key=" + self.__api_key,
             json=payload,
         )
 

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -145,11 +145,7 @@ class Version:
         still_generating, progress = self.__check_if_generating()
 
         if still_generating:
-            progress_message = (
-                "Generating version still in progress. Progress: "
-                + str(round(progress * 100, 2))
-                + "%"
-            )
+            progress_message = "Generating version still in progress. Progress: " + str(round(progress * 100, 2)) + "%"
             sys.stdout.write("\r" + progress_message)
             sys.stdout.flush()
             time.sleep(5)
@@ -188,9 +184,7 @@ class Version:
             # if ultralytics is installed, we will assume users will want to use yolov8 and we check for the supported version  # noqa: E501 // docs
             try:
                 import_module("ultralytics")
-                print_warn_for_wrong_dependencies_versions(
-                    [("ultralytics", "==", "8.0.196")]
-                )
+                print_warn_for_wrong_dependencies_versions([("ultralytics", "==", "8.0.196")])
             except ImportError:
                 print(
                     "[WARNING] we noticed you are downloading a `yolov8` datasets but you don't have `ultralytics` installed. "  # noqa: E501 // docs
@@ -209,9 +203,7 @@ class Version:
         if location is None:
             location = self.__get_download_location()
         if os.path.exists(location) and not overwrite:
-            return Dataset(
-                self.name, self.version, model_format, os.path.abspath(location)
-            )
+            return Dataset(self.name, self.version, model_format, os.path.abspath(location))
 
         if self.__api_key == "coco-128-sample":
             link = "https://app.roboflow.com/ds/n9QwXwUK42?key=NnVCe2yMxP"
@@ -271,11 +263,7 @@ class Version:
                 if status_code_check == 202:
                     progress = response.json()["progress"]
                     progress_message = (
-                        "Exporting format "
-                        + model_format
-                        + " in progress : "
-                        + str(round(progress * 100, 2))
-                        + "%"
+                        "Exporting format " + model_format + " in progress : " + str(round(progress * 100, 2)) + "%"
                     )
                     sys.stdout.write("\r" + progress_message)
                     sys.stdout.flush()
@@ -369,9 +357,7 @@ class Version:
         num_machine_spin_dots = []
 
         while status == "training" or status == "running":
-            url = (
-                f"{API_URL}/{self.workspace}/{self.project}/{self.version}?nocache=true"
-            )
+            url = f"{API_URL}/{self.workspace}/{self.project}/{self.version}?nocache=true"
             response = requests.get(url, params={"api_key": self.__api_key})
             response.raise_for_status()
             version = response.json()["version"]
@@ -391,25 +377,11 @@ class Version:
 
             if "roboflow-train" in models.keys():
                 # training has started
-                epochs = np.array(
-                    [
-                        int(epoch["epoch"])
-                        for epoch in models["roboflow-train"]["epochs"]
-                    ]
-                )
-                mAP = np.array(
-                    [
-                        float(epoch["mAP"])
-                        for epoch in models["roboflow-train"]["epochs"]
-                    ]
-                )
+                epochs = np.array([int(epoch["epoch"]) for epoch in models["roboflow-train"]["epochs"]])
+                mAP = np.array([float(epoch["mAP"]) for epoch in models["roboflow-train"]["epochs"]])
                 loss = np.array(
                     [
-                        (
-                            float(epoch["box_loss"])
-                            + float(epoch["class_loss"])
-                            + float(epoch["obj_loss"])
-                        )
+                        (float(epoch["box_loss"]) + float(epoch["class_loss"]) + float(epoch["obj_loss"]))
                         for epoch in models["roboflow-train"]["epochs"]
                     ]
                 )
@@ -432,13 +404,7 @@ class Version:
                 else:
                     if len(epochs) > 0:
                         title = (
-                            title
-                            + ": Epoch: "
-                            + str(epochs[-1])
-                            + " mAP: "
-                            + str(mAP[-1])
-                            + " loss: "
-                            + str(loss[-1])
+                            title + ": Epoch: " + str(epochs[-1]) + " mAP: " + str(mAP[-1]) + " loss: " + str(loss[-1])
                         )
                     if not first_graph_write:
                         write_line(title)
@@ -461,15 +427,8 @@ class Version:
 
         supported_models = ["yolov5", "yolov7-seg", "yolov8"]
 
-        if not any(
-            supported_model in model_type for supported_model in supported_models
-        ):
-            raise (
-                ValueError(
-                    f"Model type {model_type} not supported. Supported models are"
-                    f" {supported_models}"
-                )
-            )
+        if not any(supported_model in model_type for supported_model in supported_models):
+            raise (ValueError(f"Model type {model_type} not supported. Supported models are" f" {supported_models}"))
 
         if "yolov8" in model_type:
             try:
@@ -482,9 +441,7 @@ class Version:
                     " models. Please install it with `pip install ultralytics`"
                 )
 
-            print_warn_for_wrong_dependencies_versions(
-                [("ultralytics", "==", "8.0.196")], ask_to_continue=True
-            )
+            print_warn_for_wrong_dependencies_versions([("ultralytics", "==", "8.0.196")], ask_to_continue=True)
 
         elif "yolov5" in model_type or "yolov7" in model_type:
             try:
@@ -519,11 +476,7 @@ class Version:
                     "names": class_names,
                     "yaml": model["model"].yaml,
                     "nc": nc,
-                    "args": {
-                        k: val
-                        for k, val in args.items()
-                        if ((k == "model") or (k == "imgsz") or (k == "batch"))
-                    },
+                    "args": {k: val for k, val in args.items() if ((k == "model") or (k == "imgsz") or (k == "batch"))},
                     "ultralytics_version": ultralytics.__version__,
                     "model_type": model_type,
                 }
@@ -561,9 +514,7 @@ class Version:
         with open(os.path.join(model_path, "model_artifacts.json"), "w") as fp:
             json.dump(model_artifacts, fp)
 
-        torch.save(
-            model["model"].state_dict(), os.path.join(model_path, "state_dict.pt")
-        )
+        torch.save(model["model"].state_dict(), os.path.join(model_path, "state_dict.pt"))
 
         lista_files = [
             "results.csv",
@@ -572,9 +523,7 @@ class Version:
             "state_dict.pt",
         ]
 
-        with zipfile.ZipFile(
-            os.path.join(model_path, "roboflow_deploy.zip"), "w"
-        ) as zipMe:
+        with zipfile.ZipFile(os.path.join(model_path, "roboflow_deploy.zip"), "w") as zipMe:
             for file in lista_files:
                 if os.path.exists(os.path.join(model_path, file)):
                     zipMe.write(
@@ -584,12 +533,7 @@ class Version:
                     )
                 else:
                     if file in ["model_artifacts.json", "state_dict.pt"]:
-                        raise (
-                            ValueError(
-                                f"File {file} not found. Please make sure to provide a"
-                                " valid model path."
-                            )
-                        )
+                        raise (ValueError(f"File {file} not found. Please make sure to provide a" " valid model path."))
 
         res = requests.get(
             f"{API_URL}/{self.workspace}/{self.project}/{self.version}"
@@ -748,8 +692,7 @@ class Version:
 
         if not format:
             raise RuntimeError(
-                "You must pass a format argument to version.download() or define a"
-                " model in your Roboflow object"
+                "You must pass a format argument to version.download() or define a" " model in your Roboflow object"
             )
 
         friendly_formats = {"yolov5": "yolov5pytorch", "yolov7": "yolov7pytorch"}

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -3,6 +3,8 @@ import glob
 import json
 import os
 import sys
+from roboflow.adapters import rfapi
+
 
 import requests
 import supervision as sv
@@ -91,15 +93,8 @@ class Workspace:
                 )
             )
 
-        dataset_info = requests.get(
-            API_URL + "/" + self.url + "/" + project_id + "?api_key=" + self.__api_key
-        )
-
-        # Throw error if dataset isn't valid/user doesn't have permissions to access the dataset   # noqa: E501 // docs
-        if dataset_info.status_code != 200:
-            raise RuntimeError(dataset_info.text)
-
-        dataset_info = dataset_info.json()["project"]
+        dataset_info = rfapi.get_project(self.__api_key, self.url, project_id)
+        dataset_info = dataset_info["project"]
 
         return Project(self.__api_key, dataset_info, self.model_format)
 

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -82,11 +82,7 @@ class Workspace:
         # project_id = project_id.replace(self.url + "/", "")
 
         if "/" in project_id:
-            raise RuntimeError(
-                "The {} project is not available in this ({}) workspace".format(
-                    project_id, self.url
-                )
-            )
+            raise RuntimeError("The {} project is not available in this ({}) workspace".format(project_id, self.url))
 
         dataset_info = rfapi.get_project(self.__api_key, self.url, project_id)
         dataset_info = dataset_info["project"]
@@ -113,9 +109,7 @@ class Workspace:
             "annotation": annotation,
         }
 
-        r = requests.post(
-            API_URL + "/" + self.url + "/projects?api_key=" + self.__api_key, json=data
-        )
+        r = requests.post(API_URL + "/" + self.url + "/projects?api_key=" + self.__api_key, json=data)
 
         r.raise_for_status()
 
@@ -124,9 +118,7 @@ class Workspace:
 
         return self.project(r.json()["id"].split("/")[-1])
 
-    def clip_compare(
-        self, dir: str = "", image_ext: str = ".png", target_image: str = ""
-    ) -> dict:
+    def clip_compare(self, dir: str = "", image_ext: str = ".png", target_image: str = "") -> dict:
         """
         Compare all images in a directory to a target image using CLIP
 
@@ -187,10 +179,7 @@ class Workspace:
         # perform first inference
         predictions = stage_one_model.predict(image)
 
-        if (
-            stage_one_project.type == "object-detection"
-            and stage_two_project == "classification"
-        ):
+        if stage_one_project.type == "object-detection" and stage_two_project == "classification":
             # interact with each detected object from stage one inference results
             for boundingbox in predictions:
                 # rip bounding box coordinates from json1
@@ -274,10 +263,7 @@ class Workspace:
                 # capture OCR results from cropped image
                 results.append(ocr_infer(croppedImg)["results"])
         else:
-            print(
-                "please use an object detection model--can only perform two stage with"
-                " bounding box results"
-            )
+            print("please use an object detection model--can only perform two stage with" " bounding box results")
 
         return results
 
@@ -302,9 +288,7 @@ class Workspace:
             project_type (str): type of the project (only `object-detection` is supported)
         """  # noqa: E501 // docs
         if dataset_format == "auto":
-            return self._upload_dataset_auto(
-                dataset_path, project_name, num_workers, project_license, project_type
-            )
+            return self._upload_dataset_auto(dataset_path, project_name, num_workers, project_license, project_type)
         else:
             return self._upload_dataset_legacy(
                 dataset_path,
@@ -382,9 +366,7 @@ class Workspace:
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
             list(executor.map(_upload_image, images))
 
-    def _get_or_create_project(
-        self, project_id, license: str = "MIT", type: str = "object-detection"
-    ):
+    def _get_or_create_project(self, project_id, license: str = "MIT", type: str = "object-detection"):
         try:
             existing_project = self.project(project_id)
             return existing_project, False
@@ -455,14 +437,10 @@ class Workspace:
                 split (str): split to which the the image should be added (train, valid, test)
             """  # noqa: E501 // docs
             label_file = img_file.replace(".jpg", ".xml")
-            dataset_upload_project.upload(
-                image_path=img_file, annotation_path=label_file, split=split
-            )
+            dataset_upload_project.upload(image_path=img_file, annotation_path=label_file, split=split)
 
         def parallel_upload(file_list, split):
-            with concurrent.futures.ThreadPoolExecutor(
-                max_workers=num_workers
-            ) as executor:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
                 list(
                     tqdm(
                         executor.map(upload_file, file_list, [split] * len(file_list)),
@@ -504,30 +482,18 @@ class Workspace:
         prediction_results = []
 
         # ensure that all fields of conditionals have a key:value pair
-        conditionals["target_classes"] = (
-            []
-            if "target_classes" not in conditionals
-            else conditionals["target_classes"]
-        )
+        conditionals["target_classes"] = [] if "target_classes" not in conditionals else conditionals["target_classes"]
         conditionals["confidence_interval"] = (
-            [30, 99]
-            if "confidence_interval" not in conditionals
-            else conditionals["confidence_interval"]
+            [30, 99] if "confidence_interval" not in conditionals else conditionals["confidence_interval"]
         )
         conditionals["required_class_variance_count"] = (
-            1
-            if "required_class_variance_count" not in conditionals
-            else conditionals["required_class_variance_count"]
+            1 if "required_class_variance_count" not in conditionals else conditionals["required_class_variance_count"]
         )
         conditionals["required_objects_count"] = (
-            1
-            if "required_objects_count" not in conditionals
-            else conditionals["required_objects_count"]
+            1 if "required_objects_count" not in conditionals else conditionals["required_objects_count"]
         )
         conditionals["required_class_count"] = (
-            0
-            if "required_class_count" not in conditionals
-            else conditionals["required_class_count"]
+            0 if "required_class_count" not in conditionals else conditionals["required_class_count"]
         )
         conditionals["minimum_size_requirement"] = (
             float("-inf")
@@ -535,18 +501,14 @@ class Workspace:
             else conditionals["minimum_size_requirement"]
         )
         conditionals["maximum_size_requirement"] = (
-            float("inf")
-            if "maximum_size_requirement" not in conditionals
-            else conditionals["maximum_size_requirement"]
+            float("inf") if "maximum_size_requirement" not in conditionals else conditionals["maximum_size_requirement"]
         )
 
         # check if inference_model references endpoint or local
         local = "http://localhost:9001/" if use_localhost else None
 
         inference_model = (
-            self.project(inference_endpoint[0])
-            .version(version_number=inference_endpoint[1], local=local)
-            .model
+            self.project(inference_endpoint[0]).version(version_number=inference_endpoint[1], local=local).model
         )
         upload_project = self.project(upload_destination)
 
@@ -565,13 +527,7 @@ class Workspace:
         for index, image in enumerate(globbed_files):
             try:
                 print(
-                    "*** Processing image ["
-                    + str(index + 1)
-                    + "/"
-                    + str(len(globbed_files))
-                    + "] - "
-                    + image
-                    + " ***"
+                    "*** Processing image [" + str(index + 1) + "/" + str(len(globbed_files)) + "] - " + image + " ***"
                 )
             except Exception:
                 pass
@@ -584,8 +540,7 @@ class Workspace:
 
                 if (
                     similarity <= conditionals["similarity_confidence_threshold"]
-                    or similarity_timeout_counter
-                    == conditionals["similarity_timeout_limit"]
+                    or similarity_timeout_counter == conditionals["similarity_timeout_limit"]
                 ):
                     image1 = image
                     similarity_timeout_counter = 0
@@ -624,10 +579,8 @@ class Workspace:
                 # compare confidence of detected object to confidence thresholds
                 # confidence comes in as a .XXX instead of XXX%
                 if (
-                    prediction["confidence"] * 100
-                    >= conditionals["confidence_interval"][0]
-                    and prediction["confidence"] * 100
-                    <= conditionals["confidence_interval"][1]
+                    prediction["confidence"] * 100 >= conditionals["confidence_interval"][0]
+                    and prediction["confidence"] * 100 <= conditionals["confidence_interval"][1]
                 ):
                     # filter out non-target_class uploads if enabled
                     if (
@@ -644,11 +597,7 @@ class Workspace:
 
         # return predictions with filenames if globbed images from dir,
         # otherwise return latest prediction result
-        return (
-            prediction_results
-            if type(raw_data_location) is not ndarray
-            else prediction_results[-1]["predictions"]
-        )
+        return prediction_results if type(raw_data_location) is not ndarray else prediction_results[-1]["predictions"]
 
     def __str__(self):
         projects = self.projects()

--- a/roboflow/models/__init__.py
+++ b/roboflow/models/__init__.py
@@ -1,2 +1,2 @@
-from .clip import CLIPModel
-from .gaze import GazeModel
+from .clip import CLIPModel  # noqa: F401
+from .gaze import GazeModel  # noqa: F401

--- a/roboflow/models/classification.py
+++ b/roboflow/models/classification.py
@@ -143,7 +143,9 @@ class ClassificationModel:
         # Generates URL based on all parameters
         splitted = self.id.rsplit("/")
         without_workspace = splitted[1]
-        version = self.version or splitted[2]
+        version = self.version
+        if not version and len(splitted) > 2:
+            version = splitted[2]
 
         self.api_url = "".join(
             [

--- a/roboflow/models/classification.py
+++ b/roboflow/models/classification.py
@@ -164,9 +164,7 @@ class ClassificationModel:
         """
         # Checks if image exists
         if image_path_check is not None:
-            if not os.path.exists(image_path_check) and not check_image_url(
-                image_path_check
-            ):
+            if not os.path.exists(image_path_check) and not check_image_url(image_path_check):
                 raise Exception("Image does not exist at " + image_path_check + "!")
 
     def __str__(self):

--- a/roboflow/models/classification.py
+++ b/roboflow/models/classification.py
@@ -56,7 +56,7 @@ class ClassificationModel:
         self.colors = {} if colors is None else colors
         self.preprocessing = {} if preprocessing is None else preprocessing
 
-        if local is not None:
+        if local:
             print("initalizing local classification model hosted at :" + local)
             self.base_url = local
 
@@ -143,10 +143,11 @@ class ClassificationModel:
         # Generates URL based on all parameters
         splitted = self.id.rsplit("/")
         without_workspace = splitted[1]
+        version = self.version or splitted[2]
 
         self.api_url = "".join(
             [
-                self.base_url + without_workspace + "/" + str(self.version),
+                self.base_url + without_workspace + "/" + str(version),
                 "?api_key=" + self.__api_key,
                 "&name=YOUR_IMAGE.jpg",
             ]

--- a/roboflow/models/inference.py
+++ b/roboflow/models/inference.py
@@ -82,9 +82,7 @@ class InferenceModel:
         image_dims = {"width": str(dimensions[0]), "height": str(dimensions[1])}
         buffered = io.BytesIO()
         image.save(buffered, quality=90, format="JPEG")
-        data = MultipartEncoder(
-            fields={"file": ("imageToUpload", buffered.getvalue(), "image/jpeg")}
-        )
+        data = MultipartEncoder(fields={"file": ("imageToUpload", buffered.getvalue(), "image/jpeg")})
         return (
             {},
             {"data": data, "headers": {"Content-Type": data.content_type}},
@@ -214,9 +212,7 @@ class InferenceModel:
 
             signed_url = response.json()["signed_url"]
 
-            signed_url_expires = (
-                signed_url.split("&X-Goog-Expires")[1].split("&")[0].strip("=")
-            )
+            signed_url_expires = signed_url.split("&X-Goog-Expires")[1].split("&")[0].strip("=")
 
             # make a POST request to the signed URL
             headers = {"Content-Type": "application/octet-stream"}
@@ -233,9 +229,7 @@ class InferenceModel:
                 raise Exception(f"There was an error uploading the video: {e}")
 
             if not result.ok:
-                raise Exception(
-                    f"There was an error uploading the video: {result.text}"
-                )
+                raise Exception(f"There was an error uploading the video: {result.text}")
         else:
             signed_url = video_path
 
@@ -249,12 +243,8 @@ class InferenceModel:
             models = [
                 {
                     "model_id": SUPPORTED_ADDITIONAL_MODELS[model]["model_id"],
-                    "model_version": SUPPORTED_ADDITIONAL_MODELS[model][
-                        "model_version"
-                    ],
-                    "inference_type": SUPPORTED_ADDITIONAL_MODELS[model][
-                        "inference_type"
-                    ],
+                    "model_version": SUPPORTED_ADDITIONAL_MODELS[model]["model_version"],
+                    "inference_type": SUPPORTED_ADDITIONAL_MODELS[model]["inference_type"],
                 }
             ]
         else:
@@ -269,9 +259,7 @@ class InferenceModel:
         for model in additional_models:
             models.append(SUPPORTED_ADDITIONAL_MODELS[model])
 
-        payload = json.dumps(
-            {"input_url": signed_url, "infer_fps": fps, "models": models}
-        )
+        payload = json.dumps({"input_url": signed_url, "infer_fps": fps, "models": models})
 
         headers = {"Content-Type": "application/json"}
 
@@ -313,9 +301,7 @@ class InferenceModel:
         if job_id is None:
             job_id = self.job_id
 
-        url = urljoin(
-            API_URL, "/videoinfer/?api_key=" + self.__api_key + "&job_id=" + self.job_id
-        )
+        url = urljoin(API_URL, "/videoinfer/?api_key=" + self.__api_key + "&job_id=" + self.job_id)
         try:
             response = requests.get(url, headers={"Content-Type": "application/json"})
         except Exception as e:
@@ -332,9 +318,7 @@ class InferenceModel:
             return {}  # Still running
         else:  # done
             output_signed_url = data["output_signed_url"]
-            inference_data = requests.get(
-                output_signed_url, headers={"Content-Type": "application/json"}
-            )
+            inference_data = requests.get(output_signed_url, headers={"Content-Type": "application/json"})
 
             # frame_offset and model name are top-level keys
             return inference_data.json()

--- a/roboflow/models/instance_segmentation.py
+++ b/roboflow/models/instance_segmentation.py
@@ -28,9 +28,7 @@ class InstanceSegmentationModel(InferenceModel):
         """
         super(InstanceSegmentationModel, self).__init__(api_key, version_id)
         if local is None:
-            self.api_url = (
-                f"{INSTANCE_SEGMENTATION_URL}/{self.dataset_id}/{self.version}"
-            )
+            self.api_url = f"{INSTANCE_SEGMENTATION_URL}/{self.dataset_id}/{self.version}"
         else:
             self.api_url = f"{local}/{self.dataset_id}/{self.version}"
         self.colors = {} if colors is None else colors

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -72,7 +72,7 @@ class ObjectDetectionModel(InferenceModel):
         self.__api_key = api_key
         self.id = id
         self.name = name
-        self.version = version
+        self.version = version or self.version
         self.classes = classes
         self.overlap = overlap
         self.confidence = confidence

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -187,9 +187,9 @@ class ObjectDetectionModel(InferenceModel):
                 # Here we resize the image to the preprocessing settings
                 # before sending it over the wire
                 if "resize" in self.preprocessing.keys():
-                    if dimensions[0] > int(
-                        self.preprocessing["resize"]["width"]
-                    ) or dimensions[1] > int(self.preprocessing["resize"]["height"]):
+                    if dimensions[0] > int(self.preprocessing["resize"]["width"]) or dimensions[1] > int(
+                        self.preprocessing["resize"]["height"]
+                    ):
                         image = image.resize(
                             (
                                 int(self.preprocessing["resize"]["width"]),
@@ -248,33 +248,13 @@ class ObjectDetectionModel(InferenceModel):
             if resize:
                 new_preds = []
                 for p in resp_json["predictions"]:
-                    p["x"] = int(
-                        p["x"]
-                        * (
-                            int(original_dimensions[0])
-                            / int(self.preprocessing["resize"]["width"])
-                        )
-                    )
-                    p["y"] = int(
-                        p["y"]
-                        * (
-                            int(original_dimensions[1])
-                            / int(self.preprocessing["resize"]["height"])
-                        )
-                    )
+                    p["x"] = int(p["x"] * (int(original_dimensions[0]) / int(self.preprocessing["resize"]["width"])))
+                    p["y"] = int(p["y"] * (int(original_dimensions[1]) / int(self.preprocessing["resize"]["height"])))
                     p["width"] = int(
-                        p["width"]
-                        * (
-                            int(original_dimensions[0])
-                            / int(self.preprocessing["resize"]["width"])
-                        )
+                        p["width"] * (int(original_dimensions[0]) / int(self.preprocessing["resize"]["width"]))
                     )
                     p["height"] = int(
-                        p["height"]
-                        * (
-                            int(original_dimensions[1])
-                            / int(self.preprocessing["resize"]["height"])
-                        )
+                        p["height"] * (int(original_dimensions[1]) / int(self.preprocessing["resize"]["height"]))
                     )
 
                     new_preds.append(p)
@@ -327,9 +307,7 @@ class ObjectDetectionModel(InferenceModel):
             inference_engine_url=inference_engine_url,
         )
 
-        def plot_one_box(
-            x, img, color=None, label=None, line_thickness=None, colors=None
-        ):
+        def plot_one_box(x, img, color=None, label=None, line_thickness=None, colors=None):
             # Plots one bounding box on image img
 
             self.colors = {} if colors is None else colors
@@ -341,9 +319,7 @@ class ObjectDetectionModel(InferenceModel):
             else:
                 color = [random.randint(0, 255) for _ in range(3)]
 
-            tl = (
-                line_thickness or round(0.002 * (img.shape[0] + img.shape[1]) / 2) + 1
-            )  # line/font thickness
+            tl = line_thickness or round(0.002 * (img.shape[0] + img.shape[1]) / 2) + 1  # line/font thickness
 
             c1, c2 = (int(x[0]), int(x[1])), (int(x[2]), int(x[3]))
 
@@ -496,9 +472,7 @@ class ObjectDetectionModel(InferenceModel):
         """
         supported_formats = ["pt"]
         if format not in supported_formats:
-            raise Exception(
-                f"Unsupported format {format}. Must be one of {supported_formats}"
-            )
+            raise Exception(f"Unsupported format {format}. Must be one of {supported_formats}")
 
         workspace, project, version = self.id.rsplit("/")
 
@@ -541,9 +515,7 @@ class ObjectDetectionModel(InferenceModel):
         # Check if Image path exists exception check
         # (for both hosted URL and local image)
         if image_path_check is not None:
-            if not os.path.exists(image_path_check) and not check_image_url(
-                image_path_check
-            ):
+            if not os.path.exists(image_path_check) and not check_image_url(image_path_check):
                 raise Exception("Image does not exist at " + image_path_check + "!")
 
     def __generate_url(

--- a/roboflow/models/video.py
+++ b/roboflow/models/video.py
@@ -100,9 +100,7 @@ class VideoInferenceModel(InferenceModel):
                 raise Exception(f"Model {model} is no t supported for video inference.")
 
         if inference_type not in SUPPORTED_ROBOFLOW_MODELS:
-            raise Exception(
-                f"Model {inference_type} is not supported for video inference."
-            )
+            raise Exception(f"Model {inference_type} is not supported for video inference.")
 
         if not is_valid_video(video_path):
             raise Exception("Video path is not valid")
@@ -134,9 +132,7 @@ class VideoInferenceModel(InferenceModel):
         for model in additional_models:
             models.append(SUPPORTED_ADDITIONAL_MODELS[model])
 
-        payload = json.dumps(
-            {"input_url": signed_url, "infer_fps": fps, "models": models}
-        )
+        payload = json.dumps({"input_url": signed_url, "infer_fps": fps, "models": models})
 
         response = requests.request("POST", url, headers=headers, data=payload)
 
@@ -170,9 +166,7 @@ class VideoInferenceModel(InferenceModel):
         if job_id is None:
             job_id = self.job_id
 
-        url = urljoin(
-            API_URL, "/videoinfer/?api_key=", self.__api_key, "&job_id=", self.job_id
-        )
+        url = urljoin(API_URL, "/videoinfer/?api_key=", self.__api_key, "&job_id=", self.job_id)
 
         try:
             response = requests.get(url, headers={"Content-Type": "application/json"})
@@ -188,9 +182,7 @@ class VideoInferenceModel(InferenceModel):
         if data["success"] == 0:
             output_signed_url = data["output_signed_url"]
 
-            inference_data = requests.get(
-                output_signed_url, headers={"Content-Type": "application/json"}
-            )
+            inference_data = requests.get(output_signed_url, headers={"Content-Type": "application/json"})
 
             # frame_offset and model name are top-level keys
             return inference_data.json()

--- a/roboflow/roboflowpy.py
+++ b/roboflow/roboflowpy.py
@@ -307,13 +307,15 @@ def _add_infer_parser(subparsers):
     infer_parser.add_argument(
         "-c",
         dest="confidence",
-        help="specify a confidence threshold between 0.0 and 1.0, default is 0.5 (only applies to object-detection models)",
+        help="specify a confidence threshold between 0.0 and 1.0, default is 0.5"
+        "(only applies to object-detection models)",
         default=0.5,
     )
     infer_parser.add_argument(
         "-o",
         dest="overlap",
-        help="specify an overlap threshold between 0.0 and 1.0, default is 0.5 (only applies to object-detection models)",
+        help="specify an overlap threshold between 0.0 and 1.0, default is 0.5"
+        "(only applies to object-detection models)",
         default=0.5,
     )
     infer_parser.add_argument(

--- a/roboflow/roboflowpy.py
+++ b/roboflow/roboflowpy.py
@@ -89,27 +89,27 @@ def list_workspaces(args):
     for w in workspaces:
         print()
         print(f"{w['name']}{' (default workspace)' if w['url'] == rf_workspace else ''}")
-        print(f"  link: {APP_URL}/{w['id']}")
+        print(f"  link: {APP_URL}/{w['url']}")
         print(f"  id: {w['url']}")
 
 
 def get_workspace(args):
-    api_key = load_roboflow_api_key()
+    api_key = load_roboflow_api_key(args.workspaceId)
     workspace_json = rfapi.get_workspace(api_key, args.workspaceId)
     print(json.dumps(workspace_json, indent=2))
 
 
 def get_project(args):
-    api_key = load_roboflow_api_key()
     workspace_url = args.workspace or get_conditional_configuration_variable("RF_WORKSPACE", default=None)
+    api_key = load_roboflow_api_key(workspace_url)
     dataset_json = rfapi.get_project(api_key, workspace_url, args.projectId)
     print(json.dumps(dataset_json, indent=2))
 
 
 def infer(args):
-    api_key = load_roboflow_api_key()
-    workspace = args.workspace or get_conditional_configuration_variable("RF_WORKSPACE", default=None)
-    version_id = f"{workspace}/{args.model}"
+    workspace_url = args.workspace or get_conditional_configuration_variable("RF_WORKSPACE", default=None)
+    api_key = load_roboflow_api_key(workspace_url)
+    version_id = f"{workspace_url}/{args.model}"
     model = ObjectDetectionModel(api_key, version_id)  # TODO: detect/use correct model type
     kwargs = {}
     if args.confidence is not None:

--- a/roboflow/roboflowpy.py
+++ b/roboflow/roboflowpy.py
@@ -20,9 +20,7 @@ def _parse_url(url):
     if match:
         organization = match.group(1) or match.group(4)
         dataset = match.group(2) or match.group(5)
-        version = match.group(3) or match.group(
-            6
-        )  # This can be None if not present in the URL
+        version = match.group(3) or match.group(6)  # This can be None if not present in the URL
         return organization, dataset, version
     return None, None, None
 
@@ -90,9 +88,7 @@ def list_workspaces(args):
     rf_workspace = get_conditional_configuration_variable("RF_WORKSPACE", default=None)
     for w in workspaces:
         print()
-        print(
-            f"{w['name']}{' (default workspace)' if w['url'] == rf_workspace else ''}"
-        )
+        print(f"{w['name']}{' (default workspace)' if w['url'] == rf_workspace else ''}")
         print(f"  link: {APP_URL}/{w['id']}")
         print(f"  id: {w['url']}")
 
@@ -105,22 +101,16 @@ def get_workspace(args):
 
 def get_project(args):
     api_key = load_roboflow_api_key()
-    workspace_url = args.workspace or get_conditional_configuration_variable(
-        "RF_WORKSPACE", default=None
-    )
+    workspace_url = args.workspace or get_conditional_configuration_variable("RF_WORKSPACE", default=None)
     dataset_json = rfapi.get_project(api_key, workspace_url, args.projectId)
     print(json.dumps(dataset_json, indent=2))
 
 
 def infer(args):
     api_key = load_roboflow_api_key()
-    workspace = args.workspace or get_conditional_configuration_variable(
-        "RF_WORKSPACE", default=None
-    )
+    workspace = args.workspace or get_conditional_configuration_variable("RF_WORKSPACE", default=None)
     version_id = f"{workspace}/{args.model}"
-    model = ObjectDetectionModel(
-        api_key, version_id
-    )  # TODO: detect/use correct model type
+    model = ObjectDetectionModel(api_key, version_id)  # TODO: detect/use correct model type
     kwargs = {}
     if args.confidence is not None:
         kwargs["confidence"] = int(args.confidence * 100)
@@ -131,9 +121,7 @@ def infer(args):
 
 
 def _argparser():
-    parser = argparse.ArgumentParser(
-        description="Welcome to the roboflow CLI: computer vision at your fingertips 🪄"
-    )
+    parser = argparse.ArgumentParser(description="Welcome to the roboflow CLI: computer vision at your fingertips 🪄")
     subparsers = parser.add_subparsers(title="subcommands")
     _add_login_parser(subparsers)
     _add_download_parser(subparsers)
@@ -150,9 +138,7 @@ def _add_download_parser(subparsers):
         "download",
         help="Download a dataset version from your workspace or Roboflow Universe.",
     )
-    download_parser.add_argument(
-        "datasetUrl", help="Dataset URL (e.g., `roboflow-100/cells-uyemf/2`)"
-    )
+    download_parser.add_argument("datasetUrl", help="Dataset URL (e.g., `roboflow-100/cells-uyemf/2`)")
     download_parser.add_argument(
         "-f",
         dest="format",
@@ -162,16 +148,12 @@ def _add_download_parser(subparsers):
         "createml, clip, multiclass, coco-segmentation, yolo5-obb, "
         "png-mask-semantic, yolov8]",
     )
-    download_parser.add_argument(
-        "-l", dest="location", help="Location to download the dataset"
-    )
+    download_parser.add_argument("-l", dest="location", help="Location to download the dataset")
     download_parser.set_defaults(func=download)
 
 
 def _add_upload_parser(subparsers):
-    upload_parser = subparsers.add_parser(
-        "upload", help="Upload a single image to a dataset"
-    )
+    upload_parser = subparsers.add_parser("upload", help="Upload a single image to a dataset")
     upload_parser.add_argument(
         "imagefile",
         help="path to image file",
@@ -179,8 +161,7 @@ def _add_upload_parser(subparsers):
     upload_parser.add_argument(
         "-w",
         dest="workspace",
-        help="specify a workspace url or id "
-        "(will use default workspace if not specified)",
+        help="specify a workspace url or id " "(will use default workspace if not specified)",
     )
     upload_parser.add_argument(
         "-p",
@@ -231,9 +212,7 @@ def _add_upload_parser(subparsers):
 
 
 def _add_import_parser(subparsers):
-    import_parser = subparsers.add_parser(
-        "import", help="Import a dataset from a local folder"
-    )
+    import_parser = subparsers.add_parser("import", help="Import a dataset from a local folder")
     import_parser.add_argument(
         "folder",
         help="filesystem path to a folder that contains your dataset",
@@ -241,8 +220,7 @@ def _add_import_parser(subparsers):
     import_parser.add_argument(
         "-w",
         dest="workspace",
-        help="specify a workspace url or id "
-        "(will use default workspace if not specified)",
+        help="specify a workspace url or id " "(will use default workspace if not specified)",
     )
     import_parser.add_argument(
         "-p",
@@ -259,8 +237,7 @@ def _add_import_parser(subparsers):
     import_parser.add_argument(
         "-f",
         dest="format",
-        help="dataset format. Valid options are "
-        "[voc, yolov8, yolov5, auto] (use auto for autodetect)",
+        help="dataset format. Valid options are " "[voc, yolov8, yolov5, auto] (use auto for autodetect)",
         default="auto",
     )
     import_parser.set_defaults(func=import_dataset)
@@ -279,9 +256,7 @@ def _add_projects_parser(subparsers):
         help="specify a workspace url or id (will use default workspace if not specified)",
     )
     projectlist_parser.set_defaults(func=list_projects)
-    projectget_parser = projectsubparsers.add_parser(
-        "get", help="show detailed info for a project"
-    )
+    projectget_parser = projectsubparsers.add_parser("get", help="show detailed info for a project")
     projectget_parser.add_argument(
         "projectId",
         help="project ID",
@@ -300,13 +275,9 @@ def _add_workspaces_parser(subparsers):
         help="workspace related commands.  type 'roboflow workspace' to see detailed command help",
     )
     workspacesubparsers = workspace_parser.add_subparsers(title="workspace subcommands")
-    workspacelist_parser = workspacesubparsers.add_parser(
-        "list", help="list workspaces"
-    )
+    workspacelist_parser = workspacesubparsers.add_parser("list", help="list workspaces")
     workspacelist_parser.set_defaults(func=list_workspaces)
-    workspaceget_parser = workspacesubparsers.add_parser(
-        "get", help="show detailed info for a workspace"
-    )
+    workspaceget_parser = workspacesubparsers.add_parser("get", help="show detailed info for a workspace")
     workspaceget_parser.add_argument(
         "workspaceId",
         help="project ID",

--- a/roboflow/util/active_learning_utils.py
+++ b/roboflow/util/active_learning_utils.py
@@ -18,9 +18,7 @@ def count_class_occurances(predictions, target_class):
 
 
 # compares counts and returns False if counts below requirement
-def count_comparisons(
-    predictions, required_objects_count, required_class_count, target_class
-):
+def count_comparisons(predictions, required_objects_count, required_class_count, target_class):
     if (
         len(predictions) < required_objects_count
         or target_class
@@ -33,11 +31,7 @@ def count_comparisons(
 
 # checks box size and returns False if not within requirements
 def check_box_size(prediction, minimum_size_requirement, maximum_size_requirement):
-    if (
-        maximum_size_requirement
-        > prediction["height"] * prediction["width"]
-        > minimum_size_requirement
-    ):
+    if maximum_size_requirement > prediction["height"] * prediction["width"] > minimum_size_requirement:
         return True
     else:
         return False

--- a/roboflow/util/prediction.py
+++ b/roboflow/util/prediction.py
@@ -12,7 +12,13 @@ import requests
 from matplotlib import patches
 from PIL import Image
 
-from roboflow.config import CLASSIFICATION_MODEL, INSTANCE_SEGMENTATION_MODEL, OBJECT_DETECTION_MODEL, PREDICTION_OBJECT, SEMANTIC_SEGMENTATION_MODEL
+from roboflow.config import (
+    CLASSIFICATION_MODEL,
+    INSTANCE_SEGMENTATION_MODEL,
+    OBJECT_DETECTION_MODEL,
+    PREDICTION_OBJECT,
+    SEMANTIC_SEGMENTATION_MODEL,
+)
 from roboflow.util.image_utils import mask_image, validate_image_path
 
 
@@ -73,20 +79,13 @@ def plot_annotation(axes, prediction=None, stroke=1, transparency=60, colors=Non
             # Plot Rectangle
             axes.add_patch(rect)
     elif prediction["prediction_type"] == CLASSIFICATION_MODEL:
-        axes.set_title(
-            "Class: "
-            + prediction["top"]
-            + " | Confidence: "
-            + str(prediction["confidence"])
-        )
+        axes.set_title("Class: " + prediction["top"] + " | Confidence: " + str(prediction["confidence"]))
     elif prediction["prediction_type"] == INSTANCE_SEGMENTATION_MODEL:
         if prediction["class"] in colors.keys():
             stroke_color = colors[prediction["class"]]
 
         points = [[p["x"], p["y"]] for p in prediction["points"]]
-        polygon = patches.Polygon(
-            points, linewidth=stroke, edgecolor=stroke_color, facecolor="none"
-        )
+        polygon = patches.Polygon(points, linewidth=stroke, edgecolor=stroke_color, facecolor="none")
         axes.add_patch(polygon)
     elif prediction["prediction_type"] == SEMANTIC_SEGMENTATION_MODEL:
         encoded_mask = prediction["segmentation_mask"]
@@ -227,9 +226,7 @@ class Prediction:
             np_points = np.array(points, dtype=np.int32)
             if self["class"] in self.colors.keys():
                 stroke_color = self.colors[self["class"]]
-            cv2.polylines(
-                image, [np_points], isClosed=True, color=stroke_color, thickness=stroke
-            )
+            cv2.polylines(image, [np_points], isClosed=True, color=stroke_color, thickness=stroke)
         elif self["prediction_type"] == SEMANTIC_SEGMENTATION_MODEL:
             image = mask_image(image, self["segmentation_mask"], transparency)
 
@@ -308,9 +305,7 @@ class PredictionGroup:
             validate_image_path(self.base_image_path)
             _, axes = plot_image(self.base_image_path)
             for single_prediction in self:
-                plot_annotation(
-                    axes, single_prediction, stroke, colors=single_prediction.colors
-                )
+                plot_annotation(axes, single_prediction, stroke, colors=single_prediction.colors)
         # Show the plot to the user
         plt.show()
 
@@ -349,9 +344,7 @@ class PredictionGroup:
                     stroke,
                 )
                 # Get size of text
-                text_size = cv2.getTextSize(
-                    class_name, cv2.FONT_HERSHEY_SIMPLEX, 0.4, 1
-                )[0]
+                text_size = cv2.getTextSize(class_name, cv2.FONT_HERSHEY_SIMPLEX, 0.4, 1)[0]
                 # Draw background rectangle for text
                 cv2.rectangle(
                     image,
@@ -379,13 +372,7 @@ class PredictionGroup:
                 height, width = image.shape[:2]
 
                 border_size = 100
-                text = (
-                    "Class: "
-                    + prediction["top"]
-                    + " | "
-                    + "Confidence: "
-                    + str(prediction["confidence"])
-                )
+                text = "Class: " + prediction["top"] + " | " + "Confidence: " + str(prediction["confidence"])
                 text_size = cv2.getTextSize(text, cv2.FONT_HERSHEY_COMPLEX, 1, 1)[0]
                 # Apply Border
                 image = cv2.copyMakeBorder(
@@ -456,18 +443,11 @@ class PredictionGroup:
         # Ensures only predictions can be added to a prediction group
         if is_prediction_check is not None:
             if type(is_prediction_check).__name__ is not PREDICTION_OBJECT:
-                raise Exception(
-                    "Cannot add type "
-                    + type(is_prediction_check).__name__
-                    + " to PredictionGroup"
-                )
+                raise Exception("Cannot add type " + type(is_prediction_check).__name__ + " to PredictionGroup")
 
         # Warns user if predictions have different prediction types
         if prediction_type_check is not None:
-            if (
-                self.__len__() > 0
-                and prediction_type_check != self.base_prediction_type
-            ):
+            if self.__len__() > 0 and prediction_type_check != self.base_prediction_type:
                 warnings.warn(
                     "This prediction is a different type ("
                     + prediction_type_check
@@ -496,9 +476,7 @@ class PredictionGroup:
         return prediction_group_json
 
     @staticmethod
-    def create_prediction_group(
-        json_response, image_path, prediction_type, image_dims, colors=None
-    ):
+    def create_prediction_group(json_response, image_path, prediction_type, image_dims, colors=None):
         """
         Method to create a prediction group based on the JSON Response
 
@@ -524,15 +502,11 @@ class PredictionGroup:
                 prediction_list.append(prediction)
             img_dims = image_dims
         elif prediction_type == CLASSIFICATION_MODEL:
-            prediction = Prediction(
-                json_response, image_path, prediction_type, colors=colors
-            )
+            prediction = Prediction(json_response, image_path, prediction_type, colors=colors)
             prediction_list.append(prediction)
             img_dims = image_dims
         elif prediction_type == SEMANTIC_SEGMENTATION_MODEL:
-            prediction = Prediction(
-                json_response, image_path, prediction_type, colors=colors
-            )
+            prediction = Prediction(json_response, image_path, prediction_type, colors=colors)
             prediction_list.append(prediction)
             img_dims = image_dims
 

--- a/roboflow/util/versions.py
+++ b/roboflow/util/versions.py
@@ -34,16 +34,11 @@ def get_wrong_dependencies_versions(
         module = import_module(dependency)
         module_version = module.__version__
         if order not in order_funcs:
-            raise ValueError(
-                f"order={order} not supported, please use"
-                f" `{', '.join(order_funcs.keys())}`"
-            )
+            raise ValueError(f"order={order} not supported, please use" f" `{', '.join(order_funcs.keys())}`")
 
         is_okay = order_funcs[order](Version(module_version), Version(version))
         if not is_okay:
-            wrong_dependencies_versions.append(
-                (dependency, order, version, module_version)
-            )
+            wrong_dependencies_versions.append((dependency, order, version, module_version))
     return wrong_dependencies_versions
 
 
@@ -58,17 +53,12 @@ def print_warn_for_wrong_dependencies_versions(
             f" {dependency}{order}{version}`"
         )
         if ask_to_continue:
-            answer = input(
-                f"Would you like to continue with the wrong version of {dependency}?"
-                " y/n: "
-            )
+            answer = input(f"Would you like to continue with the wrong version of {dependency}?" " y/n: ")
             if answer.lower() != "y":
                 sys.exit(1)
 
 
-def warn_for_wrong_dependencies_versions(
-    dependencies_versions: List[Tuple[str, str, str]]
-):
+def warn_for_wrong_dependencies_versions(dependencies_versions: List[Tuple[str, str, str]]):
     """
     Decorator to print a warning based on dependencies versions. E.g.
 

--- a/tests/manual/debugme.py
+++ b/tests/manual/debugme.py
@@ -4,7 +4,7 @@ import sys
 thisdir = os.path.dirname(os.path.abspath(__file__))
 os.environ["ROBOFLOW_CONFIG_DIR"] = f"{thisdir}/data/.config"
 
-from roboflow.roboflowpy import _argparser  # flake8: noqa: E402
+from roboflow.roboflowpy import _argparser  # noqa: E402
 
 # import requests
 # requests.urllib3.disable_warnings()
@@ -22,7 +22,7 @@ if __name__ == "__main__":
         # "project get cultura-pepino-dark".split()
         # "workspace list".split()
         "workspace get wolfodorpythontests".split()
-        # f"infer -m cultura-pepino-voc/1 {thisdir}/data/cultura-pepino-coco/test/21_jpg.rf.d3a7fb90b0fafc6541378a6b362ab295.jpg".split()
+        # f"infer -m cultura-pepino-voc/1 {thisdir}/data/cultura-pepino-coco/test/21_jpg.rf.d3a7fb90b0fafc6541378a6b362ab295.jpg".split()  # noqa: E501 // docs
         # f"import {thisdir}/data/cultura-pepino-voc -w wolfodorpythontests -p cultura-pepino-voc -f auto -c 50".split()   # noqa: E501 // docs
         # f"import {thisdir}/data/cultura-pepino-darknet -w wolfodorpythontests -p cultura-pepino-darknet -f auto -c 100".split()   # noqa: E501 // docs
         # f"import {thisdir}/data/0311fisheye -w wolfodorpythontests -p 0311fisheye -f auto -c 50".split()   # noqa: E501 // docs

--- a/tests/manual/debugme.py
+++ b/tests/manual/debugme.py
@@ -1,14 +1,15 @@
 import os
 import sys
 
+thisdir = os.path.dirname(os.path.abspath(__file__))
+os.environ["ROBOFLOW_CONFIG_DIR"] = f"{thisdir}/data/.config"
+
 from roboflow.roboflowpy import _argparser
 
 # import requests
 # requests.urllib3.disable_warnings()
 
-thisdir = os.path.dirname(os.path.abspath(__file__))
 rootdir = os.path.abspath(f"{thisdir}/../..")
-os.environ["ROBOFLOW_CONFIG_DIR"] = f"{thisdir}/data/.config"
 sys.path.append(rootdir)
 
 if __name__ == "__main__":
@@ -16,7 +17,10 @@ if __name__ == "__main__":
     # args = parser.parse_args(["login"])
     # args = parser.parse_args(f"upload {thisdir}/../datasets/chess -w wolfodorpythontests -p chess -f auto".split())   # noqa: E501 // docs
     args = parser.parse_args(
-        "download https://universe.roboflow.com/gdit/aerial-airport".split()
+        # "download https://universe.roboflow.com/gdit/aerial-airport".split()
+        # "project list".split()
+        # "project get cultura-pepino-dark".split()
+        "workspace list".split()
         # f"import {thisdir}/data/cultura-pepino-voc -w wolfodorpythontests -p cultura-pepino-voc -f auto -c 50".split()   # noqa: E501 // docs
         # f"import {thisdir}/data/cultura-pepino-darknet -w wolfodorpythontests -p cultura-pepino-darknet -f auto -c 100".split()   # noqa: E501 // docs
         # f"import {thisdir}/data/0311fisheye -w wolfodorpythontests -p 0311fisheye -f auto -c 50".split()   # noqa: E501 // docs

--- a/tests/manual/debugme.py
+++ b/tests/manual/debugme.py
@@ -20,7 +20,9 @@ if __name__ == "__main__":
         # "download https://universe.roboflow.com/gdit/aerial-airport".split()
         # "project list".split()
         # "project get cultura-pepino-dark".split()
-        "workspace list".split()
+        # "workspace list".split()
+        "workspace get wolfodorpythontests".split()
+        # f"infer -m cultura-pepino-voc/1 {thisdir}/data/cultura-pepino-coco/test/21_jpg.rf.d3a7fb90b0fafc6541378a6b362ab295.jpg".split()
         # f"import {thisdir}/data/cultura-pepino-voc -w wolfodorpythontests -p cultura-pepino-voc -f auto -c 50".split()   # noqa: E501 // docs
         # f"import {thisdir}/data/cultura-pepino-darknet -w wolfodorpythontests -p cultura-pepino-darknet -f auto -c 100".split()   # noqa: E501 // docs
         # f"import {thisdir}/data/0311fisheye -w wolfodorpythontests -p 0311fisheye -f auto -c 50".split()   # noqa: E501 // docs

--- a/tests/manual/debugme.py
+++ b/tests/manual/debugme.py
@@ -4,7 +4,7 @@ import sys
 thisdir = os.path.dirname(os.path.abspath(__file__))
 os.environ["ROBOFLOW_CONFIG_DIR"] = f"{thisdir}/data/.config"
 
-from roboflow.roboflowpy import _argparser
+from roboflow.roboflowpy import _argparser  # flake8: noqa: E402
 
 # import requests
 # requests.urllib3.disable_warnings()

--- a/tests/manual/debugme.py
+++ b/tests/manual/debugme.py
@@ -18,11 +18,11 @@ if __name__ == "__main__":
     # args = parser.parse_args(f"upload {thisdir}/../datasets/chess -w wolfodorpythontests -p chess -f auto".split())   # noqa: E501 // docs
     args = parser.parse_args(
         # "download https://universe.roboflow.com/gdit/aerial-airport".split()
-        "project list -w wolfodorpythontests".split()
+        # "project list -w wolfodorpythontests".split()
         # "project get cultura-pepino-dark".split()
         # "workspace list".split()
         # "workspace get wolfodorpythontests".split()
-        # f"infer -m cultura-pepino-voc/1 {thisdir}/data/cultura-pepino-coco/test/21_jpg.rf.d3a7fb90b0fafc6541378a6b362ab295.jpg".split()  # noqa: E501 // docs
+        f"infer -w jacob-solawetz -m rock-paper-scissors-slim/5 -c .01 {thisdir}/data/scissors.png".split()  # noqa: E501 // docs
         # f"import {thisdir}/data/cultura-pepino-voc -w wolfodorpythontests -p cultura-pepino-voc -f auto -c 50".split()   # noqa: E501 // docs
         # f"import {thisdir}/data/cultura-pepino-darknet -w wolfodorpythontests -p cultura-pepino-darknet -f auto -c 100".split()   # noqa: E501 // docs
         # f"import {thisdir}/data/0311fisheye -w wolfodorpythontests -p 0311fisheye -f auto -c 50".split()   # noqa: E501 // docs

--- a/tests/manual/debugme.py
+++ b/tests/manual/debugme.py
@@ -23,6 +23,8 @@ if __name__ == "__main__":
         # "workspace list".split()
         # "workspace get wolfodorpythontests".split()
         f"infer -w jacob-solawetz -m rock-paper-scissors-slim/5 -c .01 {thisdir}/data/scissors.png".split()  # noqa: E501 // docs
+        # f"infer -w roboflow-6tyri -m usa-states/3 -c .94 -t instance-segmentation {thisdir}/data/unitedstates.jpg".split()  # noqa: E501 // docs
+        # f"infer -w naumov-igor-segmentation -m car-segmetarion/2 -t semantic-segmentation {thisdir}/data/car.jpg".split()  # noqa: E501 // docs
         # f"import {thisdir}/data/cultura-pepino-voc -w wolfodorpythontests -p cultura-pepino-voc -f auto -c 50".split()   # noqa: E501 // docs
         # f"import {thisdir}/data/cultura-pepino-darknet -w wolfodorpythontests -p cultura-pepino-darknet -f auto -c 100".split()   # noqa: E501 // docs
         # f"import {thisdir}/data/0311fisheye -w wolfodorpythontests -p 0311fisheye -f auto -c 50".split()   # noqa: E501 // docs

--- a/tests/manual/debugme.py
+++ b/tests/manual/debugme.py
@@ -18,10 +18,10 @@ if __name__ == "__main__":
     # args = parser.parse_args(f"upload {thisdir}/../datasets/chess -w wolfodorpythontests -p chess -f auto".split())   # noqa: E501 // docs
     args = parser.parse_args(
         # "download https://universe.roboflow.com/gdit/aerial-airport".split()
-        # "project list".split()
+        "project list -w wolfodorpythontests".split()
         # "project get cultura-pepino-dark".split()
         # "workspace list".split()
-        "workspace get wolfodorpythontests".split()
+        # "workspace get wolfodorpythontests".split()
         # f"infer -m cultura-pepino-voc/1 {thisdir}/data/cultura-pepino-coco/test/21_jpg.rf.d3a7fb90b0fafc6541378a6b362ab295.jpg".split()  # noqa: E501 // docs
         # f"import {thisdir}/data/cultura-pepino-voc -w wolfodorpythontests -p cultura-pepino-voc -f auto -c 50".split()   # noqa: E501 // docs
         # f"import {thisdir}/data/cultura-pepino-darknet -w wolfodorpythontests -p cultura-pepino-darknet -f auto -c 100".split()   # noqa: E501 // docs

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,4 +1,4 @@
-from . import RoboflowTest
+from tests import RoboflowTest
 
 
 class TestProject(RoboflowTest):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -5,7 +5,7 @@ from roboflow.core.version import Version
 from roboflow.models.classification import ClassificationModel
 from roboflow.models.object_detection import ObjectDetectionModel
 
-from . import PROJECT_NAME, RoboflowTest, ordered
+from tests import PROJECT_NAME, RoboflowTest, ordered
 
 
 class TestQueries(RoboflowTest):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -7,7 +7,7 @@ import responses
 
 from roboflow.core.version import Version, unwrap_version_id
 
-from .helpers import get_version
+from tests.helpers import get_version
 
 
 class TestDownload(unittest.TestCase):
@@ -20,9 +20,7 @@ class TestDownload(unittest.TestCase):
             version_number="4",
         )
 
-        self.generating_url = (
-            "https://api.roboflow.com/Test Workspace Name/Test Dataset/4"
-        )
+        self.generating_url = "https://api.roboflow.com/Test Workspace Name/Test Dataset/4"
 
     @responses.activate
     def test_download_raises_exception_on_bad_request(self):
@@ -68,18 +66,14 @@ class TestDownload(unittest.TestCase):
 class TestExport(unittest.TestCase):
     def setUp(self):
         super(TestExport, self).setUp()
-        self.api_url = (
-            "https://api.roboflow.com/test-workspace/test-project/4/test-format"
-        )
+        self.api_url = "https://api.roboflow.com/test-workspace/test-project/4/test-format"
         self.version = get_version(
             project_name="Test Dataset",
             id="test-workspace/test-project/2",
             version_number="4",
         )
 
-        self.generating_url = (
-            "https://api.roboflow.com/Test Workspace Name/Test Dataset/4"
-        )
+        self.generating_url = "https://api.roboflow.com/Test Workspace Name/Test Dataset/4"
 
     @responses.activate
     def test_export_returns_true_on_api_success(self):
@@ -94,15 +88,11 @@ class TestExport(unittest.TestCase):
 
         self.assertTrue(export)
         self.assertEqual(request.method, "GET")
-        self.assertDictEqual(
-            request.params, {"nocache": "true", "api_key": "test-api-key"}
-        )
+        self.assertDictEqual(request.params, {"nocache": "true", "api_key": "test-api-key"})
 
     @responses.activate
     def test_export_raises_error_on_bad_request(self):
-        responses.add(
-            responses.GET, self.api_url, status=400, json={"error": "BROKEN!!"}
-        )
+        responses.add(responses.GET, self.api_url, status=400, json={"error": "BROKEN!!"})
         responses.add(
             responses.GET,
             self.generating_url,
@@ -135,9 +125,7 @@ class TestGetDownloadLocation(unittest.TestCase):
 
         # This is a weird python thing to get access to the private function for testing
         self.get_download_location = self.version._Version__get_download_location
-        self.generating_url = (
-            "https://api.roboflow.com/Test Workspace Name/Test Dataset/4"
-        )
+        self.generating_url = "https://api.roboflow.com/Test Workspace Name/Test Dataset/4"
 
     @responses.activate
     def test_get_download_location_with_env_variable(self, *_):
@@ -170,9 +158,7 @@ class TestGetDownloadURL(unittest.TestCase):
 
         # This is a weird python thing to get access to the private function for testing
         self.get_download_url = self.version._Version__get_download_url
-        self.generating_url = (
-            "https://api.roboflow.com/Test Workspace Name/Test Dataset/4"
-        )
+        self.generating_url = "https://api.roboflow.com/Test Workspace Name/Test Dataset/4"
 
     @responses.activate
     def test_get_download_url(self):
@@ -182,9 +168,7 @@ class TestGetDownloadURL(unittest.TestCase):
             json={"version": {"generating": False, "progress": 1.0}},
         )
         url = self.get_download_url("yolo1337")
-        self.assertEqual(
-            url, "https://api.roboflow.com/test-workspace/test-project/3/yolo1337"
-        )
+        self.assertEqual(url, "https://api.roboflow.com/test-workspace/test-project/3/yolo1337")
 
 
 class TestGetFormatIdentifier(unittest.TestCase):
@@ -205,9 +189,7 @@ class TestGetFormatIdentifier(unittest.TestCase):
     def test_returns_friendly_names_for_supported_formats(self):
         formats = [("yolov5", "yolov5pytorch"), ("yolov7", "yolov7pytorch")]
         for external_format, internal_format in formats:
-            self.assertEqual(
-                self.get_format_identifier(external_format), internal_format
-            )
+            self.assertEqual(self.get_format_identifier(external_format), internal_format)
 
     def test_falls_back_to_instance_variable_if_model_format_is_none(self):
         self.version.model_format = "fallback"


### PR DESCRIPTION
# Description

It's not ideally efficient for our users to need to install [roboflow-python](https://pypi.org/project/roboflow/) AND [roboflow-cli](https://www.npmjs.com/package/roboflow-cli) to do similar things.
It's also not ideal for us to need to maintain both ;-)

This PR adds more subcommands to the python version of the `roboflow` command:

* list workspaces and projects
* get details for workspaces and projects
* run inference

The commands are documented in [this new markdown file](https://github.com/roboflow/roboflow-python/blob/newcommands/CLI-COMMANDS.md) (and there's a reference to it in the main README)

It also fixes a bug with the authentication mechanism: if the user had authenticated for multiple workspaces, it would only use the API_KEY for the default workspace, and the authentication would fail for other workspaces. This fix benefits both the command line use case and the python-library use case.

Also, I was annoyed by the 88 line-length enforced by flake8. Increased it to 120. Some changes in this PR is only reformatting because of that :P

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Installed locally and ran a bunch of commands

## Docs

* Added new markdown file in this repo: https://github.com/roboflow/roboflow-python/blob/newcommands/CLI-COMMANDS.md
* Eventually I will replace the [documentation for the node-cli](https://docs.roboflow.com/api-reference/install-cli) in our official docs, but I'd rather wait a bit for a few early adopters and make sure this doesn't have any obvious bugs.
