### PR TITLE
Revert "Allow null "updated" or "created" timestamps"

### DIFF
--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -60,7 +60,7 @@ class Project:
             self.annotation = a_project["annotation"]
             self.classes = a_project["classes"]
             self.colors = a_project["colors"]
-            self.created = datetime.datetime.fromtimestamp(a_project["created"]) if a_project["created"] else None
+            self.created = datetime.datetime.fromtimestamp(a_project["created"])
             self.id = a_project["id"]
             self.images = a_project["images"]
             self.name = a_project["name"]
@@ -69,7 +69,7 @@ class Project:
             self.type = a_project["type"]
             self.multilabel = a_project.get("multilabel", False)
             self.unannotated = a_project["unannotated"]
-            self.updated = datetime.datetime.fromtimestamp(a_project["updated"]) if a_project["updated"] else None
+            self.updated = datetime.datetime.fromtimestamp(a_project["updated"])
             self.model_format = model_format
 
             temp = self.id.rsplit("/")


### PR DESCRIPTION
Reverts roboflow/roboflow-python#338

It was a hotfix to not break with `updated == null`, but we already fixed the root cause.

It is not good to keep these checks because we'll never trust we can safely remove them in the future.