### PR TITLE
bump version to 1.3.5

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -21,7 +21,7 @@ except ImportError:
     CLIPModel = None  # type: ignore[assignment,misc]
     GazeModel = None  # type: ignore[assignment,misc]
 
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 
 
 def check_key(api_key, model, notebook, num_retries=0):


### PR DESCRIPTION
Bumps `__version__` to 1.3.5 so we can cut a release including the text-image-pairs (VLM) hosted inference support from #461.

## Test plan
- [x] `__version__` updated in `roboflow/__init__.py`
- [ ] Merge, then cut `v1.3.5` release to trigger PyPI + docs publish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the package `__version__` constant and does not change runtime behavior.
> 
> **Overview**
> Bumps the library version in `roboflow/__init__.py` from `1.3.4` to `1.3.5` to cut a new release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf983e1439ea15171dbc5581f5eb1f9f72fc8394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->