### PR TITLE
bugfix: login breaks if ~/.config doesn't exist

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -15,7 +15,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.36"
+__version__ = "1.1.37"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -94,7 +94,7 @@ def login(workspace=None, force=False):
 
         # make config directory if it doesn't exist
         if not os.path.exists(os.path.dirname(conf_location)):
-            os.mkdir(os.path.dirname(conf_location))
+            os.makedirs(os.path.dirname(conf_location))
 
         r_login = {"workspaces": r_login}
         # set first workspace as default workspace

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     extras_require={
         "desktop": ["opencv-python==4.8.0.74"],
         "dev": [
-            "mypy",
+            "mypy<1.11.0",
             "responses",
             "ruff",
             "twine",


### PR DESCRIPTION
# Description

Fixes login bug (`os.mkdir can only create directory if parent dir already exists`)
![CleanShot 2024-07-26 at 13 33 26@2x](https://github.com/user-attachments/assets/520e0be4-835b-4c75-8847-4e8c0d2f5820)


## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally

