### PR TITLE
Limit pillow-heif <1.0 and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.1.67
+
+- Restrict `pillow-heif` dependency to `<1.0` to retain AVIF support.
+
 ## 1.1.50
 
 - Added support for Palligema2 model uploads via `upload_model` command with the following model types:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ matplotlib
 numpy>=1.18.5
 opencv-python-headless==4.10.0.84
 Pillow>=7.1.2
-pillow-heif>=0.18.0
+pillow-heif>=0.18.0,<1.0
 python-dateutil
 python-dotenv
 requests

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -15,7 +15,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.66"
+__version__ = "1.1.67"
 
 
 def check_key(api_key, model, notebook, num_retries=0):


### PR DESCRIPTION
## Summary
- keep avif support by limiting pillow-heif to <1.0
- bump patch version
- document change in CHANGELOG

## Testing
- `python -m unittest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68611eac36ec832c9c5db5449bd3a58d