### PR TITLE
Use local timezone when query logs & usages for dedicated deployment

### DIFF
--- a/roboflow/adapters/deploymentapi.py
+++ b/roboflow/adapters/deploymentapi.py
@@ -1,5 +1,5 @@
 import requests
-
+import urllib
 from roboflow.config import DEDICATED_DEPLOYMENT_URL
 
 
@@ -58,13 +58,14 @@ def list_machine_types(api_key):
 
 
 def get_deployment_log(api_key, deployment_name, from_timestamp=None, to_timestamp=None, max_entries=-1):
-    url = f"{DEDICATED_DEPLOYMENT_URL}/get_log?api_key={api_key}&deployment_name={deployment_name}"
+    params = {'api_key': api_key, 'deployment_name': deployment_name}
     if from_timestamp is not None:
-        url += f"&from_timestamp={from_timestamp.isoformat()}"
+        params['from_timestamp'] = from_timestamp.isoformat() # may contain + sign
     if to_timestamp is not None:
-        url += f"&to_timestamp={to_timestamp.isoformat()}"
+        params['to_timestamp'] = to_timestamp.isoformat() # may contain + sign
     if max_entries > 0:
-        url += f"&max_entries={max_entries}"
+        params['max_entries'] = max_entries
+    url = f"{DEDICATED_DEPLOYMENT_URL}/get_log?{urllib.parse.urlencode(params)}"
     response = requests.get(url)
     if response.status_code != 200:
         return response.status_code, response.text

--- a/roboflow/adapters/deploymentapi.py
+++ b/roboflow/adapters/deploymentapi.py
@@ -44,7 +44,12 @@ def list_deployment(api_key):
 
 
 def get_workspace_usage(api_key, from_timestamp, to_timestamp):
-    url = f"{DEDICATED_DEPLOYMENT_URL}/usage_workspace?api_key={api_key}&from_timestamp={from_timestamp.isoformat()}&to_timestamp={to_timestamp.isoformat()}"
+    params = {"api_key": api_key}
+    if from_timestamp is not None:
+        params["from_timestamp"] = from_timestamp.isoformat()  # may contain + sign
+    if to_timestamp is not None:
+        params["to_timestamp"] = to_timestamp.isoformat()  # may contain + sign
+    url = f"{DEDICATED_DEPLOYMENT_URL}/usage_workspace?{urllib.parse.urlencode(params)}"
     response = requests.get(url)
     if response.status_code != 200:
         return response.status_code, response.text
@@ -52,7 +57,12 @@ def get_workspace_usage(api_key, from_timestamp, to_timestamp):
 
 
 def get_deployment_usage(api_key, deployment_name, from_timestamp, to_timestamp):
-    url = f"{DEDICATED_DEPLOYMENT_URL}/usage_deployment?api_key={api_key}&deployment_name={deployment_name}&from_timestamp={from_timestamp.isoformat()}&to_timestamp={to_timestamp.isoformat()}"
+    params = {"api_key": api_key, "deployment_name": deployment_name}
+    if from_timestamp is not None:
+        params["from_timestamp"] = from_timestamp.isoformat()  # may contain + sign
+    if to_timestamp is not None:
+        params["to_timestamp"] = to_timestamp.isoformat()  # may contain + sign
+    url = f"{DEDICATED_DEPLOYMENT_URL}/usage_deployment?{urllib.parse.urlencode(params)}"
     response = requests.get(url)
     if response.status_code != 200:
         return response.status_code, response.text

--- a/roboflow/adapters/deploymentapi.py
+++ b/roboflow/adapters/deploymentapi.py
@@ -1,5 +1,7 @@
-import requests
 import urllib
+
+import requests
+
 from roboflow.config import DEDICATED_DEPLOYMENT_URL
 
 
@@ -58,13 +60,13 @@ def list_machine_types(api_key):
 
 
 def get_deployment_log(api_key, deployment_name, from_timestamp=None, to_timestamp=None, max_entries=-1):
-    params = {'api_key': api_key, 'deployment_name': deployment_name}
+    params = {"api_key": api_key, "deployment_name": deployment_name}
     if from_timestamp is not None:
-        params['from_timestamp'] = from_timestamp.isoformat() # may contain + sign
+        params["from_timestamp"] = from_timestamp.isoformat()  # may contain + sign
     if to_timestamp is not None:
-        params['to_timestamp'] = to_timestamp.isoformat() # may contain + sign
+        params["to_timestamp"] = to_timestamp.isoformat()  # may contain + sign
     if max_entries > 0:
-        params['max_entries'] = max_entries
+        params["max_entries"] = max_entries
     url = f"{DEDICATED_DEPLOYMENT_URL}/get_log?{urllib.parse.urlencode(params)}"
     response = requests.get(url)
     if response.status_code != 200:

--- a/roboflow/deployment.py
+++ b/roboflow/deployment.py
@@ -23,19 +23,19 @@ def check_from_to_timestamp(from_timestamp, to_timestamp, default_timedelta):
         print("Please provide a valid to_timestamp in ISO8601 format")
         exit(1)
 
-    time_now = datetime.now().replace(tzinfo=None)
+    time_now = datetime.now().astimezone()  # local timezone
     if from_timestamp is None and to_timestamp is None:
         from_timestamp = time_now - default_timedelta
         to_timestamp = time_now
     elif from_timestamp is not None and to_timestamp is None:
-        from_timestamp = datetime.fromisoformat(from_timestamp).replace(tzinfo=None)
+        from_timestamp = datetime.fromisoformat(from_timestamp).astimezone()
         to_timestamp = from_timestamp + default_timedelta
     elif from_timestamp is None and to_timestamp is not None:
-        to_timestamp = datetime.fromisoformat(to_timestamp).replace(tzinfo=None)
+        to_timestamp = datetime.fromisoformat(to_timestamp).astimezone()
         from_timestamp = to_timestamp - default_timedelta
     else:
-        from_timestamp = datetime.fromisoformat(from_timestamp).replace(tzinfo=None)
-        to_timestamp = datetime.fromisoformat(to_timestamp).replace(tzinfo=None)
+        from_timestamp = datetime.fromisoformat(from_timestamp).astimezone()
+        to_timestamp = datetime.fromisoformat(to_timestamp).astimezone()
         if from_timestamp >= to_timestamp:
             print("from_timestamp should be earlier than to_timestamp")
             exit(1)

--- a/roboflow/deployment.py
+++ b/roboflow/deployment.py
@@ -169,7 +169,7 @@ def get_deployment_log(args):
         print("Please provide an api key")
         exit(1)
 
-    to_timestamp = datetime.now()
+    to_timestamp = datetime.now().astimezone() # local timezone
     from_timestamp = to_timestamp - timedelta(seconds=args.duration)
     last_log_timestamp = from_timestamp
     log_ids = set()  # to avoid duplicate logs
@@ -183,7 +183,7 @@ def get_deployment_log(args):
             exit(status_code)
 
         for log in msg[::-1]:  # logs are sorted by reversed timestamp
-            log_timestamp = datetime.fromisoformat(log["timestamp"]).replace(tzinfo=None)
+            log_timestamp = datetime.fromisoformat(log["timestamp"]).astimezone()  # local timezone
             if (log["insert_id"] in log_ids) or (log_timestamp < last_log_timestamp):
                 continue
             log_ids.add(log["insert_id"])
@@ -195,5 +195,5 @@ def get_deployment_log(args):
 
         time.sleep(10)
         from_timestamp = last_log_timestamp
-        to_timestamp = datetime.now()
+        to_timestamp = datetime.now().astimezone() # local timezone
         max_entries = 300  # only set max_entries for the first request

--- a/roboflow/deployment.py
+++ b/roboflow/deployment.py
@@ -16,11 +16,11 @@ def is_valid_ISO8601_timestamp(ts):
 
 def check_from_to_timestamp(from_timestamp, to_timestamp, default_timedelta):
     if from_timestamp and not is_valid_ISO8601_timestamp(from_timestamp):
-        print("Please provide a valid from_timestamp in ISO8601 format")
+        print("Please provide a valid from_timestamp in ISO8601 format (YYYY-MM-DD HH:MM:SS)")
         exit(1)
 
     if to_timestamp and not is_valid_ISO8601_timestamp(to_timestamp):
-        print("Please provide a valid to_timestamp in ISO8601 format")
+        print("Please provide a valid to_timestamp in ISO8601 format (YYYY-MM-DD HH:MM:SS)")
         exit(1)
 
     time_now = datetime.now().astimezone()  # local timezone

--- a/roboflow/deployment.py
+++ b/roboflow/deployment.py
@@ -169,7 +169,7 @@ def get_deployment_log(args):
         print("Please provide an api key")
         exit(1)
 
-    to_timestamp = datetime.now().astimezone() # local timezone
+    to_timestamp = datetime.now().astimezone()  # local timezone
     from_timestamp = to_timestamp - timedelta(seconds=args.duration)
     last_log_timestamp = from_timestamp
     log_ids = set()  # to avoid duplicate logs
@@ -195,5 +195,5 @@ def get_deployment_log(args):
 
         time.sleep(10)
         from_timestamp = last_log_timestamp
-        to_timestamp = datetime.now().astimezone() # local timezone
+        to_timestamp = datetime.now().astimezone()  # local timezone
         max_entries = 300  # only set max_entries for the first request


### PR DESCRIPTION
# Description

Use local timezone when query logs & usages for dedicated deployment, default is UTC time.

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
