### PR TITLE
Fix types in version init

### DIFF
--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -101,13 +101,12 @@ class Version:
 
             version_without_workspace = os.path.basename(str(version))
 
-            version_info = requests.get(f"{API_URL}/{workspace}/{project}/{self.version}?api_key={self.__api_key}")
+            response = requests.get(f"{API_URL}/{workspace}/{project}/{self.version}?api_key={self.__api_key}")
+            response.raise_for_status()
+            version_info = response.json()["version"]
+            has_model = bool(version_info.get("models"))
 
-            # check if version has a model
-            if version_info.status_code == 200:
-                version_info = version_info.json()["version"]
-
-            if ("models" in version_info) and (not version_info["models"]):
+            if not has_model:
                 self.model = None
             elif self.type == TYPE_OBJECT_DETECTION:
                 self.model = ObjectDetectionModel(

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -102,9 +102,11 @@ class Version:
             version_without_workspace = os.path.basename(str(version))
 
             response = requests.get(f"{API_URL}/{workspace}/{project}/{self.version}?api_key={self.__api_key}")
-            response.raise_for_status()
-            version_info = response.json()["version"]
-            has_model = bool(version_info.get("models"))
+            if response.ok:
+                version_info = response.json()["version"]
+                has_model = bool(version_info.get("models"))
+            else:
+                has_model = False
 
             if not has_model:
                 self.model = None


### PR DESCRIPTION
# Description

Fix errors found after mypy merge.

```
roboflow/core/version.py:110: error: Unsupported operand types for in ("str" and "Response")  [operator]
roboflow/core/version.py:110: error: Value of type "Response" is not indexable  [index]
```

It was a small bug that would be triggered only when our API failed.

Minor regression from https://github.com/roboflow/roboflow-python/pull/276.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI pass.