### PR TITLE
bugfix - downloading yolov8 files incorrectly amends data.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,5 +154,3 @@ tests/manual/data
 README.roboflow.txt
 *.zip
 .DS_Store
-
-Aerial-Airport-1

--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,5 @@ tests/manual/data
 README.roboflow.txt
 *.zip
 .DS_Store
+
+Aerial-Airport-1

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -15,7 +15,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.47"
+__version__ = "1.1.48"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -7,7 +7,6 @@ import shutil
 import sys
 import time
 import zipfile
-from importlib import import_module
 from typing import TYPE_CHECKING, Optional, Union
 
 import requests

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -233,7 +233,7 @@ class Version:
 
         self.__download_zip(link, location, model_format)
         self.__extract_zip(location, model_format)
-        self.__reformat_yaml(location, model_format)
+        self.__reformat_yaml(location, model_format)  # TODO: is roboflow-python a place to be munging yaml files?
 
         return Dataset(self.name, self.version, model_format, os.path.abspath(location))
 
@@ -944,7 +944,7 @@ class Version:
                 content["train"] = location + content["train"].lstrip(".")
                 content["val"] = location + content["val"].lstrip(".")
                 content["test"] = location + content["test"].lstrip(".")
-            if format in ["yolov5pytorch", "yolov7pytorch", "yolov8", "yolov9"]:
+            if format in ["yolov5pytorch", "yolov7pytorch"]:
                 content["train"] = location + content["train"].lstrip("..")
                 content["val"] = location + content["val"].lstrip("..")
             try:

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -206,19 +206,6 @@ class Version:
 
         self.__wait_if_generating()
 
-        if model_format == "yolov8":
-            # if ultralytics is installed, we will assume users will want to use yolov8 and we check for the supported version  # noqa: E501 // docs
-            try:
-                import_module("ultralytics")
-                print_warn_for_wrong_dependencies_versions([("ultralytics", "==", "8.0.196")])
-            except ImportError:
-                print(
-                    "[WARNING] we noticed you are downloading a `yolov8` datasets but you don't have `ultralytics` installed. "  # noqa: E501 // docs
-                    "Roboflow `.deploy` supports only models trained with `ultralytics==8.0.196`, to intall it `pip install ultralytics==8.0.196`."  # noqa: E501 // docs
-                )
-                # silently fail
-                pass
-
         model_format = self.__get_format_identifier(model_format)
 
         if model_format not in self.exports:

--- a/tests/manual/debugme.py
+++ b/tests/manual/debugme.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     # args = parser.parse_args(f"upload {thisdir}/../datasets/chess -w wolfodorpythontests -p chess".split())   # noqa: E501 // docs
     args = parser.parse_args(
         # ["login"]
-        # "download https://universe.roboflow.com/gdit/aerial-airport".split()
+        "download -f yolov8 https://universe.roboflow.com/gdit/aerial-airport".split()
         # "project list -w wolfodorpythontests".split()
         # "project get cultura-pepino-dark".split()
         # "workspace list".split()
@@ -42,6 +42,6 @@ if __name__ == "__main__":
         # f"import {thisdir}/data/cultura-pepino-yolov5pytorch -w wolfodorpythontests -p yellow-auto -c 100 -n papaiasso".split()  # noqa: E501 // docs
         # f"import {thisdir}/../datasets/mosquitos -w wolfodorpythontests -p yellow-auto -n papaiasso".split()  # noqa: E501 // docs
         # f"deployment list".split()  # noqa: E501 // docs
-        f"import -w tonyprivate -p meh-plvrv {thisdir}/../datasets/paligemma/".split()  # noqa: E501 // docs
+        # f"import -w tonyprivate -p meh-plvrv {thisdir}/../datasets/paligemma/".split()  # noqa: E501 // docs
     )
     args.func(args)


### PR DESCRIPTION
# Description

Our train notebooks like [train-yolov8-object-detection-on-custom-dataset.ipynb](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/train-yolov8-object-detection-on-custom-dataset.ipynb) are having to do weird yaml amending like

![CleanShot 2024-10-11 at 14 31 41](https://github.com/user-attachments/assets/be9e0791-c576-433b-81fd-487af56ec4f1)

When you export a dataset in yolov8 format from the UI, you get a correct yaml that has

```yaml
train: ../train/images
val: ../valid/images
test: ../test/images
```

But if download it with roboflow-python you get a modified yaml like

```yaml
test: ../test/images
train: football-players-detection-12/train/images
val: football-players-detection-12/valid/images
```

It's not good that the train notebook needs to undo the mistake of roboflow-python

This PR fixes that mistake.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally
