### PR TITLE
no print, only log

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ ignore = [
     "FIX",
     "FLY",
     "FURB",
+    "G003",
+    "G004",
     "ISC",
     "N",
     "PERF",

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import sys
 import time
@@ -16,6 +17,8 @@ from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
 __version__ = "1.1.40"
+
+log = logging.getLogger(__name__)
 
 
 def check_key(api_key, model, notebook, num_retries=0):
@@ -38,7 +41,7 @@ def check_key(api_key, model, notebook, num_retries=0):
             if response.status_code != 200:
                 # retry 5 times
                 if num_retries < 5:
-                    print("retrying...")
+                    log.info("retrying...")
                     time.sleep(1)
                     num_retries += 1
                     return check_key(api_key, model, notebook, num_retries)
@@ -48,7 +51,7 @@ def check_key(api_key, model, notebook, num_retries=0):
                 r = response.json()
                 return r
     else:  # then you're using a dummy key
-        sys.stdout.write(
+        log.info(
             "upload and label your dataset, and get an API KEY here: "
             + APP_URL
             + "/?model="

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -18,6 +18,7 @@ from roboflow.util.general import write_line
 
 __version__ = "1.1.40"
 
+logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
 

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 import mimetypes
 import os
 import sys
@@ -16,6 +17,8 @@ from roboflow.config import API_URL, DEMO_KEYS
 from roboflow.core.version import Version
 from roboflow.util.general import Retry
 from roboflow.util.image_utils import load_labelmap
+
+log = logging.getLogger(__name__)
 
 ACCEPTED_IMAGE_FORMATS = {
     "image/bmp",
@@ -123,7 +126,7 @@ class Project:
             >>> project.list_versions()
         """
         version_info = self.get_version_information()
-        print(version_info)
+        log.info(version_info)
 
     def versions(self):
         """
@@ -367,7 +370,7 @@ class Project:
         extension_mimetype, _ = mimetypes.guess_type(image_path)
 
         if extension_mimetype and extension_mimetype != kind.mime:
-            print(f"[{image_path}] file type ({kind.mime}) does not match filename extension.")
+            log.info(f"[{image_path}] file type ({kind.mime}) does not match filename extension.")
 
         return kind.mime in ACCEPTED_IMAGE_FORMATS
 
@@ -460,9 +463,9 @@ class Project:
                         is_prediction=is_prediction,
                         **kwargs,
                     )
-                    print("[ " + path + " ] was uploaded succesfully.")
+                    log.info("[ " + path + " ] was uploaded succesfully.")
                 else:
-                    print("[ " + path + " ] was skipped.")
+                    log.info("[ " + path + " ] was skipped.")
                     continue
 
     def upload_image(
@@ -605,7 +608,7 @@ class Project:
                 annotation_string = open(annotation_path).read()  # type: ignore[arg-type]
             annotation_name = os.path.basename(annotation_path)  # type: ignore[arg-type]
         elif self.type == "classification":
-            print(f"-> using {annotation_path} as classname for classification project")
+            log.info(f"-> using {annotation_path} as classname for classification project")
             annotation_string = annotation_path
             annotation_name = annotation_path
         else:

--- a/roboflow/deployment.py
+++ b/roboflow/deployment.py
@@ -1,7 +1,10 @@
 import json
+import logging
 
 from roboflow.adapters import deploymentapi
 from roboflow.config import load_roboflow_api_key
+
+log = logging.getLogger(__name__)
 
 
 def add_deployment_parser(subparsers):
@@ -61,7 +64,7 @@ def add_deployment_parser(subparsers):
 def list_machine_types(args):
     api_key = args.api_key or load_roboflow_api_key(None)
     ret_json = deploymentapi.list_machine_types(api_key)
-    print(json.dumps(ret_json, indent=2))
+    log.info(json.dumps(ret_json, indent=2))
 
 
 def add_deployment(args):
@@ -75,22 +78,22 @@ def add_deployment(args):
         args.deployment_name,
         args.inference_version,
     )
-    print(json.dumps(ret_json, indent=2))
+    log.info(json.dumps(ret_json, indent=2))
 
 
 def get_deployment(args):
     api_key = args.api_key or load_roboflow_api_key(None)
     ret_json = deploymentapi.get_deployment(api_key, args.deployment_id)
-    print(json.dumps(ret_json, indent=2))
+    log.info(json.dumps(ret_json, indent=2))
 
 
 def list_deployment(args):
     api_key = args.api_key or load_roboflow_api_key(None)
     ret_json = deploymentapi.list_deployment(api_key)
-    print(json.dumps(ret_json, indent=2))
+    log.info(json.dumps(ret_json, indent=2))
 
 
 def delete_deployment(args):
     api_key = args.api_key or load_roboflow_api_key(None)
     ret_json = deploymentapi.delete_deployment(api_key, args.deployment_id)
-    print(json.dumps(ret_json, indent=2))
+    log.info(json.dumps(ret_json, indent=2))

--- a/roboflow/models/classification.py
+++ b/roboflow/models/classification.py
@@ -1,6 +1,7 @@
 import base64
 import io
 import json
+import logging
 import os
 import urllib
 from typing import Optional
@@ -12,6 +13,8 @@ from roboflow.config import CLASSIFICATION_MODEL
 from roboflow.models.inference import InferenceModel
 from roboflow.util.image_utils import check_image_url
 from roboflow.util.prediction import PredictionGroup
+
+log = logging.getLogger(__name__)
 
 
 class ClassificationModel(InferenceModel):
@@ -60,7 +63,7 @@ class ClassificationModel(InferenceModel):
         self.preprocessing = {} if preprocessing is None else preprocessing
 
         if local:
-            print(f"initalizing local classification model hosted at : {local}")
+            log.info(f"initalizing local classification model hosted at : {local}")
             self.base_url = local
 
     def predict(self, image_path, hosted=False):  # type: ignore[override]

--- a/roboflow/models/inference.py
+++ b/roboflow/models/inference.py
@@ -1,5 +1,6 @@
 import io
 import json
+import logging
 import os
 import time
 import urllib
@@ -14,6 +15,8 @@ from tqdm import tqdm
 from roboflow.config import API_URL
 from roboflow.util.image_utils import validate_image_path
 from roboflow.util.prediction import PredictionGroup
+
+log = logging.getLogger(__name__)
 
 SUPPORTED_ROBOFLOW_MODELS = ["batch-video"]
 
@@ -350,10 +353,10 @@ class InferenceModel:
             job_id = self.job_id
 
         attempts = 0
-        print(f"Checking for video inference results for job {job_id} every 60s")
+        log.info(f"Checking for video inference results for job {job_id} every 60s")
         while True:
             time.sleep(60)
-            print(f"({attempts * 60}s): Checking for inference results")
+            log.info(f"({attempts * 60}s): Checking for inference results")
             response = self.poll_for_video_results()
             attempts += 1
 

--- a/roboflow/models/keypoint_detection.py
+++ b/roboflow/models/keypoint_detection.py
@@ -1,6 +1,7 @@
 import base64
 import io
 import json
+import logging
 import os
 import urllib
 from typing import Optional
@@ -12,6 +13,8 @@ from roboflow.config import CLASSIFICATION_MODEL
 from roboflow.models.inference import InferenceModel
 from roboflow.util.image_utils import check_image_url
 from roboflow.util.prediction import PredictionGroup
+
+log = logging.getLogger(__name__)
 
 
 class KeypointDetectionModel(InferenceModel):
@@ -55,7 +58,7 @@ class KeypointDetectionModel(InferenceModel):
             self.__generate_url()
 
         if local:
-            print(f"initalizing local keypoint detection model hosted at : {local}")
+            log.info(f"initalizing local keypoint detection model hosted at : {local}")
             self.base_url = local
 
     def predict(self, image_path, hosted=False):  # type: ignore[override]

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -2,6 +2,7 @@ import base64
 import copy
 import io
 import json
+import logging
 import os
 import random
 import urllib
@@ -14,6 +15,8 @@ from roboflow.models.inference import InferenceModel
 from roboflow.util.image_utils import check_image_url
 from roboflow.util.prediction import PredictionGroup
 from roboflow.util.versions import print_warn_for_wrong_dependencies_versions
+
+log = logging.getLogger(__name__)
 
 
 class ObjectDetectionModel(InferenceModel):
@@ -82,7 +85,7 @@ class ObjectDetectionModel(InferenceModel):
         if local is None:
             self.base_url = OBJECT_DETECTION_URL + "/"
         else:
-            print("initalizing local object detection model hosted at :" + local)
+            log.info("initalizing local object detection model hosted at :" + local)
             self.base_url = local
 
         # If dataset slug not none, instantiate API URL

--- a/roboflow/models/video.py
+++ b/roboflow/models/video.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import time
 from typing import Optional, Tuple
 from urllib.parse import urljoin
@@ -8,6 +9,8 @@ import requests
 
 from roboflow.config import API_URL
 from roboflow.models.inference import InferenceModel
+
+log = logging.getLogger(__name__)
 
 SUPPORTED_ROBOFLOW_MODELS = ["object-detection", "classification", "instance-segmentation", "keypoint-detection"]
 
@@ -125,7 +128,7 @@ class VideoInferenceModel(InferenceModel):
 
         signed_url = response.json()["signed_url"]
 
-        print("Uploaded video to signed url: " + signed_url)
+        log.info("Uploaded video to signed url: " + signed_url)
 
         url = urljoin(API_URL, f"/videoinfer/?api_key={self.__api_key}")
 
@@ -179,7 +182,7 @@ class VideoInferenceModel(InferenceModel):
         try:
             response = requests.get(url, headers={"Content-Type": "application/json"})
         except Exception as e:
-            print(e)
+            log.info(e)
             raise Exception("Error polling for results.")
 
         if not response.ok:
@@ -195,7 +198,7 @@ class VideoInferenceModel(InferenceModel):
             # frame_offset and model name are top-level keys
             return inference_data.json()
         elif data["success"] == 1:
-            print("Job not complete yet. Check back in a minute.")
+            log.info("Job not complete yet. Check back in a minute.")
             return {}
         else:
             raise Exception("Job failed.")
@@ -235,6 +238,6 @@ class VideoInferenceModel(InferenceModel):
             if response != {}:
                 return response
 
-            print(f"({attempts * 60}s): Checking for inference results")
+            log.info(f"({attempts * 60}s): Checking for inference results")
 
             time.sleep(60)

--- a/roboflow/roboflowpy.py
+++ b/roboflow/roboflowpy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import logging
 import re
 
 import roboflow
@@ -13,6 +14,8 @@ from roboflow.models.instance_segmentation import InstanceSegmentationModel
 from roboflow.models.keypoint_detection import KeypointDetectionModel
 from roboflow.models.object_detection import ObjectDetectionModel
 from roboflow.models.semantic_segmentation import SemanticSegmentationModel
+
+log = logging.getLogger(__name__)
 
 
 def login(args):
@@ -37,10 +40,10 @@ def download(args):
     if not v:
         versions = project.versions()
         if not versions:
-            print(f"project {p} does not have any version. exiting")
+            log.info(f"project {p} does not have any version. exiting")
             exit(1)
         version = versions[-1]
-        print(f"Version not provided. Downloading last one ({version.version})")
+        log.info(f"Version not provided. Downloading last one ({version.version})")
     else:
         version = project.version(int(v))
     version.download(args.format, location=args.location, overwrite=True)
@@ -79,7 +82,7 @@ def upload_model(args):
     workspace = rf.workspace(args.workspace)
     project = workspace.project(args.project)
     version = project.version(args.version_number)
-    print(args.model_type, args.model_path, args.filename)
+    log.info(args.model_type, args.model_path, args.filename)
     version.deploy(str(args.model_type), str(args.model_path), str(args.filename))
 
 
@@ -88,30 +91,30 @@ def list_projects(args):
     workspace = rf.workspace(args.workspace)
     projects = workspace.project_list
     for p in projects:
-        print()
-        print(p["name"])
-        print(f"  link: {APP_URL}/{p['id']}")
-        print(f"  id: {p['id']}")
-        print(f"  type: {p['type']}")
-        print(f"  versions: {p['versions']}")
-        print(f"  images: {p['images']}")
-        print(f"  classes: {p['classes'].keys()}")
+        log.info()
+        log.info(p["name"])
+        log.info(f"  link: {APP_URL}/{p['id']}")
+        log.info(f"  id: {p['id']}")
+        log.info(f"  type: {p['type']}")
+        log.info(f"  versions: {p['versions']}")
+        log.info(f"  images: {p['images']}")
+        log.info(f"  classes: {p['classes'].keys()}")
 
 
 def list_workspaces(args):
     workspaces = roboflow_config.RF_WORKSPACES.values()
     rf_workspace = get_conditional_configuration_variable("RF_WORKSPACE", default=None)
     for w in workspaces:
-        print()
-        print(f"{w['name']}{' (default workspace)' if w['url'] == rf_workspace else ''}")
-        print(f"  link: {APP_URL}/{w['url']}")
-        print(f"  id: {w['url']}")
+        log.info()
+        log.info(f"{w['name']}{' (default workspace)' if w['url'] == rf_workspace else ''}")
+        log.info(f"  link: {APP_URL}/{w['url']}")
+        log.info(f"  id: {w['url']}")
 
 
 def get_workspace(args):
     api_key = load_roboflow_api_key(args.workspaceId)
     workspace_json = rfapi.get_workspace(api_key, args.workspaceId)
-    print(json.dumps(workspace_json, indent=2))
+    log.info(json.dumps(workspace_json, indent=2))
 
 
 def run_video_inference_api(args):
@@ -136,18 +139,18 @@ def get_workspace_project_version(args):
     # api_key = load_roboflow_api_key(args.workspaceId)
     rf = roboflow.Roboflow(args.api_key)
     workspace = rf.workspace()
-    print("workspace", workspace)
+    log.info(f"workspace {workspace}")
     project = workspace.project(args.project)
-    print("project", project)
+    log.info(f"project {project}")
     version = project.version(args.version_number)
-    print("version", version)
+    log.info(f"version {version}")
 
 
 def get_project(args):
     workspace_url = args.workspace or get_conditional_configuration_variable("RF_WORKSPACE", default=None)
     api_key = load_roboflow_api_key(workspace_url)
     dataset_json = rfapi.get_project(api_key, workspace_url, args.projectId)
-    print(json.dumps(dataset_json, indent=2))
+    log.info(json.dumps(dataset_json, indent=2))
 
 
 def infer(args):
@@ -177,7 +180,7 @@ def infer(args):
     if args.overlap is not None and projectType == "object-detection":
         kwargs["overlap"] = int(args.overlap * 100)
     group = model.predict(args.file, **kwargs)
-    print(group)
+    log.info(group)
 
 
 def _argparser():

--- a/roboflow/util/folderparser.py
+++ b/roboflow/util/folderparser.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import re
 from collections import defaultdict
@@ -6,6 +7,8 @@ from collections import defaultdict
 from tqdm import tqdm
 
 from .image_utils import load_labelmap
+
+log = logging.getLogger(__name__)
 
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp"}
 ANNOTATION_EXTENSIONS = {".txt", ".json", ".xml", ".csv"}
@@ -108,7 +111,7 @@ def _map_annotations_to_images_1tomany(images, annotationFiles):
         annotationsInSameDir = annotationsByDirname.get(dirname, [])
         if annotationsInSameDir:
             if len(annotationsInSameDir) > 1:
-                print(f"warning: found multiple annotation files on dir {dirname}")
+                log.info(f"warning: found multiple annotation files on dir {dirname}")
             annotationFile = annotationsInSameDir[0]
             format = annotationFile["parsedType"]
             image["annotationfile"] = _filterIndividualAnnotations(
@@ -163,7 +166,7 @@ def _filterIndividualAnnotations(image, annotation, format, imgRefMap, annotatio
     elif format == "createml":
         imgReferences = [i for i in parsed if i["image"] == image["name"]]
         if len(imgReferences) > 1:
-            print(f"warning: found multiple image entries for image {image['file']} in {annotation['file']}")
+            log.info(f"warning: found multiple image entries for image {image['file']} in {annotation['file']}")
         if imgReferences:
             imgReference = imgReferences[0]
             _annotation = {
@@ -231,8 +234,8 @@ def _map_labelmaps_to_annotations(annotations, labelmaps):
     labelmapmap = {lm["dirname"]: lm for lm in labelmaps}
     rootLabelmap = labelmapmap.get("/")
     if len(labelmapmap) < len(labelmaps):
-        print("warning: unexpectedly found multiple labelmaps per directory")
-        print([lm["file"] for lm in labelmaps])
+        log.info("warning: unexpectedly found multiple labelmaps per directory")
+        log.info([lm["file"] for lm in labelmaps])
     for ann in annotations:
         labelmap = labelmapmap.get(ann["dirname"]) or rootLabelmap
         if labelmap:

--- a/roboflow/util/versions.py
+++ b/roboflow/util/versions.py
@@ -1,8 +1,11 @@
+import logging
 import sys
 from importlib import import_module
 from typing import List, Tuple
 
 from packaging.version import Version
+
+log = logging.getLogger(__name__)
 
 
 def get_wrong_dependencies_versions(
@@ -47,7 +50,7 @@ def print_warn_for_wrong_dependencies_versions(
 ):
     wrong_dependencies_versions = get_wrong_dependencies_versions(dependencies_versions)
     for dependency, order, version, module_version in wrong_dependencies_versions:
-        print(
+        log.info(
             f"Dependency {dependency}{order}{version} is required but found"
             f" version={module_version}, to fix: `pip install"
             f" {dependency}{order}{version}`"


### PR DESCRIPTION
# Description

No `print`, only `log`: I'm working on a project that uses `roboflow-python` and rather than making changes to suppress stdout for this module, I updated it to use a Python logger instead.

Every module gets its own logger using `logging.getLogger(__name__)`.

Everything is logged as INFO. 

The logger uses f-strings because the optimization benefit for not using them really doesn't matter here. Ruff now ignores G003 and G004 as a result.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Ruff and mypy checks pass.

## Any specific deployment considerations

I know there are still interactive prompts in there; for my next trick, I might figure out something to do with them for when running in a non-interactive environment.
