### PR TITLE
fix: raise UploadErrors for images and annotations

### DIFF
--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -553,8 +553,9 @@ class Project:
 
     def _parse_upload_error(self, error: rfapi.UploadError) -> str:
         dict_part = str(error).split(": ", 2)[2]
-        parsed_dict = ast.literal_eval(dict_part)
-        return parsed_dict.get("message")
+        parsed_dict: dict = ast.literal_eval(dict_part)
+        message = parsed_dict.get("message")
+        return message or str(parsed_dict)
 
     def search(
         self,

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -555,8 +555,12 @@ class Project:
         dict_part = str(error).split(": ", 2)[2]
         if re.search(r"'\w+':", dict_part):
             temp_str = dict_part.replace(r"\'", "<PLACEHOLDER>")
+            temp_str = temp_str.replace('"', r"\"")
             temp_str = temp_str.replace("'", '"')
             dict_part = temp_str.replace("<PLACEHOLDER>", "'")
+            dict_part = dict_part.replace("True", "true")
+            dict_part = dict_part.replace("False", "false")
+            dict_part = dict_part.replace("None", "null")
         parsed_dict: dict = json.loads(dict_part)
         message = parsed_dict.get("message")
         return message or str(parsed_dict)

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -553,15 +553,14 @@ class Project:
 
     def _parse_upload_error(self, error: rfapi.UploadError) -> str:
         dict_part = str(error).split(": ", 2)[2]
+        dict_part = dict_part.replace("True", "true")
+        dict_part = dict_part.replace("False", "false")
+        dict_part = dict_part.replace("None", "null")
         if re.search(r"'\w+':", dict_part):
-            dict_part = dict_part.replace("True", "true")
-            dict_part = dict_part.replace("False", "false")
-            dict_part = dict_part.replace("None", "null")
             temp_str = dict_part.replace(r"\'", "<PLACEHOLDER>")
             temp_str = temp_str.replace('"', r"\"")
             temp_str = temp_str.replace("'", '"')
             dict_part = temp_str.replace("<PLACEHOLDER>", "'")
-
         parsed_dict: dict = json.loads(dict_part)
         message = parsed_dict.get("message")
         return message or str(parsed_dict)

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -554,13 +554,14 @@ class Project:
     def _parse_upload_error(self, error: rfapi.UploadError) -> str:
         dict_part = str(error).split(": ", 2)[2]
         if re.search(r"'\w+':", dict_part):
+            dict_part = dict_part.replace("True", "true")
+            dict_part = dict_part.replace("False", "false")
+            dict_part = dict_part.replace("None", "null")
             temp_str = dict_part.replace(r"\'", "<PLACEHOLDER>")
             temp_str = temp_str.replace('"', r"\"")
             temp_str = temp_str.replace("'", '"')
             dict_part = temp_str.replace("<PLACEHOLDER>", "'")
-            dict_part = dict_part.replace("True", "true")
-            dict_part = dict_part.replace("False", "false")
-            dict_part = dict_part.replace("None", "null")
+
         parsed_dict: dict = json.loads(dict_part)
         message = parsed_dict.get("message")
         return message or str(parsed_dict)

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -1,7 +1,7 @@
-import ast
 import datetime
 import json
 import os
+import re
 import sys
 import time
 import warnings
@@ -553,7 +553,11 @@ class Project:
 
     def _parse_upload_error(self, error: rfapi.UploadError) -> str:
         dict_part = str(error).split(": ", 2)[2]
-        parsed_dict: dict = ast.literal_eval(dict_part)
+        if re.search(r"'\w+':", dict_part):
+            temp_str = dict_part.replace(r"\'", "<PLACEHOLDER>")
+            temp_str = temp_str.replace("'", '"')
+            dict_part = temp_str.replace("<PLACEHOLDER>", "'")
+        parsed_dict: dict = json.loads(dict_part)
         message = parsed_dict.get("message")
         return message or str(parsed_dict)
 


### PR DESCRIPTION
# Description

Fixes issue #235 by raising `UploadError` exceptions that happens inside `single_upload`



## Type of change

Please delete options that are not relevant.
-   [X] Bug fix (non-breaking change which fixes an issue)


## How has this change been tested, please provide a testcase or example of how you tested the change?
Same test as the issue
```
import json
import roboflow

rf = roboflow.Roboflow(api_key="API_KEY")
img_path = "<path_to_img>"

workspace_id = "<ws ID>"
project_id = "<proj ID>"
workspace = rf.workspace(workspace_id)
project = workspace.project(project_id)

annotation = {
    "it is": [
        {
            "very frustrating": 0,
            "when you": "send",
            "an annotation": {
                "file and": 0.5,
                
                "function": 0.5,
                "call": 0.5,
                "completes": 0.5,
                "successfully,": 0.5,

            },
            "but": "there's",
            "no": "annotations",
            "on": "the website",
            "nor": "any",
            "errors": "raised",
        }
    ]
}
with open("annotation.json", "w") as f:
    json.dump(annotation, f)

image = project.upload(img_path, annotation_path="annotation.json")
```

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
