### PR TITLE
Bump `opencv-python-headless` yanked version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-certifi==2023.7.22
+certifi
 chardet==4.0.0
-cycler==0.10.0
+cycler
 idna==2.10
 kiwisolver>=1.3.1
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ idna==2.10
 kiwisolver>=1.3.1
 matplotlib
 numpy>=1.18.5
-opencv-python-headless==4.8.0.74
+opencv-python-headless==4.10.0.84
 Pillow>=7.1.2
 python-dateutil
 python-dotenv


### PR DESCRIPTION
# Description

We try to install a yanked version. Some installers fail because of that.

https://pypi.org/project/opencv-python-headless/#history

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI pass