### PR TITLE
new upload parameter for overwriting annotations

### DIFF
--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -85,6 +85,7 @@ def save_annotation(
     image_id: str,
     is_prediction: bool = False,
     annotation_labelmap=None,
+    overwrite: bool = False,
 ):
     """
     Upload an annotation to a specific project.
@@ -95,7 +96,7 @@ def save_annotation(
     """
 
     upload_url = _save_annotation_url(
-        api_key, project_url, annotation_name, image_id, is_prediction
+        api_key, project_url, annotation_name, image_id, is_prediction, overwrite
     )
 
     response = requests.post(
@@ -126,13 +127,17 @@ def save_annotation(
     return responsejson
 
 
-def _save_annotation_url(api_key, project_url, name, image_id, is_prediction):
+def _save_annotation_url(
+    api_key, project_url, name, image_id, is_prediction, overwrite=False
+):
     url = (
         f"{API_URL}/dataset/{project_url}/annotate/{image_id}?api_key={api_key}"
         f"&name={name}"
     )
     if is_prediction:
         url += "&prediction=true"
+    if overwrite:
+        url += "&overwrite=true"
     return url
 
 

--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -111,9 +111,7 @@ def save_annotation(
         image_id (str): image id you'd like to upload that has annotations for it.
     """
 
-    upload_url = _save_annotation_url(
-        api_key, project_url, annotation_name, image_id, is_prediction, overwrite
-    )
+    upload_url = _save_annotation_url(api_key, project_url, annotation_name, image_id, is_prediction, overwrite)
 
     response = requests.post(
         upload_url,
@@ -141,13 +139,8 @@ def save_annotation(
     return responsejson
 
 
-def _save_annotation_url(
-    api_key, project_url, name, image_id, is_prediction, overwrite=False
-):
-    url = (
-        f"{API_URL}/dataset/{project_url}/annotate/{image_id}?api_key={api_key}"
-        f"&name={name}"
-    )
+def _save_annotation_url(api_key, project_url, name, image_id, is_prediction, overwrite=False):
+    url = f"{API_URL}/dataset/{project_url}/annotate/{image_id}?api_key={api_key}" f"&name={name}"
     if is_prediction:
         url += "&prediction=true"
     if overwrite:

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -469,7 +469,6 @@ class Project:
         image_path=None,
         annotation_path=None,
         annotation_labelmap=None,
-        annotation_overwrite=False,
         hosted_image=False,
         image_id=None,
         split="train",
@@ -477,6 +476,7 @@ class Project:
         batch_name=DEFAULT_BATCH_NAME,
         tag_names=[],
         is_prediction: bool = False,
+        annotation_overwrite=False,
         **kwargs,
     ):
         project_url = self.id.rsplit("/")[1]

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -469,6 +469,7 @@ class Project:
         image_path=None,
         annotation_path=None,
         annotation_labelmap=None,
+        annotation_overwrite=False,
         hosted_image=False,
         image_id=None,
         split="train",
@@ -513,6 +514,7 @@ class Project:
                     image_id,
                     is_prediction=is_prediction,
                     annotation_labelmap=annotation_labelmap,
+                    overwrite=annotation_overwrite,
                 )
             except BaseException as e:
                 uploaded_annotation = {"error": e}


### PR DESCRIPTION
# Description

Added a new parameter for the single_upload method to enable overwriting annotations via the API. This has been requested by multiple other users. The option was available via the REST API, but not the python SDK.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested upload of image with annotations then deleted part of the annotations manually, and re-uploaded only the annotations.

## Any specific deployment considerations

One of the unittests was already broken on the main branch (`test_download_returns_dataset` in `tests.test_version`. I did not touch this.

## Docs

-   [ ] Docs updated? What were the changes: No changes made to docs.
