### PR TITLE
Bump version to 1.2.10

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -15,7 +15,7 @@ from roboflow.core.workspace import Workspace
 from roboflow.models import CLIPModel, GazeModel  # noqa: F401
 from roboflow.util.general import write_line
 
-__version__ = "1.2.9"
+__version__ = "1.2.10"
 
 
 def check_key(api_key, model, notebook, num_retries=0):


### PR DESCRIPTION
# Description

Forgot version bump in #414.

## Type of change

-   [x] Maintenance

## How has this change been tested, please provide a testcase or example of how you tested the change?

🤷🏻 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps package version in `roboflow/__init__.py` from `1.2.9` to `1.2.10`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3db06687e53f58c0c46e1fec5a8e6e94bc5498d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->