### PR TITLE
bump version to 1.3.6

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -21,7 +21,7 @@ except ImportError:
     CLIPModel = None  # type: ignore[assignment,misc]
     GazeModel = None  # type: ignore[assignment,misc]
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"
 
 
 def check_key(api_key, model, notebook, num_retries=0):


### PR DESCRIPTION
Bumps `__version__` to `1.3.6`.

After merge, draft a GitHub Release with tag `v1.3.6` to trigger PyPI publish (roboflow + roboflow-slim) and docs deploy via `.github/workflows/publish.yml`.