### PR TITLE
Add `rfdetr-seg-preview` to supported models to upload

### DIFF
--- a/roboflow/util/model_processor.py
+++ b/roboflow/util/model_processor.py
@@ -226,7 +226,7 @@ def _process_yolo(model_type: str, model_path: str, filename: str) -> str:
 
 
 def _process_rfdetr(model_type: str, model_path: str, filename: str) -> str:
-    _supported_types = ["rfdetr-base", "rfdetr-large", "rfdetr-nano", "rfdetr-small", "rfdetr-medium"]
+    _supported_types = ["rfdetr-base", "rfdetr-large", "rfdetr-nano", "rfdetr-small", "rfdetr-medium", "rfdetr-seg-preview"]
     if model_type not in _supported_types:
         raise ValueError(f"Model type {model_type} not supported. Supported types are {_supported_types}")
 

--- a/roboflow/util/model_processor.py
+++ b/roboflow/util/model_processor.py
@@ -226,7 +226,14 @@ def _process_yolo(model_type: str, model_path: str, filename: str) -> str:
 
 
 def _process_rfdetr(model_type: str, model_path: str, filename: str) -> str:
-    _supported_types = ["rfdetr-base", "rfdetr-large", "rfdetr-nano", "rfdetr-small", "rfdetr-medium", "rfdetr-seg-preview"]
+    _supported_types = [
+        "rfdetr-base",
+        "rfdetr-large",
+        "rfdetr-nano",
+        "rfdetr-small",
+        "rfdetr-medium",
+        "rfdetr-seg-preview",
+    ]
     if model_type not in _supported_types:
         raise ValueError(f"Model type {model_type} not supported. Supported types are {_supported_types}")
 


### PR DESCRIPTION
# Description

Add `rfdetr-seg-preview` to supported models to upload.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `rfdetr-seg-preview` to the supported `rfdetr` model types in `roboflow/util/model_processor._process_rfdetr`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a11e6bcd2d8cd7e0c1395805ef2332e5581762f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->