### PR TITLE
Fix train-over-api devx

### DIFF
--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -6,12 +6,13 @@ import os
 import sys
 import time
 import zipfile
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Optional, TYPE_CHECKING, Union
 
-import requests
 from dotenv import load_dotenv
+import requests
 from tqdm import tqdm
 
+from roboflow.adapters import rfapi
 from roboflow.config import (
     API_URL,
     APP_URL,
@@ -34,7 +35,6 @@ from roboflow.util.annotations import amend_data_yaml
 from roboflow.util.general import write_line
 from roboflow.util.model_processor import process
 from roboflow.util.versions import get_wrong_dependencies_versions, normalize_yolo_model_type
-from roboflow.adapters import rfapi
 
 if TYPE_CHECKING:
     import numpy as np

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -6,10 +6,10 @@ import os
 import sys
 import time
 import zipfile
-from typing import Optional, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Union
 
-from dotenv import load_dotenv
 import requests
+from dotenv import load_dotenv
 from tqdm import tqdm
 
 from roboflow.adapters import rfapi

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -34,6 +34,7 @@ from roboflow.util.annotations import amend_data_yaml
 from roboflow.util.general import write_line
 from roboflow.util.model_processor import process
 from roboflow.util.versions import get_wrong_dependencies_versions, normalize_yolo_model_type
+from roboflow.adapters import rfapi
 
 if TYPE_CHECKING:
     import numpy as np
@@ -92,11 +93,11 @@ class Version:
 
             version_without_workspace = os.path.basename(str(version))
 
-            response = requests.get(f"{API_URL}/{workspace}/{project}/{self.version}?api_key={self.__api_key}")
-            if response.ok:
-                version_info = response.json()["version"]
+            try:
+                version_response = rfapi.get_version(self.__api_key, workspace, project, self.version)
+                version_info = version_response.get("version", {})
                 has_model = bool(version_info.get("train", {}).get("model"))
-            else:
+            except rfapi.RoboflowError:
                 has_model = False
 
             if not has_model:
@@ -152,16 +153,17 @@ class Version:
 
     def __check_if_generating(self):
         # check Roboflow API to see if this version is still generating
-
-        url = f"{API_URL}/{self.workspace}/{self.project}/{self.version}?nocache=true"
-        response = requests.get(url, params={"api_key": self.__api_key})
-        response.raise_for_status()
-        if response.json()["version"]["progress"] is None:
-            progress = 0.0
-        else:
-            progress = float(response.json()["version"]["progress"])
-
-        return response.json()["version"]["generating"], progress
+        versiondict = rfapi.get_version(
+            api_key=self.__api_key,
+            workspace_url=self.workspace,
+            project_url=self.project,
+            version=self.version,
+            nocache=True,
+        )
+        version_obj = versiondict.get("version", {})
+        progress = 0.0 if version_obj.get("progress") is None else float(version_obj.get("progress"))
+        generating = bool(version_obj.get("generating") or version_obj.get("images", 0) == 0)
+        return generating, progress
 
     def __wait_if_generating(self, recurse=False):
         # checks if a given version is still in the progress of generating
@@ -219,15 +221,22 @@ class Version:
         if self.__api_key == "coco-128-sample":
             link = "https://app.roboflow.com/ds/n9QwXwUK42?key=NnVCe2yMxP"
         else:
-            url = self.__get_download_url(model_format)
-            response = requests.get(url, params={"api_key": self.__api_key})
-            if response.status_code == 200:
-                link = response.json()["export"]["link"]
-            else:
-                try:
-                    raise RuntimeError(response.json())
-                except json.JSONDecodeError:
-                    response.raise_for_status()
+            workspace, project, *_ = self.id.rsplit("/")
+            try:
+                export_info = rfapi.get_version_export(
+                    api_key=self.__api_key,
+                    workspace_url=workspace,
+                    project_url=project,
+                    version=self.version,
+                    format=model_format,
+                )
+            except rfapi.RoboflowError as e:
+                raise RuntimeError(str(e))
+
+            if "ready" in export_info and export_info.get("ready") is False:
+                raise RuntimeError(export_info)
+
+            link = export_info["export"]["link"]
 
         self.__download_zip(link, location, model_format)
         self.__extract_zip(location, model_format)
@@ -256,39 +265,36 @@ class Version:
 
         self.__wait_if_generating()
 
-        url = self.__get_download_url(model_format)
-        response = requests.get(url, params={"api_key": self.__api_key})
-        if not response.ok:
-            try:
-                raise RuntimeError(response.json())
-            except json.JSONDecodeError:
-                response.raise_for_status()
-
-        # the rest api returns 202 if the export is still in progress
-        if response.status_code == 202:
-            status_code_check = 202
-            while status_code_check == 202:
-                time.sleep(1)
-                response = requests.get(url, params={"api_key": self.__api_key})
-                status_code_check = response.status_code
-                if status_code_check == 202:
-                    progress = response.json()["progress"]
-                    progress_message = (
-                        "Exporting format " + model_format + " in progress : " + str(round(progress * 100, 2)) + "%"
-                    )
-                    sys.stdout.write("\r" + progress_message)
-                    sys.stdout.flush()
-
-        if response.status_code == 200:
+        workspace, project, *_ = self.id.rsplit("/")
+        export_info = rfapi.get_version_export(
+            api_key=self.__api_key,
+            workspace_url=workspace,
+            project_url=project,
+            version=self.version,
+            format=model_format,
+        )
+        while "ready" in export_info and export_info.get("ready") is False:
+            progress = export_info.get("progress", 0.0)
+            progress_message = (
+                "Exporting format " + model_format + " in progress : " + str(round(progress * 100, 2)) + "%"
+            )
+            sys.stdout.write("\r" + progress_message)
+            sys.stdout.flush()
+            time.sleep(1)
+            export_info = rfapi.get_version_export(
+                api_key=self.__api_key,
+                workspace_url=workspace,
+                project_url=project,
+                version=self.version,
+                format=model_format,
+            )
+        if "export" in export_info:
             sys.stdout.write("\n")
             print("\r" + "Version export complete for " + model_format + " format")
             sys.stdout.flush()
             return True
         else:
-            try:
-                raise RuntimeError(response.json())
-            except json.JSONDecodeError:
-                response.raise_for_status()
+            raise RuntimeError(f"Unexpected export {export_info}")
 
     def train(self, speed=None, model_type=None, checkpoint=None, plot_in_notebook=False) -> InferenceModel:
         """
@@ -326,28 +332,22 @@ class Version:
             self.export(train_model_format)
 
         workspace, project, *_ = self.id.rsplit("/")
-        url = f"{API_URL}/{workspace}/{project}/{self.version}/train"
 
-        data = {}
-
-        if speed:
-            data["speed"] = speed
-
-        if checkpoint:
-            data["checkpoint"] = checkpoint
-
-        if model_type:
-            # API expects camelCase key
-            data["modelType"] = model_type
+        payload_speed = speed if speed else None
+        payload_checkpoint = checkpoint if checkpoint else None
+        payload_model_type = model_type if model_type else None
 
         write_line("Reaching out to Roboflow to start training...")
 
-        response = requests.post(url, json=data, params={"api_key": self.__api_key})
-        if not response.ok:
-            try:
-                raise RuntimeError(response.json())
-            except json.JSONDecodeError:
-                response.raise_for_status()
+        rfapi.start_version_training(
+            api_key=self.__api_key,
+            workspace_url=workspace,
+            project_url=project,
+            version=self.version,
+            speed=payload_speed,
+            checkpoint=payload_checkpoint,
+            model_type=payload_model_type,
+        )
 
         status = "training"
 
@@ -374,10 +374,14 @@ class Version:
         num_machine_spin_dots = []
 
         while status == "training" or status == "running":
-            url = f"{API_URL}/{self.workspace}/{self.project}/{self.version}?nocache=true"
-            response = requests.get(url, params={"api_key": self.__api_key})
-            response.raise_for_status()
-            version = response.json()["version"]
+            version_response = rfapi.get_version(
+                api_key=self.__api_key,
+                workspace_url=self.workspace,
+                project_url=self.project,
+                version=self.version,
+                nocache=True,
+            )
+            version = version_response.get("version", {})
             if "models" in version.keys():
                 models = version["models"]
             else:

--- a/tests/manual/debugme.py
+++ b/tests/manual/debugme.py
@@ -52,18 +52,18 @@ def run_cli():
 def run_api_train():
     rf = Roboflow()
     project = rf.workspace("meh3").project("mosquitobao")
-    # version_number = project.generate_version(
-    #     settings={
-    #         "augmentation": {
-    #             "bbblur": {"pixels": 1.5},
-    #             "image": {"versions": 2},
-    #         },
-    #         "preprocessing": {
-    #             "auto-orient": True,
-    #         },
-    #     }
-    # )
-    version_number = "61"
+    version_number = project.generate_version(
+        settings={
+            "augmentation": {
+                "bbblur": {"pixels": 1.5},
+                "image": {"versions": 2},
+            },
+            "preprocessing": {
+                "auto-orient": True,
+            },
+        }
+    )
+    # version_number = "61"
     print(version_number)
     version = project.version(version_number)
     model = version.train(

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,7 +2,6 @@ import os
 import unittest
 from unittest.mock import patch
 
-import requests
 import responses
 
 from roboflow.adapters import rfapi

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -5,8 +5,18 @@ from unittest.mock import patch
 import requests
 import responses
 
+from roboflow.adapters import rfapi
 from roboflow.core.version import Version, unwrap_version_id
 from tests.helpers import get_version
+
+
+def mock_generating_url_response(generating_url):
+    """Helper function to mock the generating URL response that's repeated across tests."""
+    responses.add(
+        responses.GET,
+        generating_url,
+        json={"version": {"generating": False, "progress": 1.0, "images": 10}},
+    )
 
 
 class TestDownload(unittest.TestCase):
@@ -24,24 +34,15 @@ class TestDownload(unittest.TestCase):
     @responses.activate
     def test_download_raises_exception_on_bad_request(self):
         responses.add(responses.GET, self.api_url, status=404, json={"error": "Broken"})
-        responses.add(
-            responses.GET,
-            self.generating_url,
-            json={"version": {"generating": False, "progress": 1.0}},
-        )
-
-        with self.assertRaises(RuntimeError):
+        mock_generating_url_response(self.generating_url)
+        with self.assertRaises(rfapi.RoboflowError):
             self.version.download("coco")
 
     @responses.activate
     def test_download_raises_exception_on_api_failure(self):
         responses.add(responses.GET, self.api_url, status=500)
-        responses.add(
-            responses.GET,
-            self.generating_url,
-            json={"version": {"generating": False, "progress": 1.0}},
-        )
-        with self.assertRaises(requests.exceptions.HTTPError):
+        mock_generating_url_response(self.generating_url)
+        with self.assertRaises(rfapi.RoboflowError):
             self.version.download("coco")
 
     @responses.activate
@@ -50,11 +51,7 @@ class TestDownload(unittest.TestCase):
     @patch.object(Version, "_Version__reformat_yaml")
     def test_download_returns_dataset(self, *_):
         responses.add(responses.GET, self.api_url, json={"export": {"link": None}})
-        responses.add(
-            responses.GET,
-            self.generating_url,
-            json={"version": {"generating": False, "progress": 1.0}},
-        )
+        mock_generating_url_response(self.generating_url)
         dataset = self.version.download("coco", location="/my-spot")
         self.assertEqual(dataset.name, self.version.name)
         self.assertEqual(dataset.version, self.version.version)
@@ -76,12 +73,13 @@ class TestExport(unittest.TestCase):
 
     @responses.activate
     def test_export_returns_true_on_api_success(self):
-        responses.add(responses.GET, self.api_url, status=200)
         responses.add(
             responses.GET,
-            self.generating_url,
-            json={"version": {"generating": False, "progress": 1.0}},
+            self.api_url,
+            status=200,
+            json={"export": {"link": "https://api.roboflow.com/test-workspace/test-project/4/test-format"}},
         )
+        mock_generating_url_response(self.generating_url)
         export = self.version.export("test-format")
         request = responses.calls[0].request
 
@@ -92,23 +90,15 @@ class TestExport(unittest.TestCase):
     @responses.activate
     def test_export_raises_error_on_bad_request(self):
         responses.add(responses.GET, self.api_url, status=400, json={"error": "BROKEN!!"})
-        responses.add(
-            responses.GET,
-            self.generating_url,
-            json={"version": {"generating": False, "progress": 1.0}},
-        )
-        with self.assertRaises(RuntimeError):
+        mock_generating_url_response(self.generating_url)
+        with self.assertRaises(rfapi.RoboflowError):
             self.version.export("test-format")
 
     @responses.activate
     def test_export_raises_error_on_api_failure(self):
         responses.add(responses.GET, self.api_url, status=500)
-        responses.add(
-            responses.GET,
-            self.generating_url,
-            json={"version": {"generating": False, "progress": 1.0}},
-        )
-        with self.assertRaises(requests.exceptions.HTTPError):
+        mock_generating_url_response(self.generating_url)
+        with self.assertRaises(rfapi.RoboflowError):
             self.version.export("test-format")
 
 
@@ -128,21 +118,13 @@ class TestGetDownloadLocation(unittest.TestCase):
 
     @responses.activate
     def test_get_download_location_with_env_variable(self, *_):
-        responses.add(
-            responses.GET,
-            self.generating_url,
-            json={"version": {"generating": False, "progress": 1.0}},
-        )
+        mock_generating_url_response(self.generating_url)
         with patch.dict(os.environ, {"DATASET_DIRECTORY": "/my/exports"}, clear=True):
             self.assertEqual(self.get_download_location(), "/my/exports/Test-Dataset-3")
 
     @responses.activate
     def test_get_download_location_without_env_variable(self, *_):
-        responses.add(
-            responses.GET,
-            self.generating_url,
-            json={"version": {"generating": False, "progress": 1.0}},
-        )
+        mock_generating_url_response(self.generating_url)
         self.assertEqual(self.get_download_location(), "Test-Dataset-3")
 
 
@@ -161,11 +143,7 @@ class TestGetDownloadURL(unittest.TestCase):
 
     @responses.activate
     def test_get_download_url(self):
-        responses.add(
-            responses.GET,
-            self.generating_url,
-            json={"version": {"generating": False, "progress": 1.0}},
-        )
+        mock_generating_url_response(self.generating_url)
         url = self.get_download_url("yolo1337")
         self.assertEqual(url, "https://api.roboflow.com/test-workspace/test-project/3/yolo1337")
 


### PR DESCRIPTION
# Description

The devx for training over the API was very broken. A simple snippet like below doesn't work. 
Nick uncovered this bug because Pella was bitten. [Slack thread](https://roboflow.slack.com/archives/C06TQCCTH41/p1754422279823959?thread_ts=1754413219.026309&cid=C06TQCCTH41)

This is one of those cases that just to debug, I had had to refactor first.

What actually solved the bug is:
* adding nocache=true to api calls
* waiting for version to have generating=False AND images>0 to consider it generated. Otherwise you can run into a very likely racing condition where the train endpoint finds a version that still looks empty.

```python
    rf = Roboflow()
    project = rf.workspace("meh3").project("mosquitobao")
    version_number = project.generate_version(
        settings={
            "augmentation": {
                "bbblur": {"pixels": 1.5},
                "image": {"versions": 2},
            },
            "preprocessing": {
                "auto-orient": True,
            },
        }
    )
    # version_number = "61"
    print(version_number)
    version = project.version(version_number)
    model = version.train(
        speed="fast",  # Options: "fast" (default) or "accurate" (paid feature)
        checkpoint=None,  # Use a specific checkpoint to continue training
    )
    print(model)
```

## Type of change

- [x] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)
- [x] Bugfix 

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Tested locally with the `debugme.py` file

