### PR TITLE
Fix mutable default arguments

### DIFF
--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -1,7 +1,7 @@
 import json
 import os
 import urllib
-from typing import Optional
+from typing import List, Optional
 
 import requests
 from requests.exceptions import RequestException
@@ -56,7 +56,7 @@ def upload_image(
     hosted_image: bool = False,
     split: str = "train",
     batch_name: str = DEFAULT_BATCH_NAME,
-    tag_names: list = [],
+    tag_names: Optional[List[str]] = None,
     sequence_number: Optional[int] = None,
     sequence_size: Optional[int] = None,
     **kwargs,
@@ -71,6 +71,8 @@ def upload_image(
     """
 
     coalesced_batch_name = batch_name or DEFAULT_BATCH_NAME
+    if tag_names is None:
+        tag_names = []
 
     # If image is not a hosted image
     if not hosted_image:

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -256,13 +256,7 @@ class Project:
 
     def train(
         self,
-        new_version_settings={
-            "preprocessing": {
-                "auto-orient": True,
-                "resize": {"width": 640, "height": 640, "format": "Stretch to"},
-            },
-            "augmentation": {},
-        },
+        new_version_settings: Optional[Dict] = None,
         speed=None,
         checkpoint=None,
         plot_in_notebook=False,
@@ -293,6 +287,15 @@ class Project:
 
             >>> version.train()
         """  # noqa: E501 // docs
+
+        if new_version_settings is None:
+            new_version_settings = {
+                "preprocessing": {
+                    "auto-orient": True,
+                    "resize": {"width": 640, "height": 640, "format": "Stretch to"},
+                },
+                "augmentation": {},
+            }
 
         new_version = self.generate_version(settings=new_version_settings)
         new_version = self.version(new_version)
@@ -384,7 +387,7 @@ class Project:
         split: str = "train",
         num_retry_uploads: int = 0,
         batch_name: Optional[str] = None,
-        tag_names: list = [],
+        tag_names: Optional[List[str]] = None,
         is_prediction: bool = False,
         **kwargs,
     ):
@@ -412,6 +415,9 @@ class Project:
 
             >>> project.upload(image_path="YOUR_IMAGE.jpg")
         """  # noqa: E501 // docs
+
+        if tag_names is None:
+            tag_names = []
 
         is_hosted = image_path.startswith("http://") or image_path.startswith("https://")
 
@@ -476,12 +482,15 @@ class Project:
         split="train",
         num_retry_uploads=0,
         batch_name=None,
-        tag_names=[],
+        tag_names: Optional[List[str]] = None,
         sequence_number=None,
         sequence_size=None,
         **kwargs,
     ):
         project_url = self.id.rsplit("/")[1]
+
+        if tag_names is None:
+            tag_names = []
 
         t0 = time.time()
         upload_retry_attempts = 0
@@ -557,13 +566,15 @@ class Project:
         split="train",
         num_retry_uploads=0,
         batch_name=None,
-        tag_names=[],
+        tag_names: Optional[List[str]] = None,
         is_prediction: bool = False,
         annotation_overwrite=False,
         sequence_number=None,
         sequence_size=None,
         **kwargs,
     ):
+        if tag_names is None:
+            tag_names = []
         if image_path and image_id:
             raise Exception("You can't pass both image_id and image_path")
         if not (image_path or image_id):
@@ -641,7 +652,7 @@ class Project:
         in_dataset: Optional[str] = None,
         batch: bool = False,
         batch_id: Optional[str] = None,
-        fields: list = ["id", "created", "name", "labels"],
+        fields: Optional[List[str]] = None,
     ):
         """
         Search for images in a project.
@@ -670,6 +681,9 @@ class Project:
 
             >>> results = project.search(query="cat", limit=10)
         """  # noqa: E501 // docs
+        if fields is None:
+            fields = ["id", "created", "name", "labels"]
+
         payload: Dict[str, Union[str, int, List[str]]] = {}
 
         if like_image is not None:
@@ -719,7 +733,7 @@ class Project:
         in_dataset: Optional[str] = None,
         batch: bool = False,
         batch_id: Optional[str] = None,
-        fields: list = ["id", "created"],
+        fields: Optional[List[str]] = None,
     ):
         """
         Create a paginated list of search results for use in searching the images in a project.
@@ -752,6 +766,9 @@ class Project:
 
             >>>     print(result)
         """  # noqa: E501 // docs
+        if fields is None:
+            fields = ["id", "created"]
+
         while True:
             data = self.search(
                 like_image=like_image,

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -5,7 +5,7 @@ import glob
 import json
 import os
 import sys
-from typing import Any, List
+from typing import Any, Dict, List, Optional
 
 import requests
 from PIL import Image
@@ -433,9 +433,9 @@ class Workspace:
         self,
         raw_data_location: str = "",
         raw_data_extension: str = "",
-        inference_endpoint: list = [],
+        inference_endpoint: Optional[List[str]] = None,
         upload_destination: str = "",
-        conditionals: dict = {},
+        conditionals: Optional[Dict] = None,
         use_localhost: bool = False,
         local_server="http://localhost:9001/",
     ) -> Any:
@@ -449,6 +449,11 @@ class Workspace:
             use_localhost: (bool) = determines if local http format used or remote endpoint
             local_server: (str) = local http address for inference server, use_localhost must be True for this to be used
         """  # noqa: E501 // docs
+        if inference_endpoint is None:
+            inference_endpoint = []
+        if conditionals is None:
+            conditionals = {}
+
         import numpy as np
 
         prediction_results = []

--- a/roboflow/models/inference.py
+++ b/roboflow/models/inference.py
@@ -3,7 +3,7 @@ import json
 import os
 import time
 import urllib
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 from urllib.parse import urljoin
 
 import requests
@@ -137,7 +137,7 @@ class InferenceModel:
         self,
         video_path: str,
         fps: int = 5,
-        additional_models: list = [],
+        additional_models: Optional[List[str]] = None,
         prediction_type: str = "batch-video",
     ) -> Tuple[str, str, Optional[str]]:
         """
@@ -169,6 +169,9 @@ class InferenceModel:
         url = urljoin(API_URL, "/video_upload_signed_url?api_key=" + self.__api_key)
         if fps > 120:
             raise Exception("FPS must be less than or equal to 120.")
+
+        if additional_models is None:
+            additional_models = []
 
         for model in additional_models:
             if model not in SUPPORTED_ADDITIONAL_MODELS:


### PR DESCRIPTION
# Description

Fixes Python's common pitfall of using mutable objects (lists and dictionaries) as default function arguments. Mutable defaults are shared across function calls, which can lead to unexpected behavior when the default value is modified.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Ran `make style` successfully
- Attempted `make check_code_quality` (blocked by missing stub packages)
- Attempted `python -m unittest` (blocked by missing dependencies)

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

None - this is a backward-compatible fix that prevents potential bugs without changing API behavior.