### PR TITLE
Clarified `annotations_path`, `split params` in `project.upload`.

### DIFF
--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -371,10 +371,11 @@ class Project:
 
         Args:
             image_path (str): path to image you'd like to upload
-            annotation_path (str): if you're upload annotation, path to it
+            annotation_path (str): path to the annotation file. If not provided, the image will be uploaded without annotation.
+                Special case: in classification projects, this can instead be a class name. e.g. "dog".
             hosted_image (bool): whether the image is hosted
             image_id (str): id of the image
-            split (str): to upload the image to
+            split (str): which split to upload to - "train", "valid" or "test"
             num_retry_uploads (int): how many times to retry upload on failure
             batch_name (str): name of batch to upload to within project
             tag_names (list[str]): tags to be applied to an image


### PR DESCRIPTION
# Description

This seems like a miniscule change, but it it would have saved me 2 hours today.

It took time to create a COCO annotations file, only to find that:
* RF API fails silently when you send a file with an incorrect format, without feedback as to what's wrong
* The parameter allows sending of the class label directly.

List any dependencies that are required for this change.

None

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

This only changes the docstring.

## How has this change been tested, please provide a testcase or example of how you tested the change?

N/A

## Any specific deployment considerations

~~I got `mkdocs serve` running, but could not locate any `Project` docstring renderings.
If that is displayed somewhere, it should be checked that parameters of  `Project` are displayed correctly.~~

I think it's fine.

![image](https://github.com/roboflow/roboflow-python/assets/6500785/867c3d05-66da-4437-aa6c-8667f2d3f78b)

## Docs

-   [x] Docs updated? What were the changes:

Clarified a special case of `annotations_path`, explained it more thoroughly, and clarified the explanation for `split`.
