### PR TITLE
Add support for the Image Details endpoint

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -15,7 +15,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.53"
+__version__ = "1.1.54"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -787,7 +787,7 @@ class Project:
 
             >>> image_details = project.image("image-id")
         """
-        url = f"{API_URL}/{self.__workspace}/{self.__project_name}/images/{image_id}" f"?api_key={self.__api_key}"
+        url = f"{API_URL}/{self.__workspace}/{self.__project_name}/images/{image_id}?api_key={self.__api_key}"
 
         data = requests.get(url).json()
 

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -767,3 +767,37 @@ class Project:
         json_str = {"name": self.name, "type": self.type, "workspace": self.__workspace}
 
         return json.dumps(json_str, indent=2)
+
+    def image(self, image_id: str) -> Dict:
+        """
+        Fetch the details of a specific image from the Roboflow API.
+
+        Args:
+            image_id (str): The ID of the image to fetch.
+
+        Returns:
+            Dict: A dictionary containing the image details.
+
+        Example:
+            >>> import roboflow
+
+            >>> rf = roboflow.Roboflow(api_key="YOUR_API_KEY")
+
+            >>> project = rf.workspace().project("PROJECT_ID")
+
+            >>> image_details = project.image("image-id")
+        """
+        url = f"{API_URL}/{self.__workspace}/{self.__project_name}/images/{image_id}" f"?api_key={self.__api_key}"
+
+        data = requests.get(url).json()
+
+        if "error" in data:
+            raise RuntimeError(data["error"])
+
+        if "image" not in data:
+            print(data, image_id)
+            raise RuntimeError("Image not found")
+
+        image_details = data["image"]
+
+        return image_details

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -818,11 +818,8 @@ class Version:
 
         def bar_progress(current, total, width=80):
             progress_message = (
-                "Downloading Dataset Version Zip in "
-                + location
-                + " to "
-                + format
-                + ": %d%% [%d / %d] bytes" % (current / total * 100, current, total)
+                f"Downloading Dataset Version Zip in {location} to {format}: "
+                f"{current / total * 100:.0f}% [{current} / {total}] bytes"
             )
             sys.stdout.write("\r" + progress_message)
             sys.stdout.flush()

--- a/roboflow/deployment.py
+++ b/roboflow/deployment.py
@@ -10,7 +10,7 @@ def is_valid_ISO8601_timestamp(ts):
     try:
         datetime.fromisoformat(ts)
         return True
-    except:
+    except ValueError:
         return False
 
 


### PR DESCRIPTION
# Description

This PR adds support for the Image Details endpoint on the API to the Python SDK: https://docs.roboflow.com/api-reference/images/image-details

Example:

```
import roboflow
rf = roboflow.Roboflow(api_key="YOUR_API_KEY")
project = rf.workspace().project("PROJECT_ID")
image_details = project.image("image-id")
```

Also adds tests

## Type of change
-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?
Tested locally + externally here: https://colab.research.google.com/drive/1PMUgiSA-S-OO6F1I_k27Me282_aeJyEO?usp=sharing

Test added and ran

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
