### PR TITLE
Enhance error handling in model deployment URL retrieval

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -15,7 +15,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.63"
+__version__ = "1.1.64"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -619,7 +619,13 @@ class Workspace:
         try:
             res.raise_for_status()
         except Exception as e:
-            print(f"An error occured when getting the model deployment URL: {e}")
+            error_message = str(e)
+            status_code = str(res.status_code)
+            
+            print("\n\033[91m❌ ERROR\033[0m: Failed to get model deployment URL")
+            print("\033[93mDetails\033[0m:", error_message)
+            print("\033[93mStatus\033[0m:", status_code)
+            print(f"\033[93mResponse\033[0m:\n{res.text}\n")
             return
 
         # Upload the model to the signed URL


### PR DESCRIPTION
# Description

The previous message doesn't show any information about the error.

**Before:**

![CleanShot 2025-05-14 at 15 21 57@2x](https://github.com/user-attachments/assets/82625fe9-3200-4897-91cf-e328224f3cfb)

**After:**

![CleanShot 2025-05-14 at 15 26 31@2x](https://github.com/user-attachments/assets/356a9083-82f7-4b9d-89b2-7b8634c76ebf)

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Localy

## Any specific deployment considerations

- Release app