### PR TITLE
Create `Project` object local instead of call API after create project

### DIFF
--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -123,7 +123,7 @@ class Workspace:
         if "error" in r.json().keys():
             raise RuntimeError(r.json()["error"])
 
-        return self.project(r.json()["id"].split("/")[-1])
+        return Project(self.__api_key, r.json(), self.model_format)
 
     def clip_compare(self, dir: str = "", image_ext: str = ".png", target_image: str = "") -> List[dict]:
         """


### PR DESCRIPTION
# Description

We first try to get the project, then create a new project if it doesn't exist and after creating we get the project again.

With this change, we use the project returned after creation.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
