### PR TITLE
chardet is not required for anything

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 certifi
-chardet==4.0.0
 idna==3.7
 cycler
 kiwisolver>=1.3.1


### PR DESCRIPTION
# Description

Removes chardet dependency.
* not used by our code
* doesn't show up as a dependency of anything in [pipdeptree](https://pypi.org/project/pipdeptree/)
* tests pass without it
* command line still seems to work
* git history does not provide a clear reason for why it was added

## Type of change

-   [x] Maintainability

## How has this change been tested, please provide a testcase or example of how you tested the change?

* Tests passing
* Used the CLI locally

## Any specific deployment considerations

No need to release because of this
