### PR TITLE
Add are_predictions flag to dataset upload

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -15,7 +15,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.2.7"
+__version__ = "1.2.8"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -287,7 +287,7 @@ class Workspace:
         project_type: str = "object-detection",
         batch_name=None,
         num_retries=0,
-        are_predictions=False,
+        is_prediction=False,
     ):
         """
         Upload a dataset to Roboflow.
@@ -301,7 +301,7 @@ class Workspace:
             project_type (str): type of the project (only `object-detection` is supported)
             batch_name (str, optional): name of the batch to upload the images to. Defaults to an automatically generated value.
             num_retries (int, optional): number of times to retry uploading an image if the upload fails. Defaults to 0.
-            are_predictions (bool, optional): whether the annotations provided in the dataset are predictions and not ground truth. Defaults to False.
+            is_prediction (bool, optional): whether the annotations provided in the dataset are predictions and not ground truth. Defaults to False.
         """  # noqa: E501 // docs
         if dataset_format != "NOT_USED":
             print("Warning: parameter 'dataset_format' is deprecated and will be removed in a future release")
@@ -356,7 +356,7 @@ class Workspace:
                 sequence_number=imagedesc.get("index"),
                 sequence_size=len(images),
                 num_retry_uploads=num_retries,
-                is_prediction=are_predictions,
+                is_prediction=is_prediction,
             )
 
             return image, upload_time, upload_retry_attempts

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -287,6 +287,7 @@ class Workspace:
         project_type: str = "object-detection",
         batch_name=None,
         num_retries=0,
+        are_predictions=False,
     ):
         """
         Upload a dataset to Roboflow.
@@ -298,6 +299,9 @@ class Workspace:
             dataset_format (str): format of the dataset (`voc`, `yolov8`, `yolov5`)
             project_license (str): license of the project (set to `private` for private projects, only available for paid customers)
             project_type (str): type of the project (only `object-detection` is supported)
+            batch_name (str, optional): name of the batch to upload the images to. Defaults to an automatically generated value.
+            num_retries (int, optional): number of times to retry uploading an image if the upload fails. Defaults to 0.
+            are_predictions (bool, optional): whether the annotations provided in the dataset are predictions and not ground truth. Defaults to False.
         """  # noqa: E501 // docs
         if dataset_format != "NOT_USED":
             print("Warning: parameter 'dataset_format' is deprecated and will be removed in a future release")
@@ -352,6 +356,7 @@ class Workspace:
                 sequence_number=imagedesc.get("index"),
                 sequence_size=len(images),
                 num_retry_uploads=num_retries,
+                is_prediction=are_predictions,
             )
 
             return image, upload_time, upload_retry_attempts

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -379,7 +379,7 @@ class TestProject(RoboflowTest):
                     {"file": "pred1.jpg", "split": "train", "annotationfile": {"file": "pred1.xml"}},
                     {"file": "pred2.jpg", "split": "valid", "annotationfile": {"file": "pred2.xml"}},
                 ],
-                "params": {"are_predictions": True},
+                "params": {"is_prediction": True},
                 "assertions": {
                     "upload": {"count": 2, "kwargs": {"is_prediction": True}},
                     "save_annotation": {"count": 2},
@@ -390,7 +390,7 @@ class TestProject(RoboflowTest):
                 "dataset": [
                     {"file": "gt1.jpg", "split": "train", "annotationfile": {"file": "gt1.xml"}},
                 ],
-                "params": {"are_predictions": False},
+                "params": {"is_prediction": False},
                 "assertions": {
                     "upload": {"count": 1, "kwargs": {"is_prediction": False}},
                     "save_annotation": {"count": 1},
@@ -402,7 +402,7 @@ class TestProject(RoboflowTest):
                     {"file": "batch_pred.jpg", "split": "train", "annotationfile": {"file": "batch_pred.xml"}},
                 ],
                 "params": {
-                    "are_predictions": True,
+                    "is_prediction": True,
                     "batch_name": "prediction-batch",
                     "num_retries": 2,
                 },

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -373,6 +373,50 @@ class TestProject(RoboflowTest):
                 "params": {},
                 "assertions": {"save_annotation": {"count": 1}},
             },
+            {
+                "name": "with_predictions_flag_true",
+                "dataset": [
+                    {"file": "pred1.jpg", "split": "train", "annotationfile": {"file": "pred1.xml"}},
+                    {"file": "pred2.jpg", "split": "valid", "annotationfile": {"file": "pred2.xml"}},
+                ],
+                "params": {"are_predictions": True},
+                "assertions": {
+                    "upload": {"count": 2, "kwargs": {"is_prediction": True}},
+                    "save_annotation": {"count": 2},
+                },
+            },
+            {
+                "name": "with_predictions_flag_false",
+                "dataset": [
+                    {"file": "gt1.jpg", "split": "train", "annotationfile": {"file": "gt1.xml"}},
+                ],
+                "params": {"are_predictions": False},
+                "assertions": {
+                    "upload": {"count": 1, "kwargs": {"is_prediction": False}},
+                    "save_annotation": {"count": 1},
+                },
+            },
+            {
+                "name": "predictions_with_batch",
+                "dataset": [
+                    {"file": "batch_pred.jpg", "split": "train", "annotationfile": {"file": "batch_pred.xml"}},
+                ],
+                "params": {
+                    "are_predictions": True,
+                    "batch_name": "prediction-batch",
+                    "num_retries": 2,
+                },
+                "assertions": {
+                    "upload": {
+                        "count": 1,
+                        "kwargs": {
+                            "is_prediction": True,
+                            "batch_name": "prediction-batch",
+                            "num_retry_uploads": 2,
+                        },
+                    },
+                },
+            },
         ]
 
         error_cases = [


### PR DESCRIPTION
# Description

This flag allows dataset uploads to be sent as predictions (not automatically added to the dataset).



## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Unit tests cover this case

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   will need to update [relevant documentation](https://docs.roboflow.com/developer/upload-a-dataset)
