### PR TITLE
fix is_prediction function call

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -15,7 +15,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.2.8"
+__version__ = "1.2.9"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -356,7 +356,6 @@ class Workspace:
                 sequence_number=imagedesc.get("index"),
                 sequence_size=len(images),
                 num_retry_uploads=num_retries,
-                is_prediction=is_prediction,
             )
 
             return image, upload_time, upload_retry_attempts
@@ -390,6 +389,7 @@ class Workspace:
                 image_id=image_id,
                 job_name=batch_name,
                 num_retry_uploads=num_retries,
+                is_prediction=is_prediction,
             )
 
             return annotation, upload_time

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -381,8 +381,8 @@ class TestProject(RoboflowTest):
                 ],
                 "params": {"is_prediction": True},
                 "assertions": {
-                    "upload": {"count": 2, "kwargs": {"is_prediction": True}},
-                    "save_annotation": {"count": 2},
+                    "upload": {"count": 2},
+                    "save_annotation": {"count": 2, "kwargs": {"is_prediction": True}},
                 },
             },
             {
@@ -392,8 +392,8 @@ class TestProject(RoboflowTest):
                 ],
                 "params": {"is_prediction": False},
                 "assertions": {
-                    "upload": {"count": 1, "kwargs": {"is_prediction": False}},
-                    "save_annotation": {"count": 1},
+                    "upload": {"count": 1},
+                    "save_annotation": {"count": 1, "kwargs": {"is_prediction": False}},
                 },
             },
             {
@@ -410,8 +410,15 @@ class TestProject(RoboflowTest):
                     "upload": {
                         "count": 1,
                         "kwargs": {
-                            "is_prediction": True,
                             "batch_name": "prediction-batch",
+                            "num_retry_uploads": 2,
+                        },
+                    },
+                    "save_annotation": {
+                        "count": 1,
+                        "kwargs": {
+                            "is_prediction": True,
+                            "job_name": "prediction-batch",
                             "num_retry_uploads": 2,
                         },
                     },


### PR DESCRIPTION
# Description

The `is_prediction` flag was not being passed to the correct function call, and thus was ignored. This correctly adds it to the `save_annotation` function call where it will be used downstream.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Unit tests

## Any specific deployment considerations

standard deploy 

## Docs

-   n/a
