### PR TITLE
Fixing format export for CLI/python sdk

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -15,7 +15,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.2.4"
+__version__ = "1.2.6"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -317,6 +317,7 @@ class Version:
         self.__wait_if_generating()
 
         train_model_format = get_model_format(model_type)
+        self.export(train_model_format)
 
         workspace, project, *_ = self.id.rsplit("/")
 

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -244,7 +244,7 @@ class Version:
 
         return Dataset(self.name, self.version, model_format, os.path.abspath(location))
 
-    def export(self, model_format=None) -> str | None:
+    def export(self, model_format=None) -> bool | None:
         """
         Ask the Roboflow API to generate a version's dataset in a given format so that it can be downloaded via the `download()` method.
 
@@ -254,7 +254,7 @@ class Version:
             model_format (str): A format to use for downloading
 
         Returns:
-            The URL of the exported dataset.
+            True if the export was successful, RuntimeError if the export failed
 
         Raises:
             RuntimeError: If the Roboflow API returns an error with a helpful JSON body
@@ -325,7 +325,6 @@ class Version:
         payload_model_type = model_type if model_type else None
 
         write_line("Reaching out to Roboflow to start training...")
-        print(data)
 
         rfapi.start_version_training(
             api_key=self.__api_key,

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -235,7 +235,7 @@ class Version:
 
         return Dataset(self.name, self.version, model_format, os.path.abspath(location))
 
-    def export(self, model_format=None) -> str:
+    def export(self, model_format=None) -> str | None:
         """
         Ask the Roboflow API to generate a version's dataset in a given format so that it can be downloaded via the `download()` method.
 
@@ -289,6 +289,7 @@ class Version:
                 raise RuntimeError(response.json())
             except json.JSONDecodeError:
                 response.raise_for_status()
+            return None
 
     def train(self, speed=None, model_type=None, checkpoint=None, plot_in_notebook=False) -> InferenceModel:
         """

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -317,7 +317,8 @@ class Version:
         self.__wait_if_generating()
 
         train_model_format = get_model_format(model_type)
-        self.export(train_model_format)
+        if train_model_format not in self.exports:
+            self.export(train_model_format)
 
         workspace, project, *_ = self.id.rsplit("/")
 

--- a/roboflow/util/versions.py
+++ b/roboflow/util/versions.py
@@ -95,3 +95,40 @@ def normalize_yolo_model_type(model_type: str) -> str:
     model_type = model_type.replace("yolo11", "yolov11")
     model_type = model_type.replace("yolo12", "yolov12")
     return model_type
+
+
+def get_model_format(model_type: str) -> str:
+    """
+    Get the model format for a given model type.
+    Args:
+        model_type (str): The model type to get the format for.
+
+    Returns:
+        str: The model format.
+
+    Example:
+        >>> get_model_format("yolov5v6n")
+        "yolov5pytorch"
+        >>> get_model_format("rfdetr-nano")
+        "coco"
+        >>> get_model_format("yolov11n")
+        "yolov5pytorch"
+    """
+    # Prefixes extrated from modelRegistry.js in roboflow.
+    model_formats = {
+        "yolo": "yolov5pytorch",
+        "pali": "jsonl",
+        "flor": "jsonl",
+        "qwen": "jsonl",
+        "smol": "jsonl",
+        "vit-b": "folder",
+        "resn": "folder",
+        "rfdetr": "coco",
+        "rf-detr": "coco",
+        "deep": "png-mask-semantic",
+    }
+
+    for prefix, format in model_formats.items():
+        if prefix in model_type:
+            return format
+    return "yolov5pytorch"

--- a/tests/util/test_versions.py
+++ b/tests/util/test_versions.py
@@ -1,7 +1,7 @@
 import unittest
 from importlib import import_module
 
-from roboflow.util.versions import get_wrong_dependencies_versions
+from roboflow.util.versions import get_wrong_dependencies_versions, get_model_format
 
 
 class TestVersions(unittest.TestCase):
@@ -23,3 +23,21 @@ class TestVersions(unittest.TestCase):
             wrong_dependencies_versions = get_wrong_dependencies_versions([test])
             is_correct_dep = len(wrong_dependencies_versions) == 0
             self.assertEqual(is_correct_dep, expected_result)
+
+
+class TestGetModelFormat(unittest.TestCase):
+    def test_get_model_format_with_various_ids(self):
+        cases = [
+            ("yolov5v2s", "yolov5pytorch"),
+            ("yolov11n", "yolov5pytorch"),
+            ("rf-detr-nas-parent", "coco"),
+            ("rfdetr-nano", "coco"),
+            ("vit-base-patch16-224-in21k", "folder"),
+            ("resnet14", "folder"),
+            ("resenet38", "yolov5pytorch"),
+            ("invlid-type", "yolov5pytorch"),
+        ]
+
+        for model_type, expected_format in cases:
+            with self.subTest(model_type=model_type):
+                self.assertEqual(get_model_format(model_type), expected_format)

--- a/tests/util/test_versions.py
+++ b/tests/util/test_versions.py
@@ -1,7 +1,7 @@
 import unittest
 from importlib import import_module
 
-from roboflow.util.versions import get_wrong_dependencies_versions, get_model_format
+from roboflow.util.versions import get_model_format, get_wrong_dependencies_versions
 
 
 class TestVersions(unittest.TestCase):


### PR DESCRIPTION
# Description

The format that was used to export before calling the train did not follow the current logic that exists in the backend. And the backend did not use modelType to calculate which link to train on.

## Type of change


-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

locally, staging

## Any specific deployment considerations

None

## Docs

-   [ ] Docs updated? What were the changes: None
