### PR TITLE
Add feature for querying dedicated deployment usage (per workspace)

### DIFF
--- a/roboflow/adapters/deploymentapi.py
+++ b/roboflow/adapters/deploymentapi.py
@@ -41,6 +41,18 @@ def list_deployment(api_key):
     return response.status_code, response.json()
 
 
+def get_workspace_usage(api_key, target_month, return_details):
+    url = f"{DEDICATED_DEPLOYMENT_URL}/get_usage?api_key={api_key}"
+    if target_month is not None:
+        url += f"&target_month={target_month}"
+    if return_details:
+        url += f"&return_details={return_details}"
+    response = requests.get(url)
+    if response.status_code != 200:
+        return response.status_code, response.text
+    return response.status_code, response.json()
+
+
 def delete_deployment(api_key, deployment_name):
     url = f"{DEDICATED_DEPLOYMENT_URL}/delete"
     response = requests.post(url, json={"api_key": api_key, "deployment_name": deployment_name})

--- a/roboflow/adapters/deploymentapi.py
+++ b/roboflow/adapters/deploymentapi.py
@@ -41,12 +41,20 @@ def list_deployment(api_key):
     return response.status_code, response.json()
 
 
-def get_workspace_usage(api_key, target_month, return_details):
-    url = f"{DEDICATED_DEPLOYMENT_URL}/get_usage?api_key={api_key}"
+def get_workspace_usage(api_key, target_month):
+    url = f"{DEDICATED_DEPLOYMENT_URL}/usage_workspace?api_key={api_key}"
     if target_month is not None:
         url += f"&target_month={target_month}"
-    if return_details:
-        url += f"&return_details={return_details}"
+    response = requests.get(url)
+    if response.status_code != 200:
+        return response.status_code, response.text
+    return response.status_code, response.json()
+
+
+def get_deployment_usage(api_key, deployment_name, target_month):
+    url = f"{DEDICATED_DEPLOYMENT_URL}/usage_deployment?api_key={api_key}&deployment_name={deployment_name}"
+    if target_month is not None:
+        url += f"&target_month={target_month}"
     response = requests.get(url)
     if response.status_code != 200:
         return response.status_code, response.text

--- a/roboflow/adapters/deploymentapi.py
+++ b/roboflow/adapters/deploymentapi.py
@@ -41,20 +41,16 @@ def list_deployment(api_key):
     return response.status_code, response.json()
 
 
-def get_workspace_usage(api_key, target_month):
-    url = f"{DEDICATED_DEPLOYMENT_URL}/usage_workspace?api_key={api_key}"
-    if target_month is not None:
-        url += f"&target_month={target_month}"
+def get_workspace_usage(api_key, from_timestamp, to_timestamp):
+    url = f"{DEDICATED_DEPLOYMENT_URL}/usage_workspace?api_key={api_key}&from_timestamp={from_timestamp.isoformat()}&to_timestamp={to_timestamp.isoformat()}"
     response = requests.get(url)
     if response.status_code != 200:
         return response.status_code, response.text
     return response.status_code, response.json()
 
 
-def get_deployment_usage(api_key, deployment_name, target_month):
-    url = f"{DEDICATED_DEPLOYMENT_URL}/usage_deployment?api_key={api_key}&deployment_name={deployment_name}"
-    if target_month is not None:
-        url += f"&target_month={target_month}"
+def get_deployment_usage(api_key, deployment_name, from_timestamp, to_timestamp):
+    url = f"{DEDICATED_DEPLOYMENT_URL}/usage_deployment?api_key={api_key}&deployment_name={deployment_name}&from_timestamp={from_timestamp.isoformat()}&to_timestamp={to_timestamp.isoformat()}"
     response = requests.get(url)
     if response.status_code != 200:
         return response.status_code, response.text

--- a/roboflow/deployment.py
+++ b/roboflow/deployment.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from roboflow.adapters import deploymentapi
 from roboflow.config import load_roboflow_api_key
 
+
 def is_valid_ISO8601_timestamp(ts):
     try:
         datetime.fromisoformat(ts)
@@ -12,15 +13,16 @@ def is_valid_ISO8601_timestamp(ts):
     except:
         return False
 
+
 def check_from_to_timestamp(from_timestamp, to_timestamp, default_timedelta):
     if from_timestamp and not is_valid_ISO8601_timestamp(from_timestamp):
         print("Please provide a valid from_timestamp in ISO8601 format")
         exit(1)
-    
+
     if to_timestamp and not is_valid_ISO8601_timestamp(to_timestamp):
         print("Please provide a valid to_timestamp in ISO8601 format")
         exit(1)
-    
+
     time_now = datetime.now().replace(tzinfo=None)
     if from_timestamp is None and to_timestamp is None:
         from_timestamp = time_now - default_timedelta
@@ -37,7 +39,7 @@ def check_from_to_timestamp(from_timestamp, to_timestamp, default_timedelta):
         if from_timestamp >= to_timestamp:
             print("from_timestamp should be earlier than to_timestamp")
             exit(1)
-    
+
     return from_timestamp, to_timestamp
 
 
@@ -109,14 +111,22 @@ def add_deployment_parser(subparsers):
 
     deployment_usage_workspace_parser.set_defaults(func=get_workspace_usage)
     deployment_usage_workspace_parser.add_argument("-a", "--api_key", help="api key")
-    deployment_usage_workspace_parser.add_argument("-f", "--from_timestamp", help="begin time stamp in ISO8601 format (YYYY-MM-DD HH:MM:SS)", default=None)
-    deployment_usage_workspace_parser.add_argument("-t", "--to_timestamp", help="end time stamp in ISO8601 format (YYYY-MM-DD HH:MM:SS)", default=None)
-    
+    deployment_usage_workspace_parser.add_argument(
+        "-f", "--from_timestamp", help="begin time stamp in ISO8601 format (YYYY-MM-DD HH:MM:SS)", default=None
+    )
+    deployment_usage_workspace_parser.add_argument(
+        "-t", "--to_timestamp", help="end time stamp in ISO8601 format (YYYY-MM-DD HH:MM:SS)", default=None
+    )
+
     deployment_usage_deployment_parser.set_defaults(func=get_deployment_usage)
     deployment_usage_deployment_parser.add_argument("-a", "--api_key", help="api key")
     deployment_usage_deployment_parser.add_argument("deployment_name", help="deployment name")
-    deployment_usage_deployment_parser.add_argument("-f", "--from_timestamp", help="begin time stamp in ISO8601 format (YYYY-MM-DD HH:MM:SS)", default=None)
-    deployment_usage_deployment_parser.add_argument("-t", "--to_timestamp", help="end time stamp in ISO8601 format (YYYY-MM-DD HH:MM:SS)", default=None)
+    deployment_usage_deployment_parser.add_argument(
+        "-f", "--from_timestamp", help="begin time stamp in ISO8601 format (YYYY-MM-DD HH:MM:SS)", default=None
+    )
+    deployment_usage_deployment_parser.add_argument(
+        "-t", "--to_timestamp", help="end time stamp in ISO8601 format (YYYY-MM-DD HH:MM:SS)", default=None
+    )
 
     deployment_delete_parser.set_defaults(func=delete_deployment)
     deployment_delete_parser.add_argument("-a", "--api_key", help="api key")
@@ -208,7 +218,7 @@ def get_workspace_usage(args):
     if api_key is None:
         print("Please provide an api key")
         exit(1)
-    
+
     from_timestamp, to_timestamp = check_from_to_timestamp(args.from_timestamp, args.to_timestamp, timedelta(days=1))
     status_code, msg = deploymentapi.get_workspace_usage(api_key, from_timestamp, to_timestamp)
     if status_code != 200:
@@ -222,7 +232,7 @@ def get_deployment_usage(args):
     if api_key is None:
         print("Please provide an api key")
         exit(1)
-    
+
     from_timestamp, to_timestamp = check_from_to_timestamp(args.from_timestamp, args.to_timestamp, timedelta(days=1))
     status_code, msg = deploymentapi.get_deployment_usage(api_key, args.deployment_name, from_timestamp, to_timestamp)
     if status_code != 200:

--- a/roboflow/deployment.py
+++ b/roboflow/deployment.py
@@ -18,7 +18,9 @@ def add_deployment_parser(subparsers):
         "get", help="show detailed info for a dedicated deployment"
     )
     deployment_list_parser = deployment_subparsers.add_parser("list", help="list dedicated deployments in a workspace")
-    deployment_usage_parser = deployment_subparsers.add_parser("usage", help="get dedicated deployments usage in a workspace")
+    deployment_usage_parser = deployment_subparsers.add_parser(
+        "usage", help="get dedicated deployments usage in a workspace"
+    )
     deployment_delete_parser = deployment_subparsers.add_parser("delete", help="delete a dedicated deployment")
     deployment_log_parser = deployment_subparsers.add_parser("log", help="show log info for a dedicated deployment")
 
@@ -66,10 +68,10 @@ def add_deployment_parser(subparsers):
 
     deployment_list_parser.set_defaults(func=list_deployment)
     deployment_list_parser.add_argument("-a", "--api_key", help="api key")
-    
+
     deployment_usage_parser.set_defaults(func=get_workspace_usage)
     deployment_usage_parser.add_argument("-a", "--api_key", help="api key")
-    deployment_usage_parser.add_argument("target_month", help="target month (format: YYYYMM)", nargs='?')
+    deployment_usage_parser.add_argument("target_month", help="target month (format: YYYYMM)", nargs="?")
     deployment_usage_parser.add_argument("-d", "--details", help="get usage details", action="store_true")
 
     deployment_delete_parser.set_defaults(func=delete_deployment)

--- a/roboflow/deployment.py
+++ b/roboflow/deployment.py
@@ -18,8 +18,11 @@ def add_deployment_parser(subparsers):
         "get", help="show detailed info for a dedicated deployment"
     )
     deployment_list_parser = deployment_subparsers.add_parser("list", help="list dedicated deployments in a workspace")
-    deployment_usage_parser = deployment_subparsers.add_parser(
-        "usage", help="get dedicated deployments usage in a workspace"
+    deployment_usage_workspace_parser = deployment_subparsers.add_parser(
+        "usage_workspace", help="get all dedicated deployments usage in a workspace"
+    )
+    deployment_usage_deployment_parser = deployment_subparsers.add_parser(
+        "usage_deployment", help="get usage of a specific dedicated deployments"
     )
     deployment_delete_parser = deployment_subparsers.add_parser("delete", help="delete a dedicated deployment")
     deployment_log_parser = deployment_subparsers.add_parser("log", help="show log info for a dedicated deployment")
@@ -69,10 +72,14 @@ def add_deployment_parser(subparsers):
     deployment_list_parser.set_defaults(func=list_deployment)
     deployment_list_parser.add_argument("-a", "--api_key", help="api key")
 
-    deployment_usage_parser.set_defaults(func=get_workspace_usage)
-    deployment_usage_parser.add_argument("-a", "--api_key", help="api key")
-    deployment_usage_parser.add_argument("target_month", help="target month (format: YYYYMM)", nargs="?")
-    deployment_usage_parser.add_argument("-d", "--details", help="get usage details", action="store_true")
+    deployment_usage_workspace_parser.set_defaults(func=get_workspace_usage)
+    deployment_usage_workspace_parser.add_argument("-a", "--api_key", help="api key")
+    deployment_usage_workspace_parser.add_argument("target_month", help="target month (format: YYYYMM)", nargs="?")
+    
+    deployment_usage_deployment_parser.set_defaults(func=get_deployment_usage)
+    deployment_usage_deployment_parser.add_argument("-a", "--api_key", help="api key")
+    deployment_usage_deployment_parser.add_argument("deployment_name", help="deployment name")
+    deployment_usage_deployment_parser.add_argument("target_month", help="target month (format: YYYYMM)", nargs="?")
 
     deployment_delete_parser.set_defaults(func=delete_deployment)
     deployment_delete_parser.add_argument("-a", "--api_key", help="api key")
@@ -164,7 +171,19 @@ def get_workspace_usage(args):
     if api_key is None:
         print("Please provide an api key")
         exit(1)
-    status_code, msg = deploymentapi.get_workspace_usage(api_key, args.target_month, args.details)
+    status_code, msg = deploymentapi.get_workspace_usage(api_key, args.target_month)
+    if status_code != 200:
+        print(f"{status_code}: {msg}")
+        exit(status_code)
+    print(json.dumps(msg, indent=2))
+
+
+def get_deployment_usage(args):
+    api_key = args.api_key or load_roboflow_api_key(None)
+    if api_key is None:
+        print("Please provide an api key")
+        exit(1)
+    status_code, msg = deploymentapi.get_deployment_usage(api_key, args.deployment_name, args.target_month)
     if status_code != 200:
         print(f"{status_code}: {msg}")
         exit(status_code)

--- a/roboflow/deployment.py
+++ b/roboflow/deployment.py
@@ -18,6 +18,7 @@ def add_deployment_parser(subparsers):
         "get", help="show detailed info for a dedicated deployment"
     )
     deployment_list_parser = deployment_subparsers.add_parser("list", help="list dedicated deployments in a workspace")
+    deployment_usage_parser = deployment_subparsers.add_parser("usage", help="get dedicated deployments usage in a workspace")
     deployment_delete_parser = deployment_subparsers.add_parser("delete", help="delete a dedicated deployment")
     deployment_log_parser = deployment_subparsers.add_parser("log", help="show log info for a dedicated deployment")
 
@@ -65,6 +66,11 @@ def add_deployment_parser(subparsers):
 
     deployment_list_parser.set_defaults(func=list_deployment)
     deployment_list_parser.add_argument("-a", "--api_key", help="api key")
+    
+    deployment_usage_parser.set_defaults(func=get_workspace_usage)
+    deployment_usage_parser.add_argument("-a", "--api_key", help="api key")
+    deployment_usage_parser.add_argument("target_month", help="target month (format: YYYYMM)", nargs='?')
+    deployment_usage_parser.add_argument("-d", "--details", help="get usage details", action="store_true")
 
     deployment_delete_parser.set_defaults(func=delete_deployment)
     deployment_delete_parser.add_argument("-a", "--api_key", help="api key")
@@ -145,6 +151,18 @@ def list_deployment(args):
         print("Please provide an api key")
         exit(1)
     status_code, msg = deploymentapi.list_deployment(api_key)
+    if status_code != 200:
+        print(f"{status_code}: {msg}")
+        exit(status_code)
+    print(json.dumps(msg, indent=2))
+
+
+def get_workspace_usage(args):
+    api_key = args.api_key or load_roboflow_api_key(None)
+    if api_key is None:
+        print("Please provide an api key")
+        exit(1)
+    status_code, msg = deploymentapi.get_workspace_usage(api_key, args.target_month, args.details)
     if status_code != 200:
         print(f"{status_code}: {msg}")
         exit(status_code)

--- a/roboflow/deployment.py
+++ b/roboflow/deployment.py
@@ -5,6 +5,41 @@ from datetime import datetime, timedelta
 from roboflow.adapters import deploymentapi
 from roboflow.config import load_roboflow_api_key
 
+def is_valid_ISO8601_timestamp(ts):
+    try:
+        datetime.fromisoformat(ts)
+        return True
+    except:
+        return False
+
+def check_from_to_timestamp(from_timestamp, to_timestamp, default_timedelta):
+    if from_timestamp and not is_valid_ISO8601_timestamp(from_timestamp):
+        print("Please provide a valid from_timestamp in ISO8601 format")
+        exit(1)
+    
+    if to_timestamp and not is_valid_ISO8601_timestamp(to_timestamp):
+        print("Please provide a valid to_timestamp in ISO8601 format")
+        exit(1)
+    
+    time_now = datetime.now().replace(tzinfo=None)
+    if from_timestamp is None and to_timestamp is None:
+        from_timestamp = time_now - default_timedelta
+        to_timestamp = time_now
+    elif from_timestamp is not None and to_timestamp is None:
+        from_timestamp = datetime.fromisoformat(from_timestamp).replace(tzinfo=None)
+        to_timestamp = from_timestamp + default_timedelta
+    elif from_timestamp is None and to_timestamp is not None:
+        to_timestamp = datetime.fromisoformat(to_timestamp).replace(tzinfo=None)
+        from_timestamp = to_timestamp - default_timedelta
+    else:
+        from_timestamp = datetime.fromisoformat(from_timestamp).replace(tzinfo=None)
+        to_timestamp = datetime.fromisoformat(to_timestamp).replace(tzinfo=None)
+        if from_timestamp >= to_timestamp:
+            print("from_timestamp should be earlier than to_timestamp")
+            exit(1)
+    
+    return from_timestamp, to_timestamp
+
 
 def add_deployment_parser(subparsers):
     deployment_parser = subparsers.add_parser(
@@ -74,12 +109,14 @@ def add_deployment_parser(subparsers):
 
     deployment_usage_workspace_parser.set_defaults(func=get_workspace_usage)
     deployment_usage_workspace_parser.add_argument("-a", "--api_key", help="api key")
-    deployment_usage_workspace_parser.add_argument("target_month", help="target month (format: YYYYMM)", nargs="?")
+    deployment_usage_workspace_parser.add_argument("-f", "--from_timestamp", help="begin time stamp in ISO8601 format (YYYY-MM-DD HH:MM:SS)", default=None)
+    deployment_usage_workspace_parser.add_argument("-t", "--to_timestamp", help="end time stamp in ISO8601 format (YYYY-MM-DD HH:MM:SS)", default=None)
     
     deployment_usage_deployment_parser.set_defaults(func=get_deployment_usage)
     deployment_usage_deployment_parser.add_argument("-a", "--api_key", help="api key")
     deployment_usage_deployment_parser.add_argument("deployment_name", help="deployment name")
-    deployment_usage_deployment_parser.add_argument("target_month", help="target month (format: YYYYMM)", nargs="?")
+    deployment_usage_deployment_parser.add_argument("-f", "--from_timestamp", help="begin time stamp in ISO8601 format (YYYY-MM-DD HH:MM:SS)", default=None)
+    deployment_usage_deployment_parser.add_argument("-t", "--to_timestamp", help="end time stamp in ISO8601 format (YYYY-MM-DD HH:MM:SS)", default=None)
 
     deployment_delete_parser.set_defaults(func=delete_deployment)
     deployment_delete_parser.add_argument("-a", "--api_key", help="api key")
@@ -171,7 +208,9 @@ def get_workspace_usage(args):
     if api_key is None:
         print("Please provide an api key")
         exit(1)
-    status_code, msg = deploymentapi.get_workspace_usage(api_key, args.target_month)
+    
+    from_timestamp, to_timestamp = check_from_to_timestamp(args.from_timestamp, args.to_timestamp, timedelta(days=1))
+    status_code, msg = deploymentapi.get_workspace_usage(api_key, from_timestamp, to_timestamp)
     if status_code != 200:
         print(f"{status_code}: {msg}")
         exit(status_code)
@@ -183,7 +222,9 @@ def get_deployment_usage(args):
     if api_key is None:
         print("Please provide an api key")
         exit(1)
-    status_code, msg = deploymentapi.get_deployment_usage(api_key, args.deployment_name, args.target_month)
+    
+    from_timestamp, to_timestamp = check_from_to_timestamp(args.from_timestamp, args.to_timestamp, timedelta(days=1))
+    status_code, msg = deploymentapi.get_deployment_usage(api_key, args.deployment_name, from_timestamp, to_timestamp)
     if status_code != 200:
         print(f"{status_code}: {msg}")
         exit(status_code)


### PR DESCRIPTION
# Description

Add feature for querying dedicated deployment usage:
all deployments in a workspace: `roboflow deployment usage_workspace [from_timestamp] [to_timestamp]`
a specific active deployment: `roboflow deployment usage_deployment deployment_name [from_timestamp] [to_timestamp]`

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
