### PR TITLE
Only stretch image to resize if format is Stretch

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -43,7 +43,7 @@ def check_key(api_key, model, notebook, num_retries=0):
                     num_retries += 1
                     return check_key(api_key, model, notebook, num_retries)
                 else:
-                    raise RuntimeError("There was an error validating the api key with Roboflow" " server.")
+                    raise RuntimeError("There was an error validating the api key with Roboflow server.")
             else:
                 r = response.json()
                 return r
@@ -71,7 +71,7 @@ def login(workspace=None, force=False):
     # default configuration location
     conf_location = os.getenv("ROBOFLOW_CONFIG_DIR", default=default_path)
     if os.path.isfile(conf_location) and not force:
-        write_line("You are already logged into Roboflow. To make a different login," "run roboflow.login(force=True).")
+        write_line("You are already logged into Roboflow. To make a different login,run roboflow.login(force=True).")
         return None
         # we could eventually return the workspace object here
         # return Roboflow().workspace()

--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -179,7 +179,7 @@ def save_annotation(
 
 
 def _save_annotation_url(api_key, project_url, name, image_id, job_name, is_prediction, overwrite=False):
-    url = f"{API_URL}/dataset/{project_url}/annotate/{image_id}?api_key={api_key}" f"&name={name}"
+    url = f"{API_URL}/dataset/{project_url}/annotate/{image_id}?api_key={api_key}&name={name}"
     if job_name:
         url += f"&jobName={job_name}"
     if is_prediction:

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -230,7 +230,7 @@ class Project:
             )
 
         r = requests.post(
-            f"{API_URL}/{self.__workspace}/{self.__project_name}/" f"generate?api_key={self.__api_key}",
+            f"{API_URL}/{self.__workspace}/{self.__project_name}/generate?api_key={self.__api_key}",
             json=settings,
         )
 
@@ -426,7 +426,7 @@ class Project:
 
             if not is_image:
                 raise RuntimeError(
-                    "The image you provided {} is not a supported file format. We" " currently support: {}.".format(
+                    "The image you provided {} is not a supported file format. We currently support: {}.".format(
                         image_path, ", ".join(ACCEPTED_IMAGE_FORMATS)
                     )
                 )

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -495,7 +495,7 @@ class Version:
         ]
 
         if not any(supported_model in model_type for supported_model in supported_models):
-            raise (ValueError(f"Model type {model_type} not supported. Supported models are" f" {supported_models}"))
+            raise (ValueError(f"Model type {model_type} not supported. Supported models are {supported_models}"))
 
         if model_type.startswith(("paligemma", "paligemma2", "florence-2")):
             if any(model in model_type for model in ["paligemma", "paligemma2", "florence-2"]):
@@ -648,7 +648,7 @@ class Version:
                     )
                 else:
                     if file in ["model_artifacts.json", "state_dict.pt"]:
-                        raise (ValueError(f"File {file} not found. Please make sure to provide a" " valid model path."))
+                        raise (ValueError(f"File {file} not found. Please make sure to provide a valid model path."))
 
         self.upload_zip(model_type, model_path)
 
@@ -761,7 +761,7 @@ class Version:
                     )
                 else:
                     if file in ["model_artifacts.json", filename]:
-                        raise (ValueError(f"File {file} not found. Please make sure to provide a" " valid model path."))
+                        raise (ValueError(f"File {file} not found. Please make sure to provide a valid model path."))
 
         self.upload_zip(model_type, model_path)
 
@@ -791,8 +791,7 @@ class Version:
 
             if self.public:
                 print(
-                    "View the status of your deployment at:"
-                    f" {APP_URL}/{self.workspace}/{self.project}/{self.version}"
+                    f"View the status of your deployment at: {APP_URL}/{self.workspace}/{self.project}/{self.version}"
                 )
                 print(
                     "Share your model with the world at:"
@@ -801,8 +800,7 @@ class Version:
                 )
             else:
                 print(
-                    "View the status of your deployment at:"
-                    f" {APP_URL}/{self.workspace}/{self.project}/{self.version}"
+                    f"View the status of your deployment at: {APP_URL}/{self.workspace}/{self.project}/{self.version}"
                 )
 
         except Exception as e:
@@ -824,7 +822,7 @@ class Version:
             progress_message = (
                 "Downloading Dataset Version Zip in "
                 f"{location} to {format}: "
-                f"{current/total*100:.0f}% [{current} / {total}] bytes"
+                f"{current / total * 100:.0f}% [{current} / {total}] bytes"
             )
             sys.stdout.write("\r" + progress_message)
             sys.stdout.flush()
@@ -923,7 +921,7 @@ class Version:
 
         if not format:
             raise RuntimeError(
-                "You must pass a format argument to version.download() or define a" " model in your Roboflow object"
+                "You must pass a format argument to version.download() or define a model in your Roboflow object"
             )
 
         friendly_formats = {"yolov5": "yolov5pytorch", "yolov7": "yolov7pytorch"}

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -269,7 +269,7 @@ class Workspace:
                 # capture OCR results from cropped image
                 results.append(ocr_infer(croppedImg)["results"])
         else:
-            print("please use an object detection model--can only perform two stage with" " bounding box results")
+            print("please use an object detection model--can only perform two stage with bounding box results")
 
         return results
 

--- a/roboflow/deployment.py
+++ b/roboflow/deployment.py
@@ -197,7 +197,7 @@ def get_deployment(args):
             print(json.dumps(msg, indent=2))
             break
 
-        print(f'{datetime.now().strftime("%H:%M:%S")} Waiting for deployment {args.deployment_name} to be ready...\n')
+        print(f"{datetime.now().strftime('%H:%M:%S')} Waiting for deployment {args.deployment_name} to be ready...\n")
         time.sleep(30)
 
 
@@ -278,7 +278,7 @@ def get_deployment_log(args):
                 continue
             log_ids.add(log["insert_id"])
             last_log_timestamp = log_timestamp
-            print(f'[{log_timestamp.strftime("%Y-%m-%d %H:%M:%S.%f")}] {log["payload"]}')
+            print(f"[{log_timestamp.strftime('%Y-%m-%d %H:%M:%S.%f')}] {log['payload']}")
 
         if not args.follow:
             break

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -179,6 +179,8 @@ class ObjectDetectionModel(InferenceModel):
             import cv2
             import numpy as np
 
+            should_resize = "resize" in self.preprocessing.keys() and "Stretch" in self.preprocessing["resize"]["format"]
+
             if isinstance(image_path, str):
                 image = Image.open(image_path).convert("RGB")
                 dimensions = image.size
@@ -186,7 +188,7 @@ class ObjectDetectionModel(InferenceModel):
 
                 # Here we resize the image to the preprocessing settings
                 # before sending it over the wire
-                if "resize" in self.preprocessing.keys():
+                if should_resize:
                     if dimensions[0] > int(self.preprocessing["resize"]["width"]) or dimensions[1] > int(
                         self.preprocessing["resize"]["height"]
                     ):
@@ -245,7 +247,7 @@ class ObjectDetectionModel(InferenceModel):
         if self.format == "json":
             resp_json = resp.json()
 
-            if resize and original_dimensions is not None:
+            if should_resize and original_dimensions is not None:
                 new_preds = []
                 for p in resp_json["predictions"]:
                     p["x"] = int(p["x"] * (int(original_dimensions[0]) / int(self.preprocessing["resize"]["width"])))

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -173,6 +173,7 @@ class ObjectDetectionModel(InferenceModel):
             self.__exception_check(image_path_check=image_path)
 
         original_dimensions = None
+        should_resize = False
         # If image is local image
         if not hosted:
             import cv2

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -179,7 +179,9 @@ class ObjectDetectionModel(InferenceModel):
             import cv2
             import numpy as np
 
-            should_resize = "resize" in self.preprocessing.keys() and "Stretch" in self.preprocessing["resize"]["format"]
+            should_resize = (
+                "resize" in self.preprocessing.keys() and "Stretch" in self.preprocessing["resize"]["format"]
+            )
 
             if isinstance(image_path, str):
                 image = Image.open(image_path).convert("RGB")

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -172,7 +172,6 @@ class ObjectDetectionModel(InferenceModel):
         else:
             self.__exception_check(image_path_check=image_path)
 
-        resize = False
         original_dimensions = None
         # If image is local image
         if not hosted:
@@ -201,7 +200,6 @@ class ObjectDetectionModel(InferenceModel):
                             )
                         )
                         dimensions = image.size
-                        resize = True
 
                 # Create buffer
                 buffered = io.BytesIO()

--- a/roboflow/roboflowpy.py
+++ b/roboflow/roboflowpy.py
@@ -249,7 +249,7 @@ def _add_upload_parser(subparsers):
     upload_parser.add_argument(
         "-w",
         dest="workspace",
-        help="specify a workspace url or id " "(will use default workspace if not specified)",
+        help="specify a workspace url or id (will use default workspace if not specified)",
     )
     upload_parser.add_argument(
         "-p",
@@ -307,7 +307,7 @@ def _add_import_parser(subparsers):
     import_parser.add_argument(
         "-w",
         dest="workspace",
-        help="specify a workspace url or id " "(will use default workspace if not specified)",
+        help="specify a workspace url or id (will use default workspace if not specified)",
     )
     import_parser.add_argument(
         "-p",

--- a/roboflow/util/versions.py
+++ b/roboflow/util/versions.py
@@ -34,7 +34,7 @@ def get_wrong_dependencies_versions(
         module = import_module(dependency)
         module_version = module.__version__
         if order not in order_funcs:
-            raise ValueError(f"order={order} not supported, please use" f" `{', '.join(order_funcs.keys())}`")
+            raise ValueError(f"order={order} not supported, please use `{', '.join(order_funcs.keys())}`")
 
         is_okay = order_funcs[order](Version(module_version), Version(version))
         if not is_okay:
@@ -53,7 +53,7 @@ def print_warn_for_wrong_dependencies_versions(
             f" {dependency}{order}{version}`"
         )
         if ask_to_continue:
-            answer = input(f"Would you like to continue with the wrong version of {dependency}?" " y/n: ")
+            answer = input(f"Would you like to continue with the wrong version of {dependency}? y/n: ")
             if answer.lower() != "y":
                 sys.exit(1)
 


### PR DESCRIPTION
# Description

Only perform a optimizing "stretch" resize if that is the resize format. Without this fix it will produce incorrect predictions for resize formats such as "Fit within". 

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally with the python package.

## Any specific deployment considerations

none

## Docs

-   [ ] Docs updated? What were the changes:
