### PR TITLE
Individual Upload timeouts

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -14,7 +14,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.25"
+__version__ = "1.1.26"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -123,7 +123,7 @@ def save_annotation(
         upload_url,
         data=json.dumps({"annotationFile": annotation_string, "labelmap": annotation_labelmap}),
         headers={"Content-Type": "application/json"},
-        timeout=(60, 60)
+        timeout=(60, 60),
     )
     responsejson = None
     try:

--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -71,14 +71,14 @@ def upload_image(
                 "file": ("imageToUpload", imgjpeg, "image/jpeg"),
             }
         )
-        response = requests.post(upload_url, data=m, headers={"Content-Type": m.content_type})
+        response = requests.post(upload_url, data=m, headers={"Content-Type": m.content_type}, timeout=(300, 300))
 
     else:
         # Hosted image upload url
 
         upload_url = _hosted_upload_url(api_key, project_url, image_path, split)
         # Get response
-        response = requests.post(upload_url)
+        response = requests.post(upload_url, timeout=(300, 300))
     responsejson = None
     try:
         responsejson = response.json()
@@ -123,6 +123,7 @@ def save_annotation(
         upload_url,
         data=json.dumps({"annotationFile": annotation_string, "labelmap": annotation_labelmap}),
         headers={"Content-Type": "application/json"},
+        timeout=(60, 60)
     )
     responsejson = None
     try:


### PR DESCRIPTION
# Description

This adds a large timeout to uploads (5min for images, 1min for annotations).
When uploading datasets with lots and lots of images, this will make sure that uploader workers don't get stuck forever on bad http calls.
I was able to upload full COCO dataset with the CLI after this change

## Type of change

-   [x] Reliability improvement

## How has this change been tested, please provide a testcase or example of how you tested the change?

I was able to upload full COCO dataset with the CLI after this change

