### PR TITLE
Preserve original image bytes on SDK upload

### DIFF
--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -1,4 +1,5 @@
 import json
+import mimetypes
 import os
 import urllib
 from typing import Dict, List, Optional, Union
@@ -293,10 +294,11 @@ def upload_image(
 
     # If image is not a hosted image
     if not hosted_image:
-        from roboflow.util import image_utils
-
         image_name = os.path.basename(image_path)
-        imgjpeg = image_utils.file2jpeg(image_path)
+        content_type = mimetypes.guess_type(image_path)[0] or "application/octet-stream"
+
+        with open(image_path, "rb") as image_file:
+            image_bytes = image_file.read()
 
         upload_url = _local_upload_url(
             api_key, project_url, coalesced_batch_name, tag_names, sequence_number, sequence_size, kwargs
@@ -304,7 +306,7 @@ def upload_image(
         fields = {
             "name": image_name,
             "split": split,
-            "file": ("imageToUpload", imgjpeg, "image/jpeg"),
+            "file": (image_name, image_bytes, content_type),
         }
         if metadata is not None:
             fields["metadata"] = json.dumps(metadata)

--- a/tests/test_rfapi.py
+++ b/tests/test_rfapi.py
@@ -2,7 +2,7 @@ import json
 import os
 import unittest
 import urllib
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 import responses
 
@@ -18,14 +18,13 @@ class TestUploadImage(unittest.TestCase):
     TAG_NAMES_LOCAL = ["lonely-tag"]
     TAG_NAMES_HOSTED = ["tag1", "tag2"]
     IMAGE_PATH_LOCAL = "test_image.jpg"
+    IMAGE_PATH_LOCAL_PNG = "test_image.png"
     IMAGE_PATH_HOSTED = "http://example.com/test_image.jpg"
     IMAGE_NAME_HOSTED = os.path.basename(IMAGE_PATH_HOSTED)
 
     @responses.activate
-    @patch("roboflow.util.image_utils.file2jpeg")
-    def test_upload_image_local(self, mock_file2jpeg):
-        mock_file2jpeg.return_value = b"image_data"
-
+    @patch("roboflow.adapters.rfapi.open", new_callable=mock_open, read_data=b"image_data", create=True)
+    def test_upload_image_local(self, mock_image_file):
         scenarios = [
             {
                 "desc": "with batch_name",
@@ -71,6 +70,10 @@ class TestUploadImage(unittest.TestCase):
 
                 result = upload_image(self.API_KEY, self.PROJECT_URL, self.IMAGE_PATH_LOCAL, **upload_image_payload)
                 self.assertTrue(result["success"], msg=f"Failed in scenario: {scenario['desc']}")
+                self.assertIn(b"image_data", responses.calls[0].request.body)
+                self.assertIn(b"Content-Type: image/jpeg", responses.calls[0].request.body)
+
+        self.assertEqual(mock_image_file.call_count, len(scenarios))
 
     @responses.activate
     def test_upload_image_hosted(self):
@@ -123,10 +126,8 @@ class TestUploadImage(unittest.TestCase):
                 self.assertTrue(result["success"], msg=f"Failed in scenario: {scenario['desc']}")
 
     @responses.activate
-    @patch("roboflow.util.image_utils.file2jpeg")
-    def test_upload_image_local_with_metadata(self, mock_file2jpeg):
-        mock_file2jpeg.return_value = b"image_data"
-
+    @patch("roboflow.adapters.rfapi.open", new_callable=mock_open, read_data=b"image_data", create=True)
+    def test_upload_image_local_with_metadata(self, mock_image_file):
         metadata = {"camera_id": "cam001", "location": "warehouse"}
         expected_url = (
             f"{API_URL}/dataset/{self.PROJECT_URL}/upload?"
@@ -143,11 +144,30 @@ class TestUploadImage(unittest.TestCase):
             metadata=metadata,
         )
         self.assertTrue(result["success"])
+        mock_image_file.assert_called_once_with(self.IMAGE_PATH_LOCAL, "rb")
 
         # Verify metadata was sent as a multipart field
         request_body = responses.calls[0].request.body
         self.assertIn(b'"camera_id"', request_body)
         self.assertIn(b'"warehouse"', request_body)
+
+    @responses.activate
+    @patch("roboflow.adapters.rfapi.open", new_callable=mock_open, read_data=b"png_image_data", create=True)
+    def test_upload_image_local_preserves_original_file_type(self, mock_image_file):
+        expected_url = (
+            f"{API_URL}/dataset/{self.PROJECT_URL}/upload?"
+            f"api_key={self.API_KEY}&batch={urllib.parse.quote_plus(DEFAULT_BATCH_NAME)}"
+        )
+        responses.add(responses.POST, expected_url, json={"success": True}, status=200)
+
+        result = upload_image(self.API_KEY, self.PROJECT_URL, self.IMAGE_PATH_LOCAL_PNG)
+
+        self.assertTrue(result["success"])
+        mock_image_file.assert_called_once_with(self.IMAGE_PATH_LOCAL_PNG, "rb")
+        request_body = responses.calls[0].request.body
+        self.assertIn(b"png_image_data", request_body)
+        self.assertIn(b'filename="test_image.png"', request_body)
+        self.assertIn(b"Content-Type: image/png", request_body)
 
     @responses.activate
     def test_upload_image_hosted_with_metadata(self):


### PR DESCRIPTION
# Description

Preserve original local image uploads in the Python SDK instead of re-encoding every file to JPEG client-side. This delegates upload format handling to the API and aligns SDK behavior with Web UI uploads, so duplicate detection sees the same original bytes for images like PNGs uploaded through either path.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added rfapi coverage that verifies PNG uploads keep their original filename, bytes, and `image/png` content type.
- Ran `/tmp/roboflow-python-test-venv/bin/python -m unittest tests.test_rfapi`.
- Ran `/tmp/roboflow-python-test-venv/bin/ruff check roboflow/adapters/rfapi.py tests/test_rfapi.py`.
- Ran `/tmp/roboflow-python-test-venv/bin/ruff format --check roboflow/adapters/rfapi.py tests/test_rfapi.py`.
- Ran `git diff --check`.

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- Python SDK release only.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-the-wire format of local uploads (filename/bytes/content-type), which could affect backend parsing or duplicate detection behavior for existing clients. Test coverage was updated to validate multipart contents for JPEG and PNG cases.
> 
> **Overview**
> Local `upload_image` no longer converts files to JPEG before upload; it now reads the original file bytes and sends them as multipart with `mimetypes`-inferred `Content-Type` (falling back to `application/octet-stream`).
> 
> Tests were updated to mock file reads instead of `image_utils.file2jpeg`, and add coverage asserting PNG uploads preserve filename, raw bytes, and `image/png` content type, plus basic multipart assertions for JPG uploads and metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63373d65a1e6cda270fe9b5f8c313dc4af459161. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->