### PR TITLE
Allow downloads for non object-detection models

### DIFF
--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -4,14 +4,12 @@ import io
 import json
 import os
 import random
-import sys
 import urllib
 
 import cv2
 import numpy as np
 import requests
 from PIL import Image
-from tqdm import tqdm
 
 from roboflow.config import API_URL, OBJECT_DETECTION_MODEL, OBJECT_DETECTION_URL
 from roboflow.models.inference import InferenceModel
@@ -460,56 +458,6 @@ class ObjectDetectionModel(InferenceModel):
             thread.start()
         else:
             view(stopButton)
-
-    def download(self, format="pt", location="."):
-        """
-        Download the weights associated with a model.
-
-        Args:
-            format (str): The format of the output.
-                        - 'pt': returns a PyTorch weights file
-            location (str): The location to save the weights file to
-        """
-        supported_formats = ["pt"]
-        if format not in supported_formats:
-            raise Exception(f"Unsupported format {format}. Must be one of {supported_formats}")
-
-        workspace, project, version = self.id.rsplit("/")
-
-        # get pt url
-        pt_api_url = f"{API_URL}/{workspace}/{project}/{self.version}/ptFile"
-
-        r = requests.get(pt_api_url, params={"api_key": self.__api_key})
-
-        r.raise_for_status()
-
-        pt_weights_url = r.json()["weightsUrl"]
-
-        def bar_progress(current, total, width=80):
-            progress_message = (
-                "Downloading weights to "
-                + location
-                + "/weights.pt"
-                + ": %d%% [%d / %d] bytes" % (current / total * 100, current, total)
-            )
-            sys.stdout.write("\r" + progress_message)
-            sys.stdout.flush()
-
-        response = requests.get(pt_weights_url, stream=True)
-
-        # write the zip file to the desired location
-        with open(location + "/weights.pt", "wb") as f:
-            total_length = int(response.headers.get("content-length"))
-            for chunk in tqdm(
-                response.iter_content(chunk_size=1024),
-                desc=f"Downloading weights to {location}/weights.pt",
-                total=int(total_length / 1024) + 1,
-            ):
-                if chunk:
-                    f.write(chunk)
-                    f.flush()
-
-        return
 
     def __exception_check(self, image_path_check=None):
         # Check if Image path exists exception check


### PR DESCRIPTION
# Description

Moves download logic into the base class to allow download of any model. Whether the model can be downloaded is controlled server-side, so in the future, model downloads can be added server-side without the need for client changes.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested in staging.

## Any specific deployment considerations

Will need to release a new version of the sdk.

## Docs

-   n/a
