### PR TITLE
Switch to trusted publishing (OIDC) for PyPI releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
@@ -20,17 +23,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ".[dev]"
-      - name: 🚀 Publish to PyPi
-        env:
-          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-          PYPI_TEST_PASSWORD: ${{ secrets.PYPI_TEST_PASSWORD }}
-        run: |
-          make publish -e PYPI_USERNAME=$PYPI_USERNAME -e PYPI_PASSWORD=$PYPI_PASSWORD -e PYPI_TEST_PASSWORD=$PYPI_TEST_PASSWORD
+      - name: 📦 Build package
+        run: python setup.py sdist bdist_wheel
+      - name: 🚀 Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   build-slim:
     needs: build
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
@@ -44,12 +47,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ".[dev]"
-      - name: 🚀 Publish roboflow-slim to PyPi
-        env:
-          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      - name: 📦 Build slim package
         run: |
-          make publish-slim -e PYPI_USERNAME=$PYPI_USERNAME -e PYPI_PASSWORD=$PYPI_PASSWORD
+          rm -rf dist/ build/ *.egg-info
+          python setup_slim.py sdist bdist_wheel
+      - name: 🚀 Publish roboflow-slim to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   deploy-docs:
     needs: build


### PR DESCRIPTION
## Summary
- Replaces twine-based publishing with `pypa/gh-action-pypi-publish` for both `roboflow` and `roboflow-slim` packages
- Uses GitHub OIDC tokens instead of stored `PYPI_USERNAME`/`PYPI_PASSWORD` secrets
- Adds `environment: pypi` and `permissions: id-token: write` to both build jobs

## Prerequisites
Before merging, two admin steps are needed on PyPI/GitHub:
1. Register trusted publishers on pypi.org for both `roboflow` and `roboflow-slim`
2. Create a `pypi` GitHub environment in the repo settings

## Test plan
- [ ] Verify the `pypi` GitHub environment exists in repo settings
- [ ] Confirm trusted publishers are registered on PyPI for both packages
- [ ] Trigger a test release and verify both packages publish successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)