### PR TITLE
Fix check for has_model for model upload

### DIFF
--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -97,7 +97,7 @@ class Version:
             response = requests.get(f"{API_URL}/{workspace}/{project}/{self.version}?api_key={self.__api_key}")
             if response.ok:
                 version_info = response.json()["version"]
-                has_model = bool(version_info.get("models"))
+                has_model = bool(version_info.get("train", {}).get("model"))
             else:
                 has_model = False
 


### PR DESCRIPTION
# Description

Fixes bug introduced here: https://github.com/roboflow/roboflow-python/pull/279/files, where `has_model` is always false for models uploaded to Roboflow. Those models will not have a "models" field on their version record.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally with uploaded model, and model trained with roboflow.

## Any specific deployment considerations

no

## Docs

-   [ ] Docs updated? What were the changes:
