### PR TITLE
ordered-uploading

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -14,7 +14,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.17"
+__version__ = "1.1.18"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -14,7 +14,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.18"
+__version__ = "1.1.19"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -43,6 +43,8 @@ def upload_image(
     split: str = "train",
     batch_name: str = DEFAULT_BATCH_NAME,
     tag_names: list = [],
+    sequence_number: int = None,
+    sequence_size: int = None,
     **kwargs,
 ):
     """
@@ -60,7 +62,9 @@ def upload_image(
         image_name = os.path.basename(image_path)
         imgjpeg = image_utils.file2jpeg(image_path)
 
-        upload_url = _local_upload_url(api_key, project_url, batch_name, tag_names, kwargs)
+        upload_url = _local_upload_url(
+            api_key, project_url, batch_name, tag_names, sequence_number, sequence_size, kwargs
+        )
         m = MultipartEncoder(
             fields={
                 "name": image_name,
@@ -155,8 +159,10 @@ def _hosted_upload_url(api_key, project_url, image_path, split):
     return url
 
 
-def _local_upload_url(api_key, project_url, batch_name, tag_names, kwargs):
-    url = f"{API_URL}/dataset/{project_url}/upload?api_key={api_key}" f"&batch={batch_name}"
+def _local_upload_url(api_key, project_url, batch_name, tag_names, sequence_number, sequence_size, kwargs):
+    url = f"{API_URL}/dataset/{project_url}/upload?api_key={api_key}&batch={batch_name}"
+    if sequence_number is not None and sequence_size is not None:
+        url += f"&sequence_number={sequence_number}&sequence_size={sequence_size}"
     for key, value in kwargs.items():
         url += f"&{str(key)}={str(value)}"
     for tag in tag_names:

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -458,6 +458,8 @@ class Project:
         tag_names=[],
         is_prediction: bool = False,
         annotation_overwrite=False,
+        sequence_number=None,
+        sequence_size=None,
         **kwargs,
     ):
         project_url = self.id.rsplit("/")[1]
@@ -480,6 +482,8 @@ class Project:
                 split=split,
                 batch_name=batch_name,
                 tag_names=tag_names,
+                sequence_number=sequence_number,
+                sequence_size=sequence_size,
                 **kwargs,
             )
             image_id = uploaded_image["id"]

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -359,6 +359,8 @@ class Workspace:
                     annotation_path=annotation_path,
                     annotation_labelmap=labelmap,
                     split=split,
+                    sequence_number=imagedesc.get("index"),
+                    sequence_size=len(images),
                 )
                 _log_img_upload(image_path, uploadres)
             except Exception as e:

--- a/roboflow/util/folderparser.py
+++ b/roboflow/util/folderparser.py
@@ -1,5 +1,5 @@
 import os
-
+import re
 from .image_utils import load_labelmap
 
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp"}
@@ -24,13 +24,33 @@ def parsefolder(folder):
     }
 
 
+def _alphanumkey(s):
+    s = os.path.splitext(s)[0]
+    # Split the string into two parts: all characters before the last digit sequence, and the last digit sequence
+    match = re.match(r"(.*?)(\d*)$", s)
+    if match:
+        alpha_part = match.group(1)
+        num_part = match.group(2)
+        num_part = int(num_part) if num_part else 0
+        return (alpha_part, num_part)
+    else:
+        return (s, 0)
+
+
 def _list_files(folder):
     filedescriptors = []
     for root, dirs, files in os.walk(folder):
         for file in files:
             file_path = os.path.join(root, file)
             filedescriptors.append(_describe_file(file_path.split(folder)[1]))
+    filedescriptors = sorted(filedescriptors, key=lambda x: _alphanumkey(x["file"]))
+    _add_indices(filedescriptors)
     return filedescriptors
+
+
+def _add_indices(files):
+    for i, f in enumerate(files):
+        f["index"] = i
 
 
 def _describe_file(f):

--- a/tests/manual/debugme.py
+++ b/tests/manual/debugme.py
@@ -22,13 +22,15 @@ if __name__ == "__main__":
         # "project get cultura-pepino-dark".split()
         # "workspace list".split()
         # "workspace get wolfodorpythontests".split()
-        f"infer -w jacob-solawetz -m rock-paper-scissors-slim/5 -c .01 {thisdir}/data/scissors.png".split()  # noqa: E501 // docs
+        # f"infer -w jacob-solawetz -m rock-paper-scissors-slim/5 -c .01 {thisdir}/data/scissors.png".split()  # noqa: E501 // docs
         # f"infer -w roboflow-6tyri -m usa-states/3 -c .94 -t instance-segmentation {thisdir}/data/unitedstates.jpg".split()  # noqa: E501 // docs
         # f"infer -w naumov-igor-segmentation -m car-segmetarion/2 -t semantic-segmentation {thisdir}/data/car.jpg".split()  # noqa: E501 // docs
         # f"import {thisdir}/data/cultura-pepino-voc -w wolfodorpythontests -p cultura-pepino-voc -f auto -c 50".split()   # noqa: E501 // docs
         # f"import {thisdir}/data/cultura-pepino-darknet -w wolfodorpythontests -p cultura-pepino-darknet -f auto -c 100".split()   # noqa: E501 // docs
         # f"import {thisdir}/data/0311fisheye -w wolfodorpythontests -p 0311fisheye -f auto -c 50".split()   # noqa: E501 // docs
         # f"upload {thisdir}/data/cultura-pepino-darknet/train/10_jpg.rf.2b3a401b0ffd8482e52137ad22faa14f.jpg -a {thisdir}/data/cultura-pepino-darknet/train/10_jpg.rf.2b3a401b0ffd8482e52137ad22faa14f.txt -m {thisdir}/data/cultura-pepino-darknet/train/_darknet.labels -w wolfodorpythontests -p cultura-pepino-darknet -r 3".split()   # noqa: E501 // docs
+        # f"upload -p ordered-uploading {thisdir}/data/ordered-upload/1.jpg".split()
+        f"import -p ordered-uploading {thisdir}/data/ordered-upload".split()
         # f" {thisdir}/data/cultura-pepino-darknet -w wolfodorpythontests -p cultura-pepino-darknet -f auto -c 100".split()   # noqa: E501 // docs
     )
     args.func(args)


### PR DESCRIPTION
# Description

The upload image endpoint has input parameters `sequence_order` and `sequence_size` that allows the client to control the parameter used to sort images in the backend.

This PR: 
* Exposes that as new parameters in `project.single_upload` method
* Automatically uses that in `workspace.upload_dataset` so that files are saved in the alphanumerical order they are found in the filesystem (instead of a random order).

So now if you run 
`$ roboflow import path/to/dataset/` 

you get something like this:

![CleanShot 2024-02-01 at 15 50 47@2x](https://github.com/roboflow/roboflow-python/assets/218821/4741a450-bab1-4118-84a8-1e34c3ee6db0)

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested by uploading it to staging from roboflow-python dev environment

## Any specific deployment considerations

Will release version 1.1.18