### PR TITLE
Readme: upload_dataset in workspace, not project

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ project = workspace.project("PROJECT_URL")
 version = project.version("VERSION_NUMBER")
 
 # upload a dataset
-project.upload_dataset(
+workspace.upload_dataset(
     dataset_path="./dataset/",
     num_workers=10,
     dataset_format="yolov8", # supports yolov8, yolov5, and Pascal VOC

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,7 +84,7 @@ project = workspace.project("PROJECT_URL")
 version = project.version("VERSION_NUMBER")
 
 # upload a dataset
-project.upload_dataset(
+workspace.upload_dataset(
     dataset_path="./dataset/",
     num_workers=10,
     dataset_format="yolov8", # supports yolov8, yolov5, and Pascal VOC


### PR DESCRIPTION
# Description

`upload_dataset` is a function of `workspace` - not `project`.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Code line in `workspace`: https://github.com/roboflow/roboflow-python/blob/ef6e3d9b32c8503fe2bfa7583e7ee8ba169b9214/roboflow/core/workspace.py#L271

Project: https://github.com/roboflow/roboflow-python/blob/main/roboflow/core/project.py

## Any specific deployment considerations

None.

## Docs

-   [x] Docs updated? What were the changes:

Tiny updates to `Readme.md` and `index.md`.
