### PR TITLE
Add source_info query param to predict

### DIFF
--- a/roboflow/models/inference.py
+++ b/roboflow/models/inference.py
@@ -118,6 +118,7 @@ class InferenceModel:
         params, request_kwargs, image_dims = self.__get_image_params(image_path)
 
         params["api_key"] = self.__api_key
+        params["source_info"] = "python-sdk"
 
         params.update(**kwargs)
 

--- a/tests/models/test_instance_segmentation.py
+++ b/tests/models/test_instance_segmentation.py
@@ -51,6 +51,7 @@ class TestInstanceSegmentation(unittest.TestCase):
     _default_params = {
         "api_key": api_key,
         "confidence": "40",
+        "source_info": "python-sdk",
     }
 
     def setUp(self):

--- a/tests/models/test_object_detection.py
+++ b/tests/models/test_object_detection.py
@@ -40,6 +40,7 @@ class TestObjectDetection(unittest.TestCase):
         "name": "YOUR_IMAGE.jpg",
         "overlap": "30",
         "stroke": "1",
+        "source_info": "python-sdk",
     }
 
     def setUp(self):


### PR DESCRIPTION
# Description

Adds `source_info`, so hosted inference knows where the request is coming from. 

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally with pip package.

## Any specific deployment considerations

None.

## Docs

-   [ ] Docs updated? What were the changes:
