### PR TITLE
Fix labelmap YAML parsing

### DIFF
--- a/roboflow/util/image_utils.py
+++ b/roboflow/util/image_utils.py
@@ -103,7 +103,10 @@ def load_labelmap(f):
         with open(f) as file:
             data = yaml.safe_load(file)
             if "names" in data:
-                return {i: name for i, name in enumerate(data["names"])}
+                names = data["names"]
+                if isinstance(names, dict):
+                    return {int(i): name for i, name in names.items()}
+                return {i: name for i, name in enumerate(names)}
     else:
         with open(f) as file:
             lines = [line for line in file.readlines() if line.strip()]

--- a/tests/util/test_image_utils.py
+++ b/tests/util/test_image_utils.py
@@ -1,11 +1,10 @@
+import os
+import tempfile
 import unittest
 
 import responses
 
-from roboflow.util.image_utils import check_image_path, check_image_url
-from roboflow.util.image_utils import load_labelmap
-import tempfile
-import os
+from roboflow.util.image_utils import check_image_path, check_image_url, load_labelmap
 
 
 class TestCheckImagePath(unittest.TestCase):

--- a/tests/util/test_image_utils.py
+++ b/tests/util/test_image_utils.py
@@ -3,6 +3,9 @@ import unittest
 import responses
 
 from roboflow.util.image_utils import check_image_path, check_image_url
+from roboflow.util.image_utils import load_labelmap
+import tempfile
+import os
 
 
 class TestCheckImagePath(unittest.TestCase):
@@ -33,3 +36,17 @@ class TestCheckImageURL(unittest.TestCase):
         url = "https://example.com/notfound.png"
         responses.add(responses.HEAD, url, status=404)
         self.assertFalse(check_image_url(url))
+
+
+class TestLoadLabelmap(unittest.TestCase):
+    def test_yaml_dict_names(self):
+        with tempfile.NamedTemporaryFile("w+", suffix=".yaml", delete=False) as tmp:
+            tmp.write("names:\n  0: abc\n  1: def\n")
+            tmp.flush()
+            result = load_labelmap(tmp.name)
+        os.unlink(tmp.name)
+        self.assertEqual(result, {0: "abc", 1: "def"})
+
+    def test_yaml_list_names(self):
+        result = load_labelmap("tests/datasets/sharks-tiny-yolov9/data.yaml")
+        self.assertEqual(result, {0: "fish", 1: "primary", 2: "shark"})


### PR DESCRIPTION
## Summary
- handle YAML dictionaries when loading labelmaps
- test load_labelmap with dict-style names

## Testing
- `make style`
- `make check_code_quality` *(fails: missing dependencies)*
- `python -m unittest` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e759189c4832ca77102c9ce188894