### PR TITLE
Warn users about correct model type string for hf uploads

### DIFF
--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -457,6 +457,18 @@ class Version:
             raise (ValueError(f"Model type {model_type} not supported. Supported models are" f" {supported_models}"))
 
         if model_type.startswith(("paligemma", "florence-2")):
+            if "paligemma" in model_type or "florence-2" in model_type:
+                supported_hf_types = [
+                    "florence-2-base",
+                    "florence-2-large",
+                    "paligemma-3b-pt-224",
+                    "paligemma-3b-pt-448",
+                    "paligemma-3b-pt-896",
+                ]
+                if model_type not in supported_hf_types:
+                    raise RuntimeError(
+                        f"{model_type} not supported for this type of upload. Supported upload types are {supported_hf_types}"
+                    )
             self.deploy_huggingface(model_type, model_path, filename)
             return
 

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -467,7 +467,8 @@ class Version:
                 ]
                 if model_type not in supported_hf_types:
                     raise RuntimeError(
-                        f"{model_type} not supported for this type of upload. Supported upload types are {supported_hf_types}"
+                        f"{model_type} not supported for this type of upload."
+                        f"Supported upload types are {supported_hf_types}"
                     )
             self.deploy_huggingface(model_type, model_path, filename)
             return


### PR DESCRIPTION
# Description

Raise runtime error if the model type isnt supported by roboflow-model-conversion

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Locally

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
