### PR TITLE
bugfix: CLI hangs with super big dataset

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -14,7 +14,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.28"
+__version__ = "1.1.29"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/util/folderparser.py
+++ b/roboflow/util/folderparser.py
@@ -1,9 +1,9 @@
 import json
 import os
 import re
+from collections import defaultdict
 
 from tqdm import tqdm
-from collections import defaultdict
 
 from .image_utils import load_labelmap
 

--- a/roboflow/util/folderparser.py
+++ b/roboflow/util/folderparser.py
@@ -107,10 +107,10 @@ def _map_annotations_to_images_1tomany(images, annotations):
 
     for directory, annotation_files in annotationsByDirname.items():
         parsed_data = annotation_files[0]["parsed"]
-        parsed_type = annotation_files[0]['parsedType']
+        parsed_type = annotation_files[0]["parsedType"]
 
         # Process only if the format is COCO
-        if parsed_type == 'coco':
+        if parsed_type == "coco":
             for image_info in parsed_data["images"]:
                 imageByFilename[image_info["file_name"]] = image_info
 
@@ -118,7 +118,6 @@ def _map_annotations_to_images_1tomany(images, annotations):
                 # Since image_id aren't unique across directories, create a unique key with the directory name.
                 key = f"{directory}/{annotation['image_id']}"
                 annotationByDirectoryImageId[key].append(annotation)
-
 
     for image in tqdm(images, unit="percentage"):
         dirname = image["dirname"]
@@ -128,7 +127,9 @@ def _map_annotations_to_images_1tomany(images, annotations):
                 print(f"warning: found multiple annotation files on dir {dirname}")
             annotation = annotationsInSameDir[0]
             format = annotation["parsedType"]
-            image["annotationfile"] = _filterIndividualAnnotations(image, annotation, format, imageByFilename, annotationByDirectoryImageId)
+            image["annotationfile"] = _filterIndividualAnnotations(
+                image, annotation, format, imageByFilename, annotationByDirectoryImageId
+            )
 
 
 def _filterIndividualAnnotations(image, annotation, format, img_dict, anno_dict):
@@ -260,8 +261,8 @@ def _decide_split(images):
             i["split"] = "train"
 
 
-def _list_map(l, key):
+def _list_map(my_list, key):
     d = {}
-    for i in l:
+    for i in my_list:
         d.setdefault(i[key], []).append(i)
     return d

--- a/roboflow/util/folderparser.py
+++ b/roboflow/util/folderparser.py
@@ -119,7 +119,7 @@ def _map_annotations_to_images_1tomany(images, annotations):
                 key = f"{directory}/{annotation['image_id']}"
                 annotationByDirectoryImageId[key].append(annotation)
 
-    for image in tqdm(images, unit="percentage"):
+    for image in tqdm(images):
         dirname = image["dirname"]
         annotationsInSameDir = annotationsByDirname.get(dirname, [])
         if annotationsInSameDir:

--- a/roboflow/util/folderparser.py
+++ b/roboflow/util/folderparser.py
@@ -2,10 +2,9 @@ import json
 import os
 import re
 
-from .image_utils import load_labelmap
-
 from tqdm import tqdm
-from collections import defaultdict
+
+from .image_utils import load_labelmap
 
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp"}
 ANNOTATION_EXTENSIONS = {".txt", ".json", ".xml", ".csv"}
@@ -108,7 +107,7 @@ def _map_annotations_to_images_1tomany(images, annotations):
     parsed = annotationsByDirname.get(dirname, [])[0]["parsed"]
 
     img_dict = {}
-    try: 
+    try:
         for img_reference in parsed["images"]:
             file_name = img_reference["file_name"]
             img_dict[file_name] = img_reference
@@ -163,8 +162,8 @@ def _filterIndividualAnnotations(image, annotation, format, img_dict, anno_dict)
             try:
                 img_id = imgReference["id"]
                 annotations_for_image = anno_dict.get(img_id, [])
-            except TypeError as e:
-                annotations_for_image = []  
+            except TypeError:
+                annotations_for_image = []
                 print("Couldn't parse imgReference ID for image", image["name"])
 
             _annotation["rawText"] = json.dumps(
@@ -173,7 +172,7 @@ def _filterIndividualAnnotations(image, annotation, format, img_dict, anno_dict)
                     "licenses": parsed["licenses"],
                     "categories": parsed["categories"],
                     "images": [imgReference],
-                    "annotations": annotations_for_image or [fake_annotation] 
+                    "annotations": annotations_for_image or [fake_annotation]
                 }
             )
             return _annotation

--- a/tests/util/test_folderparser.py
+++ b/tests/util/test_folderparser.py
@@ -18,6 +18,7 @@ class TestFolderParser(unittest.TestCase):
         parsed = folderparser.parsefolder(sharksfolder)
         testImagePath = "/train/sharks_mp4-20_jpg.rf.90ba2e8e9ca0613f71359efb7ed48b26.jpg"
         testImage = [i for i in parsed["images"] if i["file"] == testImagePath][0]
+        print(len(json.loads(testImage["annotationfile"]["rawText"])["annotations"]))
         assert len(json.loads(testImage["annotationfile"]["rawText"])["annotations"]) == 5
 
     def test_parse_sharks_createml(self):
@@ -51,6 +52,11 @@ class TestFolderParser(unittest.TestCase):
         expected = "img_fName,img_w,img_h,class_label,bbx_xtl,bbx_ytl,bbx_xbr,bbx_ybr\n"
         expected += "train_10308.jpeg,1058,943,japonicus/koreicus,28,187,908,815\n"
         assert testImage["annotationfile"]["rawText"] == expected
+
+    def test_parse_coconut(self):
+        folder = f"/coconut/images/COCONut-S/"
+        parsed = folderparser.parsefolder(folder)
+        
 
 
 def _assertJsonMatchesFile(actual, filename):

--- a/tests/util/test_folderparser.py
+++ b/tests/util/test_folderparser.py
@@ -54,9 +54,9 @@ class TestFolderParser(unittest.TestCase):
         assert testImage["annotationfile"]["rawText"] == expected
 
     def test_parse_coconut(self):
-        folder = f"/coconut/images/COCONut-S/"
+        folder = "/coconut/images/COCONut-S/"
         parsed = folderparser.parsefolder(folder)
-        
+
 
 
 def _assertJsonMatchesFile(actual, filename):

--- a/tests/util/test_folderparser.py
+++ b/tests/util/test_folderparser.py
@@ -18,7 +18,6 @@ class TestFolderParser(unittest.TestCase):
         parsed = folderparser.parsefolder(sharksfolder)
         testImagePath = "/train/sharks_mp4-20_jpg.rf.90ba2e8e9ca0613f71359efb7ed48b26.jpg"
         testImage = [i for i in parsed["images"] if i["file"] == testImagePath][0]
-        print(len(json.loads(testImage["annotationfile"]["rawText"])["annotations"]))
         assert len(json.loads(testImage["annotationfile"]["rawText"])["annotations"]) == 5
 
     def test_parse_sharks_createml(self):

--- a/tests/util/test_folderparser.py
+++ b/tests/util/test_folderparser.py
@@ -53,11 +53,6 @@ class TestFolderParser(unittest.TestCase):
         expected += "train_10308.jpeg,1058,943,japonicus/koreicus,28,187,908,815\n"
         assert testImage["annotationfile"]["rawText"] == expected
 
-    def test_parse_coconut(self):
-        folder = "/coconut/images/COCONut-S/"
-        parsed = folderparser.parsefolder(folder)
-
-
 
 def _assertJsonMatchesFile(actual, filename):
     with open(filename, "r") as file:


### PR DESCRIPTION
# Description

Fixes [roboflow-bugtracker#908](https://github.com/roboflow/roboflow-bugtracker/issues/908)

Two dictionaries were added to speed up the search for images and annotations rather than iterating through a list to find matches. 

Along with that a tqdm loading bar was added to the image loop to give users feedback during the parsing of their annotation/image folder. 

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)


## How has this change been tested, please provide a testcase or example of how you tested the change?

All existing tests under `tests/util/test_folderparser.py` are passing after this work. 
An inital stub test below was implemented to test speed improvements on the CocoNut Datset. 

if you have the coconut dataset, it can be passed to the dev container with the following docker-compose.yml

```yaml
version: '3'
services:
  devcontainer-roboflow-python:
    build:
      context: ..
      dockerfile: Dockerfile.dev
    image: devcontainer-roboflow-python
    volumes:
      - ..:/roboflow-python
      - {path-to-coconut-dataset}:/coconut
    command: sleep infinity
```


```python
def test_parse_coconut(self):
        folder = "/coconut/images/COCONut-S/"
        parsed = folderparser.parsefolder(folder)
```

Before this PR:
![slow_upload](https://github.com/roboflow/roboflow-python/assets/33797354/0da011cb-a495-49d8-917f-796b8d6b107b)

After this PR: 
![optimized_upload](https://github.com/roboflow/roboflow-python/assets/33797354/8e41037d-552e-48fa-a240-fff932be9025)

