### PR TITLE
api key precedence

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -237,16 +237,16 @@ class Roboflow:
 
         if the_workspace is None:
             the_workspace = self.current_workspace
-            
+
         if self.api_key:  # Check if api_key was passed during __init__
             workspace_api_key = load_roboflow_api_key(the_workspace)
             api_key = workspace_api_key or self.api_key
             list_projects = rfapi.get_workspace(api_key, the_workspace)
             return Workspace(list_projects, api_key, the_workspace, self.model_format)
-        
+
         elif self.api_key in DEMO_KEYS:
             return Workspace({}, self.api_key, the_workspace, self.model_format)
-            
+
         else:
             raise ValueError("A valid API key must be provided.")
 

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -15,7 +15,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.34"
+__version__ = "1.1.35"
 
 
 def check_key(api_key, model, notebook, num_retries=0):
@@ -237,14 +237,18 @@ class Roboflow:
 
         if the_workspace is None:
             the_workspace = self.current_workspace
-
-        if self.api_key in DEMO_KEYS:
+            
+        if self.api_key:  # Check if api_key was passed during __init__
+            workspace_api_key = load_roboflow_api_key(the_workspace)
+            api_key = workspace_api_key or self.api_key
+            list_projects = rfapi.get_workspace(api_key, the_workspace)
+            return Workspace(list_projects, api_key, the_workspace, self.model_format)
+        
+        elif self.api_key in DEMO_KEYS:
             return Workspace({}, self.api_key, the_workspace, self.model_format)
-        workspace_api_key = load_roboflow_api_key(the_workspace)
-        api_key = workspace_api_key or self.api_key
-
-        list_projects = rfapi.get_workspace(api_key, the_workspace)
-        return Workspace(list_projects, api_key, the_workspace, self.model_format)
+            
+        else:
+            raise ValueError("A valid API key must be provided.")
 
     def project(self, project_name, the_workspace=None):
         """Function that takes in the name of the project and returns the project object

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -53,10 +53,8 @@ class Project:
 
             >>> project = rf.workspace().project("PROJECT_ID")
         """
-        if api_key in DEMO_KEYS:
-            self.__api_key = api_key
-            self.model_format = model_format
-        else:
+        
+        if api_key:
             self.__api_key = api_key
             self.annotation = a_project["annotation"]
             self.classes = a_project["classes"]
@@ -75,6 +73,14 @@ class Project:
             temp = self.id.rsplit("/")
             self.__workspace = temp[0]
             self.__project_name = temp[1]
+            
+        elif DEMO_KEYS:
+            self.__api_key = DEMO_KEYS[0]
+            self.model_format = model_format
+            
+        else:
+            raise ValueError("A valid API key must be provided.")
+           
 
     def get_version_information(self):
         """

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -53,7 +53,7 @@ class Project:
 
             >>> project = rf.workspace().project("PROJECT_ID")
         """
-        
+
         if api_key:
             self.__api_key = api_key
             self.annotation = a_project["annotation"]
@@ -73,14 +73,13 @@ class Project:
             temp = self.id.rsplit("/")
             self.__workspace = temp[0]
             self.__project_name = temp[1]
-            
+
         elif DEMO_KEYS:
             self.__api_key = DEMO_KEYS[0]
             self.model_format = model_format
-            
+
         else:
             raise ValueError("A valid API key must be provided.")
-           
 
     def get_version_information(self):
         """

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -132,7 +132,7 @@ class Version:
                 self.model = KeypointDetectionModel(self.__api_key, self.id, version=version_without_workspace)
             else:
                 self.model = None
-                
+
         elif DEMO_KEYS:
             api_key = DEMO_KEYS[0]
             if api_key == "coco-128-sample":

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -64,19 +64,7 @@ class Version:
         """
         Initialize a Version object.
         """
-        if api_key in DEMO_KEYS:
-            if api_key == "coco-128-sample":
-                self.__api_key = api_key
-                self.model_format = model_format
-                self.name = "coco-128"
-                self.version = "1"
-            else:
-                self.__api_key = api_key
-                self.model_format = model_format
-                self.name = "chess-pieces-new"
-                self.version = "23"
-                self.id = "joseph-nelson/chess-pieces-new"
-        else:
+        if api_key:
             self.__api_key = api_key
             self.name = name
             self.version = unwrap_version_id(version_id=version)
@@ -144,6 +132,20 @@ class Version:
                 self.model = KeypointDetectionModel(self.__api_key, self.id, version=version_without_workspace)
             else:
                 self.model = None
+                
+        elif DEMO_KEYS:
+            api_key = DEMO_KEYS[0]
+            if api_key == "coco-128-sample":
+                self.__api_key = api_key
+                self.model_format = model_format
+                self.name = "coco-128"
+                self.version = "1"
+            else:
+                self.__api_key = api_key
+                self.model_format = model_format
+                self.name = "chess-pieces-new"
+                self.version = "23"
+                self.id = "joseph-nelson/chess-pieces-new"
 
     def __check_if_generating(self):
         # check Roboflow API to see if this version is still generating

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -23,13 +23,11 @@ class Workspace:
     """
     Manage a Roboflow workspace.
     """
-
     def __init__(self, info, api_key, default_workspace, model_format):
-        if api_key in DEMO_KEYS:
-            self.__api_key = api_key
-            self.model_format = model_format
-            self.project_list = []
-        else:
+        
+        if api_key:
+            self.__api_key = api_key 
+        
             workspace_info = info["workspace"]
             self.name = workspace_info["name"]
             self.project_list = workspace_info["projects"]
@@ -38,8 +36,14 @@ class Workspace:
             self.url = workspace_info["url"]
             self.model_format = model_format
 
-            self.__api_key = api_key
+        elif DEMO_KEYS:
+            self.__api_key = DEMO_KEYS[0]
+            self.model_format = model_format
+            self.project_list = []
 
+        else:
+            raise ValueError("A valid API key must be provided.")
+                        
     def list_projects(self):
         """
         Print all projects in the workspace to the console.

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -23,11 +23,11 @@ class Workspace:
     """
     Manage a Roboflow workspace.
     """
+
     def __init__(self, info, api_key, default_workspace, model_format):
-        
         if api_key:
-            self.__api_key = api_key 
-        
+            self.__api_key = api_key
+
             workspace_info = info["workspace"]
             self.name = workspace_info["name"]
             self.project_list = workspace_info["projects"]
@@ -43,7 +43,7 @@ class Workspace:
 
         else:
             raise ValueError("A valid API key must be provided.")
-                        
+
     def list_projects(self):
         """
         Print all projects in the workspace to the console.

--- a/roboflow/roboflowpy.py
+++ b/roboflow/roboflowpy.py
@@ -113,6 +113,17 @@ def get_workspace(args):
     print(json.dumps(workspace_json, indent=2))
 
 
+
+def get_workspace_project_version(args):
+    #api_key = load_roboflow_api_key(args.workspaceId)
+    rf = roboflow.Roboflow(args.api_key)
+    workspace = rf.workspace()
+    print('workspace',workspace)
+    project = workspace.project(args.project)
+    print('project',project)
+    version = project.version(args.version_number)
+    print('version',version)
+    
 def get_project(args):
     workspace_url = args.workspace or get_conditional_configuration_variable("RF_WORKSPACE", default=None)
     api_key = load_roboflow_api_key(workspace_url)
@@ -161,6 +172,9 @@ def _argparser():
     _add_projects_parser(subparsers)
     _add_workspaces_parser(subparsers)
     _add_upload_model_parser(subparsers)
+    _add_get_workspace_project_version_parser(subparsers)
+
+    
     return parser
 
 
@@ -410,7 +424,34 @@ def _add_upload_model_parser(subparsers):
     )
     upload_model_parser.set_defaults(func=upload_model)
 
-
+def _add_get_workspace_project_version_parser(subparsers):
+    workspace_project_version_parser = subparsers.add_parser(
+        "get_workspace_info",
+        help="get workspace project version info",
+    )
+    workspace_project_version_parser.add_argument(
+        "-a",
+        dest="api_key",
+        help="api_key",
+    )
+    workspace_project_version_parser.add_argument(
+        "-w",
+        dest="workspace",
+        help="specify a workspace url or id (will use default workspace if not specified)",
+    )
+    workspace_project_version_parser.add_argument(
+        "-p",
+        dest="project",
+        help="project_id to upload the model into",
+    )
+    workspace_project_version_parser.add_argument(
+        "-v",
+        dest="version_number",
+        type=int,
+        help="version number to upload the model to",
+    )
+    workspace_project_version_parser.set_defaults(func=get_workspace_project_version)
+    
 def _add_login_parser(subparsers):
     login_parser = subparsers.add_parser("login", help="Log in to Roboflow")
     login_parser.set_defaults(func=login)

--- a/roboflow/roboflowpy.py
+++ b/roboflow/roboflowpy.py
@@ -113,17 +113,17 @@ def get_workspace(args):
     print(json.dumps(workspace_json, indent=2))
 
 
-
 def get_workspace_project_version(args):
-    #api_key = load_roboflow_api_key(args.workspaceId)
+    # api_key = load_roboflow_api_key(args.workspaceId)
     rf = roboflow.Roboflow(args.api_key)
     workspace = rf.workspace()
-    print('workspace',workspace)
+    print("workspace", workspace)
     project = workspace.project(args.project)
-    print('project',project)
+    print("project", project)
     version = project.version(args.version_number)
-    print('version',version)
-    
+    print("version", version)
+
+
 def get_project(args):
     workspace_url = args.workspace or get_conditional_configuration_variable("RF_WORKSPACE", default=None)
     api_key = load_roboflow_api_key(workspace_url)
@@ -174,7 +174,6 @@ def _argparser():
     _add_upload_model_parser(subparsers)
     _add_get_workspace_project_version_parser(subparsers)
 
-    
     return parser
 
 
@@ -424,6 +423,7 @@ def _add_upload_model_parser(subparsers):
     )
     upload_model_parser.set_defaults(func=upload_model)
 
+
 def _add_get_workspace_project_version_parser(subparsers):
     workspace_project_version_parser = subparsers.add_parser(
         "get_workspace_info",
@@ -451,7 +451,8 @@ def _add_get_workspace_project_version_parser(subparsers):
         help="version number to upload the model to",
     )
     workspace_project_version_parser.set_defaults(func=get_workspace_project_version)
-    
+
+
 def _add_login_parser(subparsers):
     login_parser = subparsers.add_parser("login", help="Log in to Roboflow")
     login_parser.set_defaults(func=login)


### PR DESCRIPTION
# Description

api key reverted to roboflow.config demo key / api key even if initializing roboflow workspace with api key. now initializing api key takes precedence

## Type of change

Please delete options that are not relevant.

-   [ X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI tests + custom test with roboflowpy.py get_workspace_project_version()

