### PR TITLE
fix: upload original image bytes instead of re-encoding to JPEG (ENT-1169)

### DIFF
--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -1,4 +1,5 @@
 import json
+import mimetypes
 import os
 import urllib
 from typing import Dict, List, Optional, Union
@@ -293,10 +294,10 @@ def upload_image(
 
     # If image is not a hosted image
     if not hosted_image:
-        from roboflow.util import image_utils
-
         image_name = os.path.basename(image_path)
-        imgjpeg = image_utils.file2jpeg(image_path)
+        with open(image_path, "rb") as fh:
+            image_bytes = fh.read()
+        content_type = mimetypes.guess_type(image_path)[0] or "application/octet-stream"
 
         upload_url = _local_upload_url(
             api_key, project_url, coalesced_batch_name, tag_names, sequence_number, sequence_size, kwargs
@@ -304,7 +305,7 @@ def upload_image(
         fields = {
             "name": image_name,
             "split": split,
-            "file": ("imageToUpload", imgjpeg, "image/jpeg"),
+            "file": (image_name, image_bytes, content_type),
         }
         if metadata is not None:
             fields["metadata"] = json.dumps(metadata)

--- a/tests/test_rfapi.py
+++ b/tests/test_rfapi.py
@@ -2,7 +2,7 @@ import json
 import os
 import unittest
 import urllib
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 import responses
 
@@ -22,10 +22,8 @@ class TestUploadImage(unittest.TestCase):
     IMAGE_NAME_HOSTED = os.path.basename(IMAGE_PATH_HOSTED)
 
     @responses.activate
-    @patch("roboflow.util.image_utils.file2jpeg")
-    def test_upload_image_local(self, mock_file2jpeg):
-        mock_file2jpeg.return_value = b"image_data"
-
+    @patch("roboflow.adapters.rfapi.open", new_callable=mock_open, read_data=b"image_data")
+    def test_upload_image_local(self, _mock_file):
         scenarios = [
             {
                 "desc": "with batch_name",
@@ -123,10 +121,8 @@ class TestUploadImage(unittest.TestCase):
                 self.assertTrue(result["success"], msg=f"Failed in scenario: {scenario['desc']}")
 
     @responses.activate
-    @patch("roboflow.util.image_utils.file2jpeg")
-    def test_upload_image_local_with_metadata(self, mock_file2jpeg):
-        mock_file2jpeg.return_value = b"image_data"
-
+    @patch("roboflow.adapters.rfapi.open", new_callable=mock_open, read_data=b"image_data")
+    def test_upload_image_local_with_metadata(self, _mock_file):
         metadata = {"camera_id": "cam001", "location": "warehouse"}
         expected_url = (
             f"{API_URL}/dataset/{self.PROJECT_URL}/upload?"
@@ -171,6 +167,32 @@ class TestUploadImage(unittest.TestCase):
             metadata=metadata,
         )
         self.assertTrue(result["success"])
+
+    @responses.activate
+    def test_upload_image_local_uploads_original_bytes(self):
+        """Server-side dedup relies on the SDK uploading the file bytes exactly as-is."""
+        import tempfile
+
+        raw_bytes = b"\x89PNG\r\n\x1a\nfake-png-bytes-not-decodable-as-jpeg"
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tf:
+            tf.write(raw_bytes)
+            tmp_path = tf.name
+
+        try:
+            expected_url = (
+                f"{API_URL}/dataset/{self.PROJECT_URL}/upload?"
+                f"api_key={self.API_KEY}&batch={urllib.parse.quote_plus(DEFAULT_BATCH_NAME)}"
+            )
+            responses.add(responses.POST, expected_url, json={"success": True}, status=200)
+
+            result = upload_image(self.API_KEY, self.PROJECT_URL, tmp_path)
+            self.assertTrue(result["success"])
+
+            request_body = responses.calls[0].request.body
+            self.assertIn(raw_bytes, request_body)
+            self.assertIn(b"image/png", request_body)
+        finally:
+            os.unlink(tmp_path)
 
     def _reset_responses(self):
         responses.reset()


### PR DESCRIPTION
## Summary
- The SDK was decoding every local upload through Pillow and re-encoding as JPEG, so identical files uploaded via the SDK and the Web UI produced different bytes and bypassed server-side SHA-256 dedup (CS-195).
- ``upload_image`` in ``roboflow/adapters/rfapi.py`` now reads the file from disk and posts the bytes as-is, with Content-Type guessed from the filename via ``mimetypes.guess_type()`` (fallback ``application/octet-stream``).
- ``file2jpeg`` is no longer called from the upload path; it remains in ``roboflow/util/image_utils.py`` since it is a public utility.
- Existing tests updated to mock ``open`` instead of ``file2jpeg``; added ``test_upload_image_local_uploads_original_bytes`` as a regression guard that writes non-JPEG bytes to a ``.png`` and asserts they appear unchanged in the multipart body.

## Test plan
- [x] ``python -m unittest`` (468 passed)
- [x] ``ruff check`` / ``ruff format --check`` clean
- [x] ``mypy roboflow`` clean
- [x] **End-to-end byte round-trip against api.roboflow.com.** Uploaded JPG, WEBP, PNG, and HEIC files via ``project.upload_image()``, then re-fetched each from the server's ``urls.original`` and compared SHA-256s.

| Format | Bytes | sha256 local | sha256 round-trip | Result |
|---|---|---|---|---|
| JPG | 298,985 | ``15803e514ed0…`` | ``15803e514ed0…`` | match |
| WEBP | 19,294 | ``46e2e6be5eb2…`` | ``46e2e6be5eb2…`` | match |
| PNG | 73,727 | ``cda9c4be8981…`` | ``cda9c4be8981…`` | match |
| HEIC | 3,055,844 | ``8fcd5d080780…`` | ``8fcd5d080780…`` | match |

  - On a re-upload of each file, the API responded with ``'duplicate': True`` — directly confirming that server-side SHA-256 dedup now recognizes SDK uploads, which was the failure mode in CS-195.
  - The server stores all files under ``original.jpg`` URLs, but the bytes served back are the unmodified WEBP/PNG/HEIC, ruling out a server-side re-encode masking the test.

Linear: ENT-1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)