### PR TITLE
Bugfix with .json not returning valid json and added .dict

### DIFF
--- a/roboflow/util/prediction.py
+++ b/roboflow/util/prediction.py
@@ -467,14 +467,17 @@ class PredictionGroup:
                     + ")"
                 )
 
-    def json(self):
-        prediction_group_json = {"predictions": []}
+    def json(self) -> str:
+        return json.dumps(self.dict())
+
+    def dict(self):
+        prediction_group_dict = {"predictions": []}
         for prediction in self.predictions:
-            prediction_group_json["predictions"].append(prediction.json())
+            prediction_group_dict["predictions"].append(prediction.json())
 
-        prediction_group_json["image"] = self.image_dims
-        return prediction_group_json
-
+        prediction_group_dict["image"] = self.image_dims
+        return prediction_group_dict
+    
     @staticmethod
     def create_prediction_group(json_response, image_path, prediction_type, image_dims, colors=None):
         """

--- a/roboflow/util/prediction.py
+++ b/roboflow/util/prediction.py
@@ -477,7 +477,7 @@ class PredictionGroup:
 
         prediction_group_dict["image"] = self.image_dims
         return prediction_group_dict
-    
+
     @staticmethod
     def create_prediction_group(json_response, image_path, prediction_type, image_dims, colors=None):
         """


### PR DESCRIPTION
# Description
We are currently facing an issue with the `.predict` function which includes an option for `.json`. However, this `.json` method does not generate valid JSON data; rather, it returns a dictionary. This discrepancy is likely to cause confusion and issues for users.

The necessary adjustments are to be implemented in the `PredictionGroup` class within the utils module.

No additional dependencies are required for this change.

## Type of Change
- [X] Bug fix (non-breaking change which resolves an issue)
- [X] New feature (non-breaking change which introduces functionality)

## Testing and Validation
This change has been executed and verified through direct code implementation. The modification entails relocating the currently effective code to a `.dict()` method and subsequently converting its output into valid JSON within the `.json` method.

## Deployment Considerations
Potential issues might arise for users who are currently utilizing the output from the `.json` method (which is effectively a dictionary) as a dictionary in their code. These users may need to adjust their implementations to accommodate the changes.