### PR TITLE
Added an environment variable to silence TQDM output

### DIFF
--- a/roboflow/config.py
+++ b/roboflow/config.py
@@ -75,7 +75,7 @@ DEFAULT_BATCH_NAME = "Pip Package Upload"
 DEFAULT_JOB_NAME = "Annotated via API"
 
 RF_WORKSPACES = get_conditional_configuration_variable("workspaces", default={})
-
+TQDM_DESCRIPTIONS = os.getenv("TQDM_DESCRIPTIONS", "true")
 
 def load_roboflow_api_key(workspace_url=None):
     if os.getenv("ROBOFLOW_API_KEY") is not None:

--- a/roboflow/config.py
+++ b/roboflow/config.py
@@ -77,6 +77,7 @@ DEFAULT_JOB_NAME = "Annotated via API"
 RF_WORKSPACES = get_conditional_configuration_variable("workspaces", default={})
 TQDM_DISABLE = os.getenv("TQDM_DISABLE", None)
 
+
 def load_roboflow_api_key(workspace_url=None):
     if os.getenv("ROBOFLOW_API_KEY") is not None:
         return os.getenv("ROBOFLOW_API_KEY")

--- a/roboflow/config.py
+++ b/roboflow/config.py
@@ -75,7 +75,7 @@ DEFAULT_BATCH_NAME = "Pip Package Upload"
 DEFAULT_JOB_NAME = "Annotated via API"
 
 RF_WORKSPACES = get_conditional_configuration_variable("workspaces", default={})
-TQDM_DESCRIPTIONS = os.getenv("TQDM_DESCRIPTIONS", "true")
+TQDM_DISABLE = os.getenv("TQDM_DISABLE", None)
 
 def load_roboflow_api_key(workspace_url=None):
     if os.getenv("ROBOFLOW_API_KEY") is not None:

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -12,17 +12,18 @@ import requests
 import yaml
 from dotenv import load_dotenv
 from tqdm import tqdm
+
 from roboflow.config import (
     API_URL,
     APP_URL,
     DEMO_KEYS,
+    TQDM_DISABLE,
     TYPE_CLASSICATION,
     TYPE_INSTANCE_SEGMENTATION,
     TYPE_KEYPOINT_DETECTION,
     TYPE_OBJECT_DETECTION,
     TYPE_SEMANTIC_SEGMENTATION,
     UNIVERSE_URL,
-    TQDM_DISABLE
 )
 from roboflow.core.dataset import Dataset
 from roboflow.models.classification import ClassificationModel

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -23,6 +23,7 @@ from roboflow.config import (
     TYPE_OBJECT_DETECTION,
     TYPE_SEMANTIC_SEGMENTATION,
     UNIVERSE_URL,
+    TQDM_DESCRIPTIONS
 )
 from roboflow.core.dataset import Dataset
 from roboflow.models.classification import ClassificationModel
@@ -740,9 +741,13 @@ class Version:
             # write the zip file to the desired location
             with open(location + "/roboflow.zip", "wb") as f:
                 total_length = int(response.headers.get("content-length"))
+                if TQDM_DESCRIPTIONS == "false":
+                    desc = None
+                else:
+                    desc = f"Downloading Dataset Version Zip in {location} to {format}:"
                 for chunk in tqdm(
                     response.iter_content(chunk_size=1024),
-                    desc=f"Downloading Dataset Version Zip in {location} to {format}:",
+                    desc=desc,
                     total=int(total_length / 1024) + 1,
                 ):
                     if chunk:
@@ -766,10 +771,14 @@ class Version:
         Raises:
             RuntimeError: If there is an error unzipping the file
         """  # noqa: E501 // docs
+        if TQDM_DESCRIPTIONS == "false":
+            desc = None
+        else:
+            desc = f"Extracting Dataset Version Zip to {location} in {format}:"
         with zipfile.ZipFile(location + "/roboflow.zip", "r") as zip_ref:
             for member in tqdm(
                 zip_ref.infolist(),
-                desc=f"Extracting Dataset Version Zip to {location} in {format}:",
+                desc=desc,
             ):
                 try:
                     zip_ref.extract(member, location)

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -12,7 +12,6 @@ import requests
 import yaml
 from dotenv import load_dotenv
 from tqdm import tqdm
-
 from roboflow.config import (
     API_URL,
     APP_URL,
@@ -23,7 +22,7 @@ from roboflow.config import (
     TYPE_OBJECT_DETECTION,
     TYPE_SEMANTIC_SEGMENTATION,
     UNIVERSE_URL,
-    TQDM_DESCRIPTIONS
+    TQDM_DISABLE
 )
 from roboflow.core.dataset import Dataset
 from roboflow.models.classification import ClassificationModel
@@ -741,10 +740,7 @@ class Version:
             # write the zip file to the desired location
             with open(location + "/roboflow.zip", "wb") as f:
                 total_length = int(response.headers.get("content-length"))
-                if TQDM_DESCRIPTIONS == "false":
-                    desc = None
-                else:
-                    desc = f"Downloading Dataset Version Zip in {location} to {format}:"
+                desc = None if TQDM_DISABLE else f"Downloading Dataset Version Zip in {location} to {format}:"
                 for chunk in tqdm(
                     response.iter_content(chunk_size=1024),
                     desc=desc,
@@ -771,10 +767,7 @@ class Version:
         Raises:
             RuntimeError: If there is an error unzipping the file
         """  # noqa: E501 // docs
-        if TQDM_DESCRIPTIONS == "false":
-            desc = None
-        else:
-            desc = f"Extracting Dataset Version Zip to {location} in {format}:"
+        desc = None if TQDM_DISABLE else f"Extracting Dataset Version Zip to {location} in {format}:"
         with zipfile.ZipFile(location + "/roboflow.zip", "r") as zip_ref:
             for member in tqdm(
                 zip_ref.infolist(),


### PR DESCRIPTION
# Description

Add the option to quieten TQDM messages.

Set the environment variable TQDM_DISABLE=1 if you don't want the download/unzipping  progress-bars

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Testing in progress...will update here

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
