### PR TITLE
Changing default URLs

### DIFF
--- a/roboflow/config.py
+++ b/roboflow/config.py
@@ -53,12 +53,12 @@ APP_URL = get_conditional_configuration_variable("APP_URL", "https://app.roboflo
 UNIVERSE_URL = get_conditional_configuration_variable("UNIVERSE_URL", "https://universe.roboflow.com")
 
 INSTANCE_SEGMENTATION_URL = get_conditional_configuration_variable(
-    "INSTANCE_SEGMENTATION_URL", "https://outline.roboflow.com"
+    "INSTANCE_SEGMENTATION_URL", "https://serverless.roboflow.com"
 )
 SEMANTIC_SEGMENTATION_URL = get_conditional_configuration_variable(
     "SEMANTIC_SEGMENTATION_URL", "https://segment.roboflow.com"
 )
-OBJECT_DETECTION_URL = get_conditional_configuration_variable("OBJECT_DETECTION_URL", "https://detect.roboflow.com")
+OBJECT_DETECTION_URL = get_conditional_configuration_variable("OBJECT_DETECTION_URL", "https://serverless.roboflow.com")
 
 CLIP_FEATURIZE_URL = get_conditional_configuration_variable("CLIP_FEATURIZE_URL", "CLIP FEATURIZE URL NOT IN ENV")
 OCR_URL = get_conditional_configuration_variable("OCR_URL", "OCR URL NOT IN ENV")

--- a/roboflow/models/keypoint_detection.py
+++ b/roboflow/models/keypoint_detection.py
@@ -49,7 +49,7 @@ class KeypointDetectionModel(InferenceModel):
         self.id = id
         self.name = name
         self.version = version
-        self.base_url = "https://detect.roboflow.com/"
+        self.base_url = "https://serverless.roboflow.com/"
 
         if self.name is not None and version is not None:
             self.__generate_url()

--- a/roboflow/models/object_detection.py
+++ b/roboflow/models/object_detection.py
@@ -278,7 +278,7 @@ class ObjectDetectionModel(InferenceModel):
     def webcam(
         self,
         webcam_id=0,
-        inference_engine_url="https://detect.roboflow.com/",
+        inference_engine_url="https://serverless.roboflow.com/",
         within_jupyter=False,
         confidence=40,
         overlap=30,
@@ -291,7 +291,7 @@ class ObjectDetectionModel(InferenceModel):
 
         Args:
             webcam_id (int): Webcam ID (default 0)
-            inference_engine_url (str): Inference engine address to use (default https://detect.roboflow.com)
+            inference_engine_url (str): Inference engine address to use (default https://serverless.roboflow.com)
             within_jupyter (bool): Whether or not to display the webcam within Jupyter notebook (default True)
             confidence (int): Confidence threshold for detections
             overlap (int): Overlap threshold for detections


### PR DESCRIPTION
# Description

Change the default inference URLs to Roboflow Serverless Inference V2

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested in staging

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
