### PR TITLE
Fix #390: Lock `pillow-hief` version to not break AVIF support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ ignore = [
     "N",
     "PERF",
     "PIE",
+    "PLC0415",  # `import` should be at the top-level of a file
     "PLR",
     "PLW",
     "PT",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ matplotlib
 numpy>=1.18.5
 opencv-python-headless==4.10.0.84
 Pillow>=7.1.2
-pillow-heif<=0.18.0
+# https://github.com/roboflow/roboflow-python/issues/390
+pillow-heif<1
 python-dateutil
 python-dotenv
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ matplotlib
 numpy>=1.18.5
 opencv-python-headless==4.10.0.84
 Pillow>=7.1.2
-pillow-heif>=0.18.0
+pillow-heif<=0.18.0
 python-dateutil
 python-dotenv
 requests

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -15,7 +15,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.66"
+__version__ = "1.1.67"
 
 
 def check_key(api_key, model, notebook, num_retries=0):


### PR DESCRIPTION
# Description

Roboflow doesn't bound the pillow-hief version, resulting in the following errors when installed on Colab and kaggle notebooks:
```
     12 
     13 pillow_heif.register_heif_opener(thumbnails=False)  # Register for HEIF/HEIC
---> 14 pillow_heif.register_avif_opener(thumbnails=False)  # Register for AVIF
     15 
     16 

AttributeError: module 'pillow_heif' has no attribute 'register_avif_opener'

```

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tests pass.

Tested manually that 0.22 works (with a deprecation notice).

```python
>>> from PIL import Image
>>> import pillow_heif
>>> pillow_heif.__version__
'0.22.0'
>>> pillow_heif.register_avif_opener()
<stdin>:1: DeprecationWarning: The AVIF support in this library is marked as deprecated and will be removed in the next version. If you still need AVIF support until it natively appears in Pillow, use the https://github.com/fdintino/pillow-avif-plugin project instead.
>>> Image.open("fox.profile0.10bpc.yuv420.avif")
<pillow_heif.as_plugin.AvifImageFile image mode=RGB size=1204x800 at 0xFFFFB34C9F10>
```

## Any specific deployment considerations
None
