### PR TITLE
Add 'rfdetr-seg-preview' to supported model types

### DIFF
--- a/roboflow/util/model_processor.py
+++ b/roboflow/util/model_processor.py
@@ -226,7 +226,14 @@ def _process_yolo(model_type: str, model_path: str, filename: str) -> str:
 
 
 def _process_rfdetr(model_type: str, model_path: str, filename: str) -> str:
-    _supported_types = ["rfdetr-base", "rfdetr-large", "rfdetr-nano", "rfdetr-small", "rfdetr-medium", "rfdetr-seg-preview"]
+    _supported_types = [
+        "rfdetr-base",
+        "rfdetr-large",
+        "rfdetr-nano",
+        "rfdetr-small",
+        "rfdetr-medium",
+        "rfdetr-seg-preview",
+    ]
     if model_type not in _supported_types:
         raise ValueError(f"Model type {model_type} not supported. Supported types are {_supported_types}")
 


### PR DESCRIPTION
# Description

This PR adds `rfdetr-seg-preview` to the supported RF-DETR model weights upload list.

## Type of change

New feature

## How has this change been tested, please provide a testcase or example of how you tested the change?

Testing now

## Any specific deployment considerations

We will need to release a new version of the Python package.

## Docs

N/A