### PR TITLE
no need to pin pyparsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ matplotlib
 numpy>=1.18.5
 opencv-python-headless==4.8.0.74
 Pillow>=7.1.2
-pyparsing==2.4.7
 python-dateutil
 python-dotenv
 requests

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -14,7 +14,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.15"
+__version__ = "1.1.16"
 
 
 def check_key(api_key, model, notebook, num_retries=0):


### PR DESCRIPTION
# Description

We have `pyparsing==2.4.7` pinned to our requirements.txt, which we shouldn't need because it's already brought in by matplotlib. This minimizes the risk of dependency problems when installing roboflow together with other packages.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Tests still pass
- We are testing some installing configurations on google colab
