### PR TITLE
Bump version to 1.3.2

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -21,7 +21,7 @@ except ImportError:
     CLIPModel = None  # type: ignore[assignment,misc]
     GazeModel = None  # type: ignore[assignment,misc]
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 
 def check_key(api_key, model, notebook, num_retries=0):


### PR DESCRIPTION
## Summary
- Bumps package version from 1.3.1 to 1.3.2 in `roboflow/__init__.py`

## Test plan
- [ ] Verify `roboflow.__version__` reports `1.3.2`
- [ ] Verify `setup.py` picks up the new version correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)