### PR TITLE
Enable upload for all our supported image formats

### DIFF
--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -15,7 +15,7 @@ from roboflow.core.version import Version
 from roboflow.util.general import Retry
 from roboflow.util.image_utils import load_labelmap
 
-ACCEPTED_IMAGE_FORMATS = ["PNG", "JPEG"]
+ACCEPTED_IMAGE_FORMATS = ["PNG", "JPG", "JPEG", "BMP", "WEBP"]
 
 
 def custom_formatwarning(msg, *args, **kwargs):


### PR DESCRIPTION
# Description
We support many other formats other than the ones we currently allow. We also lost `jpg` (not `jpeg`) support in PR #51 (https://github.com/roboflow/roboflow-python/pull/51/files#diff-05ecffcd056f67631588da1975ca43403a88910478c8435876abcdd85b7a8025)

## Type of change


-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?
Tested locally and in this colab: https://colab.research.google.com/drive/1oRqgsKEiihpVpxz5sAWXfTq5L4Eq_zdY?usp=sharing
