### PR TITLE
Add warning for mismatched mimetype and filename extension

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ exclude = ["^build/"]
 [[tool.mypy.overrides]]
 module = [
     "_datetime.*",
+    "filetype.*",
     # IPython is an optional dependency
     "IPython.display.*",
     # ipywidgets is an optional dependency

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ urllib3>=1.26.6
 tqdm>=4.41.0
 PyYAML>=5.3.1
 requests_toolbelt
-python-magic
+filetype

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -343,7 +343,7 @@ class Project:
 
         raise RuntimeError(f"Version number {version_number} is not found.")
 
-    def check_valid_image(self, image_path: str):
+    def check_valid_image(self, image_path: str) -> bool:
         """
         Check if an image is valid. Useful before attempting to upload an image to Roboflow.
 

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -1,13 +1,14 @@
 import datetime
 import json
+import mimetypes
 import os
 import sys
 import time
 import warnings
 from typing import Dict, List, Optional, Union
 
+import filetype
 import requests
-from PIL import Image, UnidentifiedImageError
 
 from roboflow.adapters import rfapi
 from roboflow.config import API_URL, DEMO_KEYS
@@ -15,7 +16,12 @@ from roboflow.core.version import Version
 from roboflow.util.general import Retry
 from roboflow.util.image_utils import load_labelmap
 
-ACCEPTED_IMAGE_FORMATS = ["PNG", "JPEG"]
+ACCEPTED_IMAGE_FORMATS = {
+    "image/bmp",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+}
 
 
 def custom_formatwarning(msg, *args, **kwargs):
@@ -346,15 +352,18 @@ class Project:
 
         Returns:
             bool: whether the image is valid or not
-        """  # noqa: E501 // docs
-        try:
-            img = Image.open(image_path)
-            valid = img.format in ACCEPTED_IMAGE_FORMATS
-            img.close()
-        except UnidentifiedImageError:
+        """
+        kind = filetype.guess(image_path)
+
+        if kind is None:
             return False
 
-        return valid
+        extension_mimetype, _ = mimetypes.guess_type(image_path)
+
+        if extension_mimetype and extension_mimetype != kind.mime:
+            print(f"[{image_path}] file type ({kind.mime}) does not match filename extension.")
+
+        return kind.mime in ACCEPTED_IMAGE_FORMATS
 
     def upload(
         self,

--- a/roboflow/models/video.py
+++ b/roboflow/models/video.py
@@ -3,7 +3,7 @@ import time
 from typing import Optional, Tuple
 from urllib.parse import urljoin
 
-import magic
+import filetype
 import requests
 
 from roboflow.config import API_URL
@@ -24,11 +24,20 @@ SUPPORTED_ADDITIONAL_MODELS = {
     },
 }
 
+ACCEPTED_VIDEO_FORMATS = {
+    "video/mp4",
+    "video/x-msvideo",  # AVI
+    "video/webm",
+}
+
 
 def is_valid_mime(filename):
-    mime = magic.Magic(mime=True)
-    file_type = mime.from_file(filename)
-    return file_type in ["video/mp4", "video/avi", "video/webm"]
+    kind = filetype.guess(filename)
+
+    if kind is None:
+        return False
+
+    return kind.mime in ACCEPTED_VIDEO_FORMATS
 
 
 def is_valid_video(filename):


### PR DESCRIPTION
# Description

* Add support for BMP and WEBP images.
* Add support for AVI video, mimetype was wrong.
* Add warn for file mimetype does not match filename extension.
* Replace `magic` dependency (and `libmagic` system dependency) with `filetype` that is pure Python.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI pass.
