### PR TITLE
Fix `GazeModel` init

### DIFF
--- a/roboflow/models/gaze.py
+++ b/roboflow/models/gaze.py
@@ -6,11 +6,12 @@ class GazeModel(InferenceModel):
     Run inference on a gaze detection model, hosted on Roboflow.
     """
 
-    def __init__(self, api_key: str):
+    def __init__(self, api_key: str, version_id: str):
         """
         Initialize a CLIP model.
 
         Args:
             api_key: Your Roboflow API key.
+            version_id (str): the ID of the dataset version to use for inference
         """
-        super().__init__(api_key=api_key)
+        super().__init__(api_key=api_key, version_id=version_id)


### PR DESCRIPTION
# Description

Fix #269.

The superclass expect a `version_id`. I'm kind of breaking backward compatibility because the class is broken anyway.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Mypy like it.
