### PR TITLE
Normalize Windows style paths to parse folder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: ["ubuntu-latest", "windows-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    runs-on: ${{ matrix.os }}
+    env:
+      PYTHONUTF8: 1
 
     steps:
       - name: 🛎️ Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     env:
       PYTHONUTF8: 1

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -15,7 +15,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.61"
+__version__ = "1.1.62"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/util/folderparser.py
+++ b/roboflow/util/folderparser.py
@@ -12,10 +12,17 @@ ANNOTATION_EXTENSIONS = {".txt", ".json", ".xml", ".csv", ".jsonl"}
 LABELMAPS_EXTENSIONS = {".labels", ".yaml", ".yml"}
 
 
+def _patch_sep(filename):
+    """
+    Replace Windows style slashes to keep filenames consistent.
+    
+    Roboflow depend on it server side.
+    """
+    return filename.replace("\\", "/")
+
+
 def parsefolder(folder):
-    folder = folder.strip()
-    if folder.endswith("/"):
-        folder = folder[:-1]
+    folder = _patch_sep(folder).strip().rstrip("/")
     if not os.path.exists(folder):
         raise Exception(f"folder does not exist. {folder}")
     files = _list_files(folder)
@@ -53,7 +60,9 @@ def _list_files(folder):
     for root, dirs, files in os.walk(folder):
         for file in files:
             file_path = os.path.join(root, file)
-            filedescriptors.append(_describe_file(file_path.split(folder)[1]))
+            rel = os.path.relpath(file_path, folder)
+            print("FILENAME", file_path, rel)
+            filedescriptors.append(_describe_file(f"/{rel}"))
     filedescriptors = sorted(filedescriptors, key=lambda x: _alphanumkey(x["file"]))
     return filedescriptors
 
@@ -64,8 +73,8 @@ def _add_indices(files):
 
 
 def _describe_file(f):
-    name = f.split("/")[-1]
-    dirname = os.path.dirname(f)
+    f = _patch_sep(f)
+    dirname, name = f.rsplit("/", 1)
     fullkey, extension = os.path.splitext(f)
     fullkey2 = fullkey.replace("/labels", "").replace("/images", "")
     key = os.path.splitext(name)[0]

--- a/roboflow/util/folderparser.py
+++ b/roboflow/util/folderparser.py
@@ -61,7 +61,6 @@ def _list_files(folder):
         for file in files:
             file_path = os.path.join(root, file)
             rel = os.path.relpath(file_path, folder)
-            print("FILENAME", file_path, rel)
             filedescriptors.append(_describe_file(f"/{rel}"))
     filedescriptors = sorted(filedescriptors, key=lambda x: _alphanumkey(x["file"]))
     return filedescriptors
@@ -279,7 +278,6 @@ def _load_labelmaps(folder, labelmaps):
         except Exception:
             # raise Exception(f"failed to load labelmap {labelmap['file']}")
             pass
-        print("LABEL MAP", folder, labelmap)
     return [lm for lm in labelmaps if lm.get("labelmap")]
 
 

--- a/roboflow/util/folderparser.py
+++ b/roboflow/util/folderparser.py
@@ -74,7 +74,8 @@ def _add_indices(files):
 
 def _describe_file(f):
     f = _patch_sep(f)
-    dirname, name = f.rsplit("/", 1)
+    name = f.split("/")[-1]
+    dirname = os.path.dirname(f)
     fullkey, extension = os.path.splitext(f)
     fullkey2 = fullkey.replace("/labels", "").replace("/images", "")
     key = os.path.splitext(name)[0]

--- a/roboflow/util/folderparser.py
+++ b/roboflow/util/folderparser.py
@@ -15,7 +15,7 @@ LABELMAPS_EXTENSIONS = {".labels", ".yaml", ".yml"}
 def _patch_sep(filename):
     """
     Replace Windows style slashes to keep filenames consistent.
-    
+
     Roboflow depend on it server side.
     """
     return filename.replace("\\", "/")

--- a/roboflow/util/folderparser.py
+++ b/roboflow/util/folderparser.py
@@ -278,6 +278,7 @@ def _load_labelmaps(folder, labelmaps):
         except Exception:
             # raise Exception(f"failed to load labelmap {labelmap['file']}")
             pass
+        print("LABEL MAP", folder, labelmap)
     return [lm for lm in labelmaps if lm.get("labelmap")]
 
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -59,7 +59,7 @@ class TestDownload(unittest.TestCase):
         self.assertEqual(dataset.name, self.version.name)
         self.assertEqual(dataset.version, self.version.version)
         self.assertEqual(dataset.model_format, "coco")
-        self.assertEqual(dataset.location, "/my-spot")
+        self.assertEqual(dataset.location, os.path.abspath("/my-spot"))
 
 
 class TestExport(unittest.TestCase):

--- a/tests/util/test_folderparser.py
+++ b/tests/util/test_folderparser.py
@@ -36,7 +36,6 @@ class TestFolderParser(unittest.TestCase):
             testImagePath = "/train/images/sharks_mp4-20_jpg.rf.5359121123e86e016401ea2731e47949.jpg"
             testImage = [i for i in parsed["images"] if i["file"] == testImagePath][0]
             expectAnnotationFile = "/train/labels/sharks_mp4-20_jpg.rf.5359121123e86e016401ea2731e47949.txt"
-            print("AAA", testImagePath, testImage)
             assert testImage["annotationfile"]["file"] == expectAnnotationFile
             assert testImage["annotationfile"]["labelmap"] == {0: "fish", 1: "primary", 2: "shark"}
 

--- a/tests/util/test_folderparser.py
+++ b/tests/util/test_folderparser.py
@@ -36,6 +36,7 @@ class TestFolderParser(unittest.TestCase):
             testImagePath = "/train/images/sharks_mp4-20_jpg.rf.5359121123e86e016401ea2731e47949.jpg"
             testImage = [i for i in parsed["images"] if i["file"] == testImagePath][0]
             expectAnnotationFile = "/train/labels/sharks_mp4-20_jpg.rf.5359121123e86e016401ea2731e47949.txt"
+            print("AAA", testImagePath, testImage)
             assert testImage["annotationfile"]["file"] == expectAnnotationFile
             assert testImage["annotationfile"]["labelmap"] == {0: "fish", 1: "primary", 2: "shark"}
 


### PR DESCRIPTION
# Description

Annotations are not uploaded because slashes don't match image filenames with our parse structure.

I'm forcing unix style slashes everywhere in folderparser.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

* We have good tests for folderparser.
* I tested to upload images from local mac.
* I don't have a Windows to validate the fix. I'll ask the user to retry after release.