### PR TITLE
Active Learning - Ability to change inference server path.

### DIFF
--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -391,6 +391,7 @@ class Workspace:
         upload_destination: str = "",
         conditionals: dict = {},
         use_localhost: bool = False,
+        local_server = "http://localhost:9001/",
     ) -> str:
         """perform inference on each image in directory and upload based on conditions
         @params:
@@ -400,6 +401,7 @@ class Workspace:
             upload_destination: (str) = name of the upload project
             conditionals: (dict) = dictionary of upload conditions
             use_localhost: (bool) = determines if local http format used or remote endpoint
+            local_server: (str) = local http address for inference server, use_localhost must be True for this to be used
         """  # noqa: E501 // docs
         prediction_results = []
 
@@ -427,7 +429,10 @@ class Workspace:
         )
 
         # check if inference_model references endpoint or local
-        local = "http://localhost:9001/" if use_localhost else None
+        if use_localhost:
+            local = local_server
+        else:
+            local = None
 
         inference_model = (
             self.project(inference_endpoint[0]).version(version_number=inference_endpoint[1], local=local).model

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -395,7 +395,7 @@ class Workspace:
         upload_destination: str = "",
         conditionals: dict = {},
         use_localhost: bool = False,
-        local_server = "http://localhost:9001/",
+        local_server="http://localhost:9001/",
     ) -> Any:
         """perform inference on each image in directory and upload based on conditions
         @params:

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -3,7 +3,7 @@ import glob
 import json
 import os
 import sys
-from typing import List
+from typing import Any, List
 
 import numpy as np
 import requests
@@ -392,7 +392,7 @@ class Workspace:
         conditionals: dict = {},
         use_localhost: bool = False,
         local_server = "http://localhost:9001/",
-    ) -> str:
+    ) -> Any:
         """perform inference on each image in directory and upload based on conditions
         @params:
             raw_data_location: (str) = folder of frames to be processed


### PR DESCRIPTION
# Description

Some users utilize the active learning code via the Python package. The inference server address is hardcoded to 'http://localhost:9001/'. These charges allow the user to pass in a different server address, other than localhost.

## Type of change

Please delete options that are not relevant.

-   [ x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested by using active learning function to upload images to Roboflow project using a local server not at localhost. 

## Docs

No changes.
