### PR TITLE
Use correct image path when validating during image directory upload

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -14,7 +14,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.33"
+__version__ = "1.1.34"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -431,7 +431,7 @@ class Project:
             images = os.listdir(image_path)
             for image in images:
                 path = image_path + "/" + image
-                if self.check_valid_image(image):
+                if self.check_valid_image(path):
                     self.single_upload(
                         image_path=path,
                         annotation_path=annotation_path,


### PR DESCRIPTION
# Description

Fix an image path issue that occurs when specifying a directory of images to upload.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally.

## Any specific deployment considerations

- pip package

## Docs

-   [ ] Docs updated? What were the changes:
