### PR TITLE
Use OS `unzip` instead of Python `zipfile` when available

### DIFF
--- a/roboflow/config.py
+++ b/roboflow/config.py
@@ -76,6 +76,7 @@ DEFAULT_JOB_NAME = "Annotated via API"
 
 RF_WORKSPACES = get_conditional_configuration_variable("workspaces", default={})
 TQDM_DISABLE = os.getenv("TQDM_DISABLE", None)
+UNZIP_DISABLE = os.getenv("UNZIP_DISABLE")
 
 
 def load_roboflow_api_key(workspace_url=None):

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -814,8 +814,9 @@ class Version:
 
         input_file = f"{location}/roboflow.zip"
         unzip_path = shutil.which("unzip")
+        print(f"Extract zip {input_file=} with {unzip_path=}")
         if unzip_path and not UNZIP_DISABLE:
-            subprocess.check_call([unzip_path, "-qo", "-d", location, input_file])
+            subprocess.check_call([unzip_path, "-o", "-d", location, input_file])
         else:
             desc = None if TQDM_DISABLE else f"Extracting Dataset Version Zip to {location} in {format}:"
             with zipfile.ZipFile(input_file, "r") as zip_ref:

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -815,7 +815,7 @@ class Version:
         input_file = f"{location}/roboflow.zip"
         unzip_path = shutil.which("unzip")
         if unzip_path and not UNZIP_DISABLE:
-            subprocess.check_call([unzip_path, "-qo", input_file])
+            subprocess.check_call([unzip_path, "-qo", "-d", location, input_file])
         else:
             desc = None if TQDM_DISABLE else f"Extracting Dataset Version Zip to {location} in {format}:"
             with zipfile.ZipFile(input_file, "r") as zip_ref:

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -816,7 +816,7 @@ class Version:
         unzip_path = shutil.which("unzip")
         print(f"Extract zip {input_file=} with {unzip_path=}")
         if unzip_path and not UNZIP_DISABLE:
-            subprocess.check_call([unzip_path, "-o", "-d", location, input_file])
+            subprocess.check_call([unzip_path, "-qo", "-d", location, input_file])
         else:
             desc = None if TQDM_DISABLE else f"Extracting Dataset Version Zip to {location} in {format}:"
             with zipfile.ZipFile(input_file, "r") as zip_ref:

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setuptools.setup(
     extras_require={
         "desktop": ["opencv-python==4.8.0.74"],
         "dev": [
-            "git+https://github.com/python/mypy.git",
+            # mypy 1.11.0 is broken with cv2
+            "mypy<1.11.0",
             "responses",
             "ruff",
             "twine",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     extras_require={
         "desktop": ["opencv-python==4.8.0.74"],
         "dev": [
-            "mypy",
+            "git+https://github.com/python/mypy.git",
             "responses",
             "ruff",
             "twine",


### PR DESCRIPTION
# Description

Add support to decompress version file using `unzip` instead of Python `zipfile`.

This file is too big for pure Python.

It still fallback to pure Python if `unzip` command is not available (or `UNZIP_DISABLE`.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER
