### PR TITLE
fix tqdm import for download progress

### DIFF
--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -10,7 +10,7 @@ import urllib
 import cv2
 import numpy as np
 import requests
-import tqdm
+from tqdm import tqdm
 from PIL import Image
 
 from roboflow.config import API_URL, OBJECT_DETECTION_MODEL, OBJECT_DETECTION_URL

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -10,8 +10,8 @@ import urllib
 import cv2
 import numpy as np
 import requests
-from tqdm import tqdm
 from PIL import Image
+from tqdm import tqdm
 
 from roboflow.config import API_URL, OBJECT_DETECTION_MODEL, OBJECT_DETECTION_URL
 from roboflow.models.inference import InferenceModel


### PR DESCRIPTION
# Description

Fixes the following error:


```
>>> model.download()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/avaishampayan/projects/petra-ai/libs/rivian-petra-ml/.venv/lib/python3.10/site-packages/roboflow/models/object_detection.py", line 503, in download
    for chunk in tqdm(
TypeError: 'module' object is not callable
```

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested Locally

## Any specific deployment considerations

n/a

## Docs

n/a
