### PR TITLE
Fixes batches being created with `None` name

### DIFF
--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -57,13 +57,15 @@ def upload_image(
         split (str): the dataset split the image to
     """
 
+    coalesced_batch_name = batch_name or DEFAULT_BATCH_NAME
+
     # If image is not a hosted image
     if not hosted_image:
         image_name = os.path.basename(image_path)
         imgjpeg = image_utils.file2jpeg(image_path)
 
         upload_url = _local_upload_url(
-            api_key, project_url, batch_name, tag_names, sequence_number, sequence_size, kwargs
+            api_key, project_url, coalesced_batch_name, tag_names, sequence_number, sequence_size, kwargs
         )
         m = MultipartEncoder(
             fields={
@@ -77,7 +79,7 @@ def upload_image(
     else:
         # Hosted image upload url
 
-        upload_url = _hosted_upload_url(api_key, project_url, image_path, split, batch_name, tag_names)
+        upload_url = _hosted_upload_url(api_key, project_url, image_path, split, coalesced_batch_name, tag_names)
         # Get response
         response = requests.post(upload_url, timeout=(300, 300))
     responsejson = None

--- a/tests/test_rfapi.py
+++ b/tests/test_rfapi.py
@@ -37,6 +37,14 @@ class TestUploadImage(unittest.TestCase):
             },
             {
                 "desc": "without batch_name",
+                "expected_url": (
+                    f"{API_URL}/dataset/{self.PROJECT_URL}/upload?"
+                    f"api_key={self.API_KEY}&batch={urllib.parse.quote_plus(DEFAULT_BATCH_NAME)}"
+                    f"&sequence_number=1&sequence_size=10&tag=lonely-tag"
+                ),
+            },
+            {
+                "desc": "without batch_name",
                 "batch_name": None,
                 "expected_url": (
                     f"{API_URL}/dataset/{self.PROJECT_URL}/upload?"
@@ -57,7 +65,7 @@ class TestUploadImage(unittest.TestCase):
                     "tag_names": self.TAG_NAMES_LOCAL,
                 }
 
-                if scenario["batch_name"] is not None:
+                if "batch_name" in scenario:
                     upload_image_payload["batch_name"] = scenario["batch_name"]
 
                 result = upload_image(self.API_KEY, self.PROJECT_URL, self.IMAGE_PATH_LOCAL, **upload_image_payload)
@@ -74,6 +82,15 @@ class TestUploadImage(unittest.TestCase):
                     f"api_key={self.API_KEY}&name={self.IMAGE_NAME_HOSTED}"
                     f"&split=train&image={urllib.parse.quote_plus(self.IMAGE_PATH_HOSTED)}"
                     f"&batch=My%20batch&tag=tag1&tag=tag2"
+                ),
+            },
+            {
+                "desc": "without batch_name",
+                "expected_url": (
+                    f"{API_URL}/dataset/{self.PROJECT_URL}/upload?"
+                    f"api_key={self.API_KEY}&batch={urllib.parse.quote_plus(DEFAULT_BATCH_NAME)}"
+                    f"&name={self.IMAGE_NAME_HOSTED}&split=train"
+                    f"&image={urllib.parse.quote_plus(self.IMAGE_PATH_HOSTED)}&tag=tag1&tag=tag2"
                 ),
             },
             {
@@ -98,7 +115,7 @@ class TestUploadImage(unittest.TestCase):
                     "tag_names": self.TAG_NAMES_HOSTED,
                 }
 
-                if scenario["batch_name"] is not None:
+                if "batch_name" in scenario:
                     upload_image_payload["batch_name"] = scenario["batch_name"]
 
                 result = upload_image(self.API_KEY, self.PROJECT_URL, self.IMAGE_PATH_HOSTED, **upload_image_payload)


### PR DESCRIPTION
# Description

Fix #263 

- Coalesces the value of `batch_name` used to build the image url to use the `DEFAULT_BATCH_NAME` when `None`.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Unit tests
