### PR TITLE
Use `pillow-avif-plugin` for AVIF support and support `pillow-heif` 1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     env:
       PYTHONUTF8: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ numpy>=1.18.5
 opencv-python-headless==4.10.0.84
 Pillow>=7.1.2
 # https://github.com/roboflow/roboflow-python/issues/390
-pillow-heif<1
+pillow-heif<2
+pillow-avif-plugin
 python-dateutil
 python-dotenv
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ opencv-python-headless==4.10.0.84
 Pillow>=7.1.2
 # https://github.com/roboflow/roboflow-python/issues/390
 pillow-heif<2
-pillow-avif-plugin
+pillow-avif-plugin<2
 python-dateutil
 python-dotenv
 requests

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -15,7 +15,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.67"
+__version__ = "1.1.68"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -15,7 +15,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.1.68"
+__version__ = "1.2.0"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/util/image_utils.py
+++ b/roboflow/util/image_utils.py
@@ -4,6 +4,8 @@ import io
 import os
 import urllib
 
+import pillow_avif  # type: ignore[import-untyped]
+
 # Third-party imports
 import pillow_heif  # type: ignore[import-untyped]
 import requests
@@ -11,7 +13,7 @@ import yaml
 from PIL import Image
 
 pillow_heif.register_heif_opener(thumbnails=False)  # Register for HEIF/HEIC
-pillow_heif.register_avif_opener(thumbnails=False)  # Register for AVIF
+pillow_avif.register_avif_opener()  # Register for AVIF
 
 
 def check_image_path(image_path):

--- a/roboflow/util/image_utils.py
+++ b/roboflow/util/image_utils.py
@@ -5,12 +5,14 @@ import os
 import urllib
 
 # Third-party imports
+import pillow_avif  # type: ignore[import-untyped]
 import pillow_heif  # type: ignore[import-untyped]
 import requests
 import yaml
 from PIL import Image
 
 pillow_heif.register_heif_opener(thumbnails=False)  # Register for HEIF/HEIC
+pillow_avif = pillow_avif  # Reference pillow_avif to not remove import by accident
 
 
 def check_image_path(image_path):

--- a/roboflow/util/image_utils.py
+++ b/roboflow/util/image_utils.py
@@ -4,16 +4,14 @@ import io
 import os
 import urllib
 
-import pillow_avif  # type: ignore[import-untyped]
-
 # Third-party imports
+import pillow_avif  # type: ignore[import-untyped]
 import pillow_heif  # type: ignore[import-untyped]
 import requests
 import yaml
 from PIL import Image
 
 pillow_heif.register_heif_opener(thumbnails=False)  # Register for HEIF/HEIC
-pillow_avif.register_avif_opener()  # Register for AVIF
 
 
 def check_image_path(image_path):

--- a/roboflow/util/image_utils.py
+++ b/roboflow/util/image_utils.py
@@ -5,7 +5,6 @@ import os
 import urllib
 
 # Third-party imports
-import pillow_avif  # type: ignore[import-untyped]
 import pillow_heif  # type: ignore[import-untyped]
 import requests
 import yaml

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -85,6 +85,7 @@ class TestProject(RoboflowTest):
             "woodland-rabbit.png",
             "file_example_TIFF_1MB.tiff",
             "sky-rabbit.heic",
+            "whatsnew.avif",
         ]
 
         for image in images_to_test:


### PR DESCRIPTION
# Description

Use `pillow-avif-plugin` for AVIF instead of `pillow-heif`, because `pillow-heif>=1` removed AVIF support. See #390.

Remove Python 3.8 from CI because it is EOL for 8 months already. It still works, but there is no wheel for `pillow-avif-plugin`. I preferred to remove it instead of adding extra installs.

# Type

* [x] Maintenance

# Testing

CI pass.
