### PR TITLE
Replace pillow-heif with pi-heif

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ ignore = [
     "T",
     "TD",
     "TRY",
+    "UP",
 ]
 
 # Exclude a variety of commonly ignored directories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ target = ["test", "roboflow"]
 tests = ["B201", "B301"]
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
@@ -100,7 +100,7 @@ banned-module-level-imports = [
 ]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 exclude = ["^build/"]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,9 +112,7 @@ module = [
     "IPython.display.*",
     # ipywidgets is an optional dependency
     "ipywidgets.*",
-    # matplotlib typing is not available for Python 3.8
-    # remove this when we stop supporting Python 3.8
-    "matplotlib.*",
+    "pi_heif.*",
     "requests_toolbelt.*",
     "torch.*",
     "ultralytics.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ module = [
     "IPython.display.*",
     # ipywidgets is an optional dependency
     "ipywidgets.*",
-    "pi_heif.*",
     "requests_toolbelt.*",
     "torch.*",
     "ultralytics.*",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ numpy>=1.18.5
 opencv-python-headless==4.10.0.84
 Pillow>=7.1.2
 # https://github.com/roboflow/roboflow-python/issues/390
-pillow-heif<2
+pi-heif<2
 pillow-avif-plugin<2
 python-dateutil
 python-dotenv

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -15,7 +15,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.2.1"
+__version__ = "1.2.3"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/util/image_utils.py
+++ b/roboflow/util/image_utils.py
@@ -4,13 +4,15 @@ import io
 import os
 import urllib
 
+
 # Third-party imports
+import pi_heif  # type: ignore[import-untyped]
 import pillow_avif  # type: ignore[import-untyped]
 import requests
 import yaml
 from PIL import Image
 
-piheif.register_heif_opener(thumbnails=False)  # Register for HEIF/HEIC
+pi_heif.register_heif_opener(thumbnails=False)  # Register for HEIF/HEIC
 pillow_avif = pillow_avif  # Reference pillow_avif to not remove import by accident
 
 

--- a/roboflow/util/image_utils.py
+++ b/roboflow/util/image_utils.py
@@ -4,9 +4,9 @@ import io
 import os
 import urllib
 
-import piheif  # type: ignore[import-untyped]
 
 # Third-party imports
+import pi_heif  # type: ignore[import-untyped]
 import pillow_avif  # type: ignore[import-untyped]
 import requests
 import yaml

--- a/roboflow/util/image_utils.py
+++ b/roboflow/util/image_utils.py
@@ -4,9 +4,7 @@ import io
 import os
 import urllib
 
-
 # Third-party imports
-import pi_heif  # type: ignore[import-untyped]
 import pillow_avif  # type: ignore[import-untyped]
 import requests
 import yaml

--- a/roboflow/util/image_utils.py
+++ b/roboflow/util/image_utils.py
@@ -4,7 +4,6 @@ import io
 import os
 import urllib
 
-
 # Third-party imports
 import pi_heif  # type: ignore[import-untyped]
 import pillow_avif  # type: ignore[import-untyped]

--- a/roboflow/util/image_utils.py
+++ b/roboflow/util/image_utils.py
@@ -4,14 +4,15 @@ import io
 import os
 import urllib
 
+import piheif  # type: ignore[import-untyped]
+
 # Third-party imports
 import pillow_avif  # type: ignore[import-untyped]
-import pillow_heif  # type: ignore[import-untyped]
 import requests
 import yaml
 from PIL import Image
 
-pillow_heif.register_heif_opener(thumbnails=False)  # Register for HEIF/HEIC
+piheif.register_heif_opener(thumbnails=False)  # Register for HEIF/HEIC
 pillow_avif = pillow_avif  # Reference pillow_avif to not remove import by accident
 
 


### PR DESCRIPTION
## Summary

Replace pillow-heif requirement with pi-heif.

## Testing

CI pass. We have an [explicit test for HEIF image](https://github.com/roboflow/roboflow-python/blob/a90f38f73cf020393bc0a7d4918eb7662a80c2c9/tests/test_project.py#L87).

Fix #398 .

------
https://chatgpt.com/codex/tasks/task_e_6885d7f85790832c9de9db4f8eaaf96a