### PR TITLE
Remove direct publishing via twine (ENT-1128)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: style check_code_quality publish publish-slim
+.PHONY: style check_code_quality
 
 export PYTHONPATH = .
 check_dirs := roboflow
@@ -11,14 +11,3 @@ check_code_quality:
 	ruff format $(check_dirs) --check
 	ruff check $(check_dirs)
 	mypy $(check_dirs)
-
-publish:
-	python setup.py sdist bdist_wheel
-	twine check dist/*
-	twine upload dist/* -u ${PYPI_USERNAME} -p ${PYPI_PASSWORD} --verbose
-
-publish-slim:
-	rm -rf dist/ build/ *.egg-info
-	python setup_slim.py sdist bdist_wheel
-	twine check dist/*
-	twine upload dist/* -u ${PYPI_USERNAME} -p ${PYPI_PASSWORD} --verbose

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setuptools.setup(
             "mypy",
             "responses",
             "ruff",
-            "twine",
             "types-pyyaml",
             "types-requests",
             "types-setuptools",

--- a/setup_slim.py
+++ b/setup_slim.py
@@ -32,7 +32,6 @@ setuptools.setup(
             "mypy",
             "responses",
             "ruff",
-            "twine",
             "types-pyyaml",
             "types-requests",
             "types-setuptools",


### PR DESCRIPTION
## Summary
- Remove `publish` and `publish-slim` Makefile targets that invoked `twine upload` with `PYPI_USERNAME`/`PYPI_PASSWORD`.
- Drop `twine` from the `dev` extras in `setup.py` and `setup_slim.py` since nothing invokes it anymore.
- GitHub Actions (trusted publishing via `pypa/gh-action-pypi-publish` in `.github/workflows/publish.yml`) is now the only path to PyPI.

Linear: [ENT-1128](https://linear.app/roboflow/issue/ENT-1128/remove-direct-publishing-of-roboflow-python-via-twine)

## Test plan
- [ ] Confirm CI (which only calls `make check_code_quality`) still passes.
- [ ] On next release, confirm `publish.yml` still publishes both `roboflow` and `roboflow-slim` to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)