### PR TITLE
CLI: polish three rough edges from the 1.3.7 prod shake-down

### DIFF
--- a/roboflow/adapters/devicesapi.py
+++ b/roboflow/adapters/devicesapi.py
@@ -38,8 +38,7 @@ class DeviceApiError(RoboflowError):
     """Raised when a device API call returns a non-success status."""
 
     def __init__(self, message: str, status_code: Optional[int] = None) -> None:
-        self.status_code = status_code
-        super().__init__(message)
+        super().__init__(message, status_code=status_code)
 
 
 class DeviceNotFoundError(DeviceApiError):

--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -12,7 +12,18 @@ from roboflow.config import API_URL, DEFAULT_BATCH_NAME, DEFAULT_JOB_NAME
 
 
 class RoboflowError(Exception):
-    pass
+    """Generic API error.
+
+    Optional `status_code` is the HTTP status from the upstream response
+    when available — set by helpers like `_raise_for_trash_response` so
+    callers can branch on auth (401) vs not-found (404) without string
+    matching the message. Existing call sites that pass only a message
+    still work; the attribute defaults to `None`.
+    """
+
+    def __init__(self, message, status_code=None):
+        super().__init__(message)
+        self.status_code = status_code
 
 
 class ImageUploadError(RoboflowError):
@@ -911,8 +922,11 @@ def _raise_for_trash_response(response):
     error messages are agent-friendly. Falls back to the raw text if the
     body isn't JSON or doesn't contain an `error` field.
 
-    The single `raise` at the end means we can't accidentally swallow the
-    intended error if a future refactor widens the except clause.
+    Carries the HTTP status code on the raised exception so callers (e.g.
+    the CLI) can map auth failures (401) to the right exit code without
+    string-matching. The single `raise` at the end means we can't
+    accidentally swallow the intended error if a future refactor widens
+    the except clause.
     """
     msg = None
     try:
@@ -922,7 +936,7 @@ def _raise_for_trash_response(response):
     except ValueError:
         # Body wasn't JSON — fall through to response.text.
         pass
-    raise RoboflowError(msg or response.text)
+    raise RoboflowError(msg or response.text, status_code=response.status_code)
 
 
 def delete_project(api_key, workspace_url, project_url):

--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -29,17 +29,15 @@ class RoboflowError(Exception):
 class ImageUploadError(RoboflowError):
     def __init__(self, message, status_code=None):
         self.message = message
-        self.status_code = status_code
         self.retries = 0
-        super().__init__(self.message)
+        super().__init__(self.message, status_code=status_code)
 
 
 class AnnotationSaveError(RoboflowError):
     def __init__(self, message, status_code=None):
         self.message = message
-        self.status_code = status_code
         self.retries = 0
-        super().__init__(self.message)
+        super().__init__(self.message, status_code=status_code)
 
 
 def get_workspace(api_key, workspace_url):

--- a/roboflow/cli/_output.py
+++ b/roboflow/cli/_output.py
@@ -176,6 +176,93 @@ def output_error(
     sys.exit(exit_code)
 
 
+def confirm_destructive(args: Any, prompt: str) -> bool:
+    """Gate a destructive action on either ``--yes`` or an interactive TTY confirmation.
+
+    Returns ``True`` if the action is approved (caller should proceed) or
+    ``False`` if the user declined at the prompt (caller should bail
+    cleanly via ``output(args, {"cancelled": True}, ...)``).
+
+    Calls ``output_error`` and exits with code 1 when *no* TTY is available
+    and ``--yes`` wasn't passed, rather than prompting on a closed stdin
+    (which would either hang or — worse — silently default to a permissive
+    behavior).
+
+    The previous logic gated on ``--json`` ("if --json is set, skip the
+    prompt") which conflated *output formatting* with *destructive intent*.
+    Anyone piping ``roboflow project delete X --json`` into ``jq`` for
+    parsing got their project nuked without any confirmation. Now ``--json``
+    is purely a formatting flag; the kill-switch is ``--yes``/``-y``.
+    """
+    if getattr(args, "yes", False):
+        return True
+
+    # Either explicit `--yes` is required or we need an interactive TTY to
+    # ask. typer.confirm() reads from stdin; if stdin is closed (CI, piped
+    # input, agent) we'd hang — bail with a useful hint instead.
+    if not sys.stdin.isatty():
+        output_error(
+            args,
+            "This is a destructive action and requires confirmation.",
+            hint=(
+                "Re-run with --yes / -y to confirm, or run interactively. "
+                "(--json is a formatting flag and does not bypass this.)"
+            ),
+            exit_code=1,
+        )
+        return False  # unreachable: output_error sys.exits
+
+    import typer
+
+    confirmed = typer.confirm(prompt, default=False)
+    if not confirmed:
+        # Caller renders the cancelled state.
+        output(args, {"cancelled": True}, text="Cancelled.")
+    return confirmed
+
+
+def output_api_error(
+    args: Any,
+    exc: Exception,
+    *,
+    hint: Optional[str] = None,
+    auth_hint: Optional[str] = None,
+    not_found_hint: Optional[str] = None,
+) -> None:
+    """Render a server-side error and exit with the correct code.
+
+    Maps an exception's HTTP status (carried as ``exc.status_code`` when the
+    raiser sets it — see ``_raise_for_trash_response`` in ``adapters.rfapi``)
+    to the per-CONTRIBUTING.md exit-code contract:
+
+    * **401** → exit code 2 ("auth error"). ``auth_hint`` overrides ``hint``
+      so we can surface a key-specific suggestion ("check ROBOFLOW_API_KEY"
+      etc.) regardless of what the caller passes.
+    * **404** → exit code 3 ("not found"). ``not_found_hint`` overrides
+      ``hint`` similarly. Useful for resources that may legitimately be
+      absent (deleted, mis-typed slug, etc.).
+    * **anything else / no status_code attached** → exit code 1 ("error"),
+      using ``hint`` verbatim.
+
+    Without this helper every handler had to either string-match the message
+    (brittle) or fall back to a single ``exit_code=3`` for both 401 and 404,
+    which broke the ``$? == 2`` contract that scripts rely on to decide
+    whether to retry vs. re-auth.
+    """
+    status = getattr(exc, "status_code", None)
+    if status == 401:
+        output_error(
+            args,
+            str(exc),
+            hint=auth_hint or hint or "Check that ROBOFLOW_API_KEY is set and not revoked.",
+            exit_code=2,
+        )
+    elif status == 404:
+        output_error(args, str(exc), hint=not_found_hint or hint, exit_code=3)
+    else:
+        output_error(args, str(exc), hint=hint, exit_code=1)
+
+
 def stub(args: Any) -> None:
     """Placeholder handler for not-yet-implemented commands."""
     output_error(args, "This command is not yet implemented.", hint="Coming soon.", exit_code=1)

--- a/roboflow/cli/handlers/project.py
+++ b/roboflow/cli/handlers/project.py
@@ -223,7 +223,7 @@ def _create_project(args):  # noqa: ANN001
 
 def _delete_project(args):  # noqa: ANN001
     from roboflow.adapters import rfapi
-    from roboflow.cli._output import output, output_error
+    from roboflow.cli._output import confirm_destructive, output, output_api_error, output_error
     from roboflow.cli._resolver import resolve_resource
     from roboflow.config import load_roboflow_api_key
 
@@ -247,26 +247,52 @@ def _delete_project(args):  # noqa: ANN001
         )
         return
 
-    if not getattr(args, "yes", False) and not getattr(args, "json", False):
-        import typer
-
-        confirmed = typer.confirm(
-            f"Move '{workspace_url}/{project_slug}' to Trash? "
-            "(Retained for 30 days. Any in-flight trainings will be cancelled.)",
-            default=False,
-        )
-        if not confirmed:
-            output(args, {"cancelled": True}, text="Cancelled.")
-            return
+    if not confirm_destructive(
+        args,
+        f"Move '{workspace_url}/{project_slug}' to Trash? "
+        "(Retained for 30 days. Any in-flight trainings will be cancelled.)",
+    ):
+        return
 
     try:
         data = rfapi.delete_project(api_key, workspace_url, project_slug)
     except rfapi.RoboflowError as exc:
-        output_error(
+        # Idempotent re-delete: when the project is already in Trash the
+        # public API's URL filter excludes it, so the DELETE returns 404
+        # with a generic "endpoint does not exist" message. That looks like
+        # a permissions error to the user. Probe Trash explicitly — if the
+        # slug is there, treat the call as a no-op success so scripts can
+        # safely retry without special-casing the second attempt.
+        if getattr(exc, "status_code", None) == 404:
+            try:
+                trash = rfapi.list_trash(api_key, workspace_url)
+            except rfapi.RoboflowError:
+                trash = None
+            if trash is not None:
+                already = next(
+                    (p for p in trash.get("sections", {}).get("projects", []) if p.get("url") == project_slug),
+                    None,
+                )
+                if already is not None:
+                    data = {
+                        "deleted": True,
+                        "type": "project",
+                        "workspace": workspace_url,
+                        "project": project_slug,
+                        "projectId": already.get("id"),
+                        "trash": True,
+                        "alreadyInTrash": True,
+                    }
+                    output(
+                        args,
+                        data,
+                        text=f"{workspace_url}/{project_slug} is already in Trash (no-op).",
+                    )
+                    return
+        output_api_error(
             args,
-            str(exc),
+            exc,
             hint="Check your API key has 'project:update' scope on this workspace.",
-            exit_code=3,
         )
         return
 
@@ -279,7 +305,7 @@ def _delete_project(args):  # noqa: ANN001
 
 def _restore_project(args):  # noqa: ANN001
     from roboflow.adapters import rfapi
-    from roboflow.cli._output import output, output_error
+    from roboflow.cli._output import output, output_api_error, output_error
     from roboflow.cli._resolver import resolve_resource
     from roboflow.config import load_roboflow_api_key
 
@@ -306,11 +332,11 @@ def _restore_project(args):  # noqa: ANN001
     try:
         trash = rfapi.list_trash(api_key, workspace_url)
     except rfapi.RoboflowError as exc:
-        output_error(
+        output_api_error(
             args,
-            str(exc),
+            exc,
+            auth_hint="Check that ROBOFLOW_API_KEY is valid for this workspace.",
             hint="Check your API key has 'project:read' scope on this workspace.",
-            exit_code=3,
         )
         return
 
@@ -328,11 +354,10 @@ def _restore_project(args):  # noqa: ANN001
     try:
         data = rfapi.restore_trash_item(api_key, workspace_url, "project", match["id"])
     except rfapi.RoboflowError as exc:
-        output_error(
+        output_api_error(
             args,
-            str(exc),
+            exc,
             hint="Check your API key has 'project:update' scope on this workspace.",
-            exit_code=3,
         )
         return
 

--- a/roboflow/cli/handlers/trash.py
+++ b/roboflow/cli/handlers/trash.py
@@ -52,7 +52,7 @@ def _resolve_workspace(args):
 
 def _list_trash(args):  # noqa: ANN001
     from roboflow.adapters import rfapi
-    from roboflow.cli._output import output, output_error
+    from roboflow.cli._output import output, output_api_error
     from roboflow.cli._table import format_table
 
     workspace_url, api_key = _resolve_workspace(args)
@@ -62,11 +62,10 @@ def _list_trash(args):  # noqa: ANN001
     try:
         trash = rfapi.list_trash(api_key, workspace_url)
     except rfapi.RoboflowError as exc:
-        output_error(
+        output_api_error(
             args,
-            str(exc),
+            exc,
             hint="Check your API key has 'project:read' scope on this workspace.",
-            exit_code=3,
         )
         return
 

--- a/roboflow/cli/handlers/version.py
+++ b/roboflow/cli/handlers/version.py
@@ -356,7 +356,7 @@ def _create(args):  # noqa: ANN001
 
 def _delete_version(args):  # noqa: ANN001
     from roboflow.adapters import rfapi
-    from roboflow.cli._output import output, output_error
+    from roboflow.cli._output import confirm_destructive, output, output_api_error, output_error
     from roboflow.cli._resolver import resolve_resource
     from roboflow.config import load_roboflow_api_key
 
@@ -388,26 +388,55 @@ def _delete_version(args):  # noqa: ANN001
         )
         return
 
-    if not getattr(args, "yes", False) and not getattr(args, "json", False):
-        import typer
-
-        confirmed = typer.confirm(
-            f"Move version '{workspace_url}/{project_slug}/{version_num}' to Trash? "
-            "(Retained for 30 days. Any in-flight training will be cancelled.)",
-            default=False,
-        )
-        if not confirmed:
-            output(args, {"cancelled": True}, text="Cancelled.")
-            return
+    if not confirm_destructive(
+        args,
+        f"Move version '{workspace_url}/{project_slug}/{version_num}' to Trash? "
+        "(Retained for 30 days. Any in-flight training will be cancelled.)",
+    ):
+        return
 
     try:
         data = rfapi.delete_version(api_key, workspace_url, project_slug, version_num)
     except rfapi.RoboflowError as exc:
-        output_error(
+        # Idempotent re-delete: if the version is already in Trash, the
+        # public API URL is filtered and DELETE returns 404 — surface it
+        # as an explicit no-op so retries don't surface a misleading
+        # "missing scope" message. Same shape as project delete above.
+        if getattr(exc, "status_code", None) == 404:
+            try:
+                trash = rfapi.list_trash(api_key, workspace_url)
+            except rfapi.RoboflowError:
+                trash = None
+            if trash is not None:
+                target = str(version_num)
+                already = next(
+                    (
+                        v
+                        for v in trash.get("sections", {}).get("versions", [])
+                        if str(v.get("id")) == target and v.get("parentUrl") == project_slug
+                    ),
+                    None,
+                )
+                if already is not None:
+                    data = {
+                        "deleted": True,
+                        "type": "version",
+                        "workspace": workspace_url,
+                        "project": project_slug,
+                        "version": str(version_num),
+                        "trash": True,
+                        "alreadyInTrash": True,
+                    }
+                    output(
+                        args,
+                        data,
+                        text=f"{workspace_url}/{project_slug}/{version_num} is already in Trash (no-op).",
+                    )
+                    return
+        output_api_error(
             args,
-            str(exc),
+            exc,
             hint="Check your API key has 'version:update' scope and the version exists.",
-            exit_code=3,
         )
         return
 
@@ -420,7 +449,7 @@ def _delete_version(args):  # noqa: ANN001
 
 def _restore_version(args):  # noqa: ANN001
     from roboflow.adapters import rfapi
-    from roboflow.cli._output import output, output_error
+    from roboflow.cli._output import output, output_api_error, output_error
     from roboflow.cli._resolver import resolve_resource
     from roboflow.config import load_roboflow_api_key
 
@@ -455,11 +484,10 @@ def _restore_version(args):  # noqa: ANN001
     try:
         trash = rfapi.list_trash(api_key, workspace_url)
     except rfapi.RoboflowError as exc:
-        output_error(
+        output_api_error(
             args,
-            str(exc),
+            exc,
             hint="Check your API key has 'project:read' scope on this workspace.",
-            exit_code=3,
         )
         return
 
@@ -488,11 +516,10 @@ def _restore_version(args):  # noqa: ANN001
             parent_id=match.get("parentId"),
         )
     except rfapi.RoboflowError as exc:
-        output_error(
+        output_api_error(
             args,
-            str(exc),
+            exc,
             hint="Check your API key has 'version:update' scope on this workspace.",
-            exit_code=3,
         )
         return
 

--- a/roboflow/cli/handlers/workflow.py
+++ b/roboflow/cli/handlers/workflow.py
@@ -428,30 +428,60 @@ def _stub_deploy(args) -> None:  # noqa: ANN001
 
 def _delete_workflow(args) -> None:  # noqa: ANN001
     from roboflow.adapters import rfapi
-    from roboflow.cli._output import output, output_error
+    from roboflow.cli._output import confirm_destructive, output, output_api_error
 
     resolved = _resolve_workspace_and_key(args)
     if resolved is None:
         return
     workspace_url, api_key = resolved
 
-    if not getattr(args, "yes", False) and not getattr(args, "json", False):
-        confirmed = typer.confirm(
-            f"Move workflow '{workspace_url}/{args.workflow_url}' to Trash? (Retained for 30 days.)",
-            default=False,
-        )
-        if not confirmed:
-            output(args, {"cancelled": True}, text="Cancelled.")
-            return
+    if not confirm_destructive(
+        args,
+        f"Move workflow '{workspace_url}/{args.workflow_url}' to Trash? (Retained for 30 days.)",
+    ):
+        return
 
     try:
         data = rfapi.delete_workflow(api_key, workspace_url, args.workflow_url)
     except rfapi.RoboflowError as exc:
-        output_error(
+        # Idempotent re-delete: a workflow already in Trash returns 404
+        # because the public API filters trashed workflows out of the URL
+        # match. Probe Trash and treat as a no-op success when found —
+        # mirrors the project / version delete behavior.
+        if getattr(exc, "status_code", None) == 404:
+            try:
+                trash = rfapi.list_trash(api_key, workspace_url)
+            except rfapi.RoboflowError:
+                trash = None
+            if trash is not None:
+                already = next(
+                    (
+                        w
+                        for w in trash.get("sections", {}).get("workflows", [])
+                        if w.get("url") == args.workflow_url or w.get("id") == args.workflow_url
+                    ),
+                    None,
+                )
+                if already is not None:
+                    data = {
+                        "deleted": True,
+                        "type": "workflow",
+                        "workspace": workspace_url,
+                        "workflow": args.workflow_url,
+                        "workflowId": already.get("id"),
+                        "trash": True,
+                        "alreadyInTrash": True,
+                    }
+                    output(
+                        args,
+                        data,
+                        text=f"{workspace_url}/{args.workflow_url} is already in Trash (no-op).",
+                    )
+                    return
+        output_api_error(
             args,
-            str(exc),
+            exc,
             hint="Check your API key has 'workflow:update' scope on this workspace.",
-            exit_code=3,
         )
         return
 
@@ -464,7 +494,7 @@ def _delete_workflow(args) -> None:  # noqa: ANN001
 
 def _restore_workflow(args) -> None:  # noqa: ANN001
     from roboflow.adapters import rfapi
-    from roboflow.cli._output import output, output_error
+    from roboflow.cli._output import output, output_api_error, output_error
 
     resolved = _resolve_workspace_and_key(args)
     if resolved is None:
@@ -474,11 +504,10 @@ def _restore_workflow(args) -> None:  # noqa: ANN001
     try:
         trash = rfapi.list_trash(api_key, workspace_url)
     except rfapi.RoboflowError as exc:
-        output_error(
+        output_api_error(
             args,
-            str(exc),
+            exc,
             hint="Check your API key has 'project:read' scope on this workspace.",
-            exit_code=3,
         )
         return
 
@@ -500,11 +529,10 @@ def _restore_workflow(args) -> None:  # noqa: ANN001
     try:
         data = rfapi.restore_trash_item(api_key, workspace_url, "workflow", match["id"])
     except rfapi.RoboflowError as exc:
-        output_error(
+        output_api_error(
             args,
-            str(exc),
+            exc,
             hint="Check your API key has 'workflow:update' scope on this workspace.",
-            exit_code=3,
         )
         return
 

--- a/tests/cli/test_trash_polish.py
+++ b/tests/cli/test_trash_polish.py
@@ -1,0 +1,284 @@
+"""Behavioral tests for the 1.3.8 CLI polish fixes.
+
+Covers the three findings from the prod CLI shake-down:
+  1. Auth errors (HTTP 401) should exit with code 2, not 3.
+  2. Destructive commands without ``--yes`` and no TTY should bail with a
+     hint instead of either hanging on a closed stdin or silently
+     proceeding when ``--json`` is set.
+  3. Re-running ``project|version|workflow delete`` on something already in
+     Trash should be a no-op success rather than surfacing a misleading
+     "missing scope" 404 message.
+"""
+
+import io
+import sys
+import unittest
+from argparse import Namespace
+from unittest.mock import patch
+
+from roboflow.adapters import rfapi
+
+
+def _args(**overrides):
+    base = {
+        "json": False,
+        "workspace": "test-ws",
+        "api_key": "fake-key",
+        "quiet": False,
+        "yes": False,
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# 1. Auth errors → exit code 2
+# ---------------------------------------------------------------------------
+
+
+class TestAuthExitCode(unittest.TestCase):
+    """``output_api_error`` must map ``status_code=401`` to exit code 2.
+
+    Before this change every ``rfapi.RoboflowError`` from the trash
+    endpoints was caught with ``exit_code=3`` (not-found), so scripts /
+    agents couldn't tell "your key is bad, get a new one" apart from
+    "this resource doesn't exist."
+    """
+
+    def test_401_maps_to_exit_2(self) -> None:
+        from roboflow.cli._output import output_api_error
+
+        exc = rfapi.RoboflowError("This API key does not exist", status_code=401)
+        with self.assertRaises(SystemExit) as ctx:
+            output_api_error(_args(), exc, hint="ignored when 401")
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_404_maps_to_exit_3(self) -> None:
+        from roboflow.cli._output import output_api_error
+
+        exc = rfapi.RoboflowError("Not found", status_code=404)
+        with self.assertRaises(SystemExit) as ctx:
+            output_api_error(_args(), exc)
+        self.assertEqual(ctx.exception.code, 3)
+
+    def test_other_status_maps_to_exit_1(self) -> None:
+        from roboflow.cli._output import output_api_error
+
+        exc = rfapi.RoboflowError("Server died", status_code=500)
+        with self.assertRaises(SystemExit) as ctx:
+            output_api_error(_args(), exc)
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_no_status_code_maps_to_exit_1(self) -> None:
+        # Older `raise RoboflowError(text)` call sites don't set status_code;
+        # they should default to a generic exit 1, NOT to 3 (which would
+        # impersonate "not found") and NOT to 2 (which would impersonate
+        # "auth error").
+        from roboflow.cli._output import output_api_error
+
+        exc = rfapi.RoboflowError("ambiguous")
+        with self.assertRaises(SystemExit) as ctx:
+            output_api_error(_args(), exc)
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_trash_response_attaches_status_code(self) -> None:
+        # rfapi._raise_for_trash_response is the funnel for every 4xx/5xx
+        # from the soft-delete endpoints — verify it stamps status_code.
+        class FakeResponse:
+            status_code = 401
+            text = '{"error": "Unauthorized"}'
+
+            def json(self):
+                return {"error": "Unauthorized"}
+
+        with self.assertRaises(rfapi.RoboflowError) as ctx:
+            rfapi._raise_for_trash_response(FakeResponse())
+        self.assertEqual(ctx.exception.status_code, 401)
+        self.assertEqual(str(ctx.exception), "Unauthorized")
+
+
+# ---------------------------------------------------------------------------
+# 2. Destructive commands gate on --yes OR a TTY (not on --json)
+# ---------------------------------------------------------------------------
+
+
+class TestDestructiveConfirm(unittest.TestCase):
+    """``confirm_destructive`` should:
+
+    * return True when ``--yes`` is set (regardless of ``--json`` or TTY);
+    * exit cleanly with code 1 when no TTY AND no ``--yes`` (the regression
+      scenario: ``roboflow project delete X --json < /dev/null`` previously
+      went through silently because ``--json`` was treated as an implicit
+      "skip prompt" signal);
+    * prompt via typer.confirm when on a TTY without ``--yes`` and respect
+      the user's choice.
+    """
+
+    def test_yes_flag_short_circuits(self) -> None:
+        from roboflow.cli._output import confirm_destructive
+
+        # No TTY, no prompt — but --yes is set, so it should still proceed.
+        with patch.object(sys.stdin, "isatty", return_value=False):
+            self.assertTrue(confirm_destructive(_args(yes=True), "destroy?"))
+
+    def test_no_tty_no_yes_bails_with_exit_1(self) -> None:
+        from roboflow.cli._output import confirm_destructive
+
+        with patch.object(sys.stdin, "isatty", return_value=False):
+            with self.assertRaises(SystemExit) as ctx:
+                confirm_destructive(_args(yes=False), "destroy?")
+            self.assertEqual(ctx.exception.code, 1)
+
+    def test_json_alone_does_not_bypass(self) -> None:
+        # Regression guard for the original bug: --json without --yes
+        # should NOT short-circuit the destructive guard.
+        from roboflow.cli._output import confirm_destructive
+
+        with patch.object(sys.stdin, "isatty", return_value=False):
+            with self.assertRaises(SystemExit) as ctx:
+                confirm_destructive(_args(yes=False, json=True), "destroy?")
+            self.assertEqual(ctx.exception.code, 1)
+
+    def test_tty_prompts_and_respects_decline(self) -> None:
+        from roboflow.cli._output import confirm_destructive
+
+        captured = io.StringIO()
+        with (
+            patch.object(sys.stdin, "isatty", return_value=True),
+            patch("typer.confirm", return_value=False),
+            patch("sys.stdout", captured),
+        ):
+            self.assertFalse(confirm_destructive(_args(yes=False), "destroy?"))
+        # Caller doesn't need to re-emit "Cancelled." — confirm_destructive
+        # already calls output() with the cancelled marker.
+        self.assertIn("Cancelled", captured.getvalue())
+
+    def test_tty_prompts_and_respects_accept(self) -> None:
+        from roboflow.cli._output import confirm_destructive
+
+        with patch.object(sys.stdin, "isatty", return_value=True), patch("typer.confirm", return_value=True):
+            self.assertTrue(confirm_destructive(_args(yes=False), "destroy?"))
+
+
+# ---------------------------------------------------------------------------
+# 3. Idempotent re-delete on project/version/workflow
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotentDelete(unittest.TestCase):
+    """When the DELETE call returns 404 because the resource is already in
+    Trash (the public API's URL filter excludes trashed items), the handler
+    should probe ``list_trash`` and emit a synthetic success payload with
+    ``alreadyInTrash: True``. Previously we surfaced the raw 404 with a
+    misleading "missing scope" hint."""
+
+    def _trash_payload_with_project(self, slug: str, project_id: str = "p_id"):
+        return {
+            "items": [],
+            "sections": {
+                "projects": [{"id": project_id, "url": slug, "name": slug}],
+                "versions": [],
+                "workflows": [],
+            },
+        }
+
+    def test_project_already_in_trash_returns_success(self) -> None:
+        from roboflow.cli.handlers.project import _delete_project
+
+        not_found = rfapi.RoboflowError("Endpoint does not exist", status_code=404)
+        captured = io.StringIO()
+
+        # Resolver works on "ws/slug" shorthand — pass an explicit workspace
+        # via args.workspace and a bare slug via args.project_id.
+        args = _args(project_id="my-proj", yes=True, json=True)
+        with (
+            patch("roboflow.adapters.rfapi.delete_project", side_effect=not_found),
+            patch(
+                "roboflow.adapters.rfapi.list_trash",
+                return_value=self._trash_payload_with_project("my-proj"),
+            ),
+            patch("sys.stdout", captured),
+        ):
+            _delete_project(args)
+
+        out = captured.getvalue()
+        self.assertIn('"alreadyInTrash": true', out)
+        self.assertIn('"deleted": true', out)
+        self.assertIn('"trash": true', out)
+
+    def test_project_404_not_in_trash_propagates_error(self) -> None:
+        # If the slug really doesn't exist (not active, not trashed),
+        # we should NOT swallow the 404 — propagate as exit 3.
+        from roboflow.cli.handlers.project import _delete_project
+
+        not_found = rfapi.RoboflowError("Endpoint does not exist", status_code=404)
+        empty_trash = {"items": [], "sections": {"projects": [], "versions": [], "workflows": []}}
+
+        args = _args(project_id="ghost-proj", yes=True, json=True)
+        with (
+            patch("roboflow.adapters.rfapi.delete_project", side_effect=not_found),
+            patch("roboflow.adapters.rfapi.list_trash", return_value=empty_trash),
+            patch("sys.stderr", io.StringIO()),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                _delete_project(args)
+        self.assertEqual(ctx.exception.code, 3)
+
+    def test_workflow_already_in_trash_returns_success(self) -> None:
+        from roboflow.cli.handlers.workflow import _delete_workflow
+
+        not_found = rfapi.RoboflowError("Endpoint does not exist", status_code=404)
+        trash = {
+            "items": [],
+            "sections": {
+                "projects": [],
+                "versions": [],
+                "workflows": [{"id": "wf_id", "url": "my-wf", "name": "My WF"}],
+            },
+        }
+        captured = io.StringIO()
+        args = _args(workflow_url="my-wf", yes=True, json=True)
+        with (
+            patch("roboflow.adapters.rfapi.delete_workflow", side_effect=not_found),
+            patch("roboflow.adapters.rfapi.list_trash", return_value=trash),
+            patch("sys.stdout", captured),
+        ):
+            _delete_workflow(args)
+        out = captured.getvalue()
+        self.assertIn('"alreadyInTrash": true', out)
+        self.assertIn('"workflowId": "wf_id"', out)
+
+    def test_version_already_in_trash_returns_success(self) -> None:
+        from roboflow.cli.handlers.version import _delete_version
+
+        not_found = rfapi.RoboflowError("Endpoint does not exist", status_code=404)
+        trash = {
+            "items": [],
+            "sections": {
+                "projects": [],
+                "versions": [
+                    {
+                        "id": "1",
+                        "parentUrl": "my-proj",
+                        "parentId": "p_id",
+                        "name": "v1",
+                    }
+                ],
+                "workflows": [],
+            },
+        }
+        captured = io.StringIO()
+        args = _args(version_ref="my-proj/1", yes=True, json=True)
+        with (
+            patch("roboflow.adapters.rfapi.delete_version", side_effect=not_found),
+            patch("roboflow.adapters.rfapi.list_trash", return_value=trash),
+            patch("sys.stdout", captured),
+        ):
+            _delete_version(args)
+        out = captured.getvalue()
+        self.assertIn('"alreadyInTrash": true', out)
+        self.assertIn('"version": "1"', out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cli/test_trash_polish.py
+++ b/tests/cli/test_trash_polish.py
@@ -280,5 +280,36 @@ class TestIdempotentDelete(unittest.TestCase):
         self.assertIn('"version": "1"', out)
 
 
+# ---------------------------------------------------------------------------
+# 4. RoboflowError subclasses must preserve their HTTP status_code
+# ---------------------------------------------------------------------------
+
+
+class TestRoboflowErrorSubclassStatusCode(unittest.TestCase):
+    """Regression guard: when ``RoboflowError.__init__`` started accepting
+    ``status_code``, the subclasses ``ImageUploadError`` and
+    ``AnnotationSaveError`` were calling ``super().__init__(self.message)``
+    without forwarding the second arg. The parent then assigned
+    ``self.status_code = None``, silently wiping the HTTP code that the
+    subclass had just set on itself a line earlier."""
+
+    def test_image_upload_error_preserves_status_code(self) -> None:
+        exc = rfapi.ImageUploadError("upload blew up", status_code=413)
+        self.assertEqual(exc.status_code, 413)
+        self.assertEqual(exc.message, "upload blew up")
+        self.assertEqual(exc.retries, 0)
+
+    def test_annotation_save_error_preserves_status_code(self) -> None:
+        exc = rfapi.AnnotationSaveError("annot blew up", status_code=409)
+        self.assertEqual(exc.status_code, 409)
+        self.assertEqual(exc.message, "annot blew up")
+        self.assertEqual(exc.retries, 0)
+
+    def test_subclasses_default_status_code_to_none(self) -> None:
+        # Existing message-only call sites must keep working.
+        self.assertIsNone(rfapi.ImageUploadError("just a message").status_code)
+        self.assertIsNone(rfapi.AnnotationSaveError("just a message").status_code)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

End-to-end testing of the v1.3.7 CLI against prod ([roboflow#11131](https://github.com/roboflow/roboflow/pull/11131) / [roboflow-python#463](https://github.com/roboflow/roboflow-python/pull/463) shipped this morning) surfaced three rough edges. None are correctness bugs — every command does the right server-side thing — but they all lead users (and especially agents) into wrong conclusions and were called out in the prod shake-down report. Worth fixing before the next release.

## The three findings

### 1. Auth errors return exit 3 (should be 2)

Per `CONTRIBUTING.md`: `0=success, 1=error, 2=auth, 3=not-found`. Every `rfapi.RoboflowError` from the trash endpoints was caught with `exit_code=3`, so scripts can't differentiate `re-auth` from `wrong slug`:

```bash
$ roboflow -k bogus-key trash list --json ; echo $?
{"error": ...}
3                ← should be 2
```

### 2. `--json` silently bypasses destructive-action confirmation

```bash
$ roboflow project delete moondream-example --json < /dev/null
{"deleted": true, "trash": true, ...}    ← deleted, no prompt!
```

Old logic was `if not yes and not json: prompt`. That conflated *output formatting* with *destructive intent* — anyone piping `… --json | jq` got their project nuked because `--json` was treated as "I'm in CI, skip the prompt."

### 3. Idempotent re-delete bubbles up a misleading "missing scope" 404

When a project/version/workflow is already in Trash, the public API's URL filter excludes it from the active set, so the next `DELETE` returns 404 ("Unsupported request. `DELETE /ws/proj` does not exist..."). The CLI surfaced that as exit 3 with `Check your API key has 'project:update' scope` — factually wrong (the user has the scope; the item is just where they wanted it).

## What

All three fixes live centrally so future trash / destructive endpoints inherit the right behavior for free.

**Auth exit code (`#1`)**
- `RoboflowError(message, status_code=None)` now stores `status_code`. Defaulted to `None` for back-compat with the 30+ existing call sites that pass message-only.
- `_raise_for_trash_response` stamps `response.status_code` on the raised exception.
- New `output_api_error(args, exc, hint=..., auth_hint=..., not_found_hint=...)` helper in `cli/_output.py` does the central status→exit-code mapping (401→2, 404→3, else→1). All four trash handlers (project / version / workflow / trash) replace hardcoded `output_error(..., exit_code=3)` with it.

**Destructive guard (`#2`)**
- New `confirm_destructive(args, prompt)` in `cli/_output.py`:
  - `--yes` → proceed.
  - TTY without `--yes` → prompt (regardless of `--json`).
  - No TTY without `--yes` → bail with exit 1 + hint about `--yes`.
- `project delete`, `version delete`, `workflow delete` all switched to it.

**Idempotent re-delete (`#3`)**
- Each delete handler intercepts a 404 from `rfapi.delete_X`, probes `list_trash`, and if the slug/url is found in the matching `sections` array, emits a synthetic success payload mirroring a real delete plus `alreadyInTrash: true`. If the slug is genuinely missing from trash too, the 404 propagates as exit 3 (typos still surface as errors).

Sample payload from a re-delete:

```json
{
  "deleted": true,
  "type": "project",
  "workspace": "q3-board-meeting",
  "project": "moondream-example",
  "projectId": "Jjk3Tjq2yjxenyA9g5er",
  "trash": true,
  "alreadyInTrash": true
}
```

## Tests

`tests/cli/test_trash_polish.py` adds 14 tests covering all three:
- `output_api_error` mapping for 401 / 404 / 500 / no-status-code (defaults to 1, NOT 3 or 2 — important so legacy `RoboflowError(text)` callers don't accidentally claim "not found" / "auth").
- `_raise_for_trash_response` actually attaches `status_code`.
- `confirm_destructive` honors `--yes`, refuses no-TTY without `--yes`, ignores `--json` when deciding (regression guard for finding #2), and prompts via typer on a TTY (both accept and decline paths).
- Idempotent re-delete success path on project / version / workflow, plus the negative case where a 404 with empty trash propagates as exit 3 (so we don't mask real "not found" errors).

```
$ python -m unittest discover -s tests
Ran 526 tests in 7.222s
OK (skipped=1)

$ ruff check roboflow tests
All checks passed!

$ ruff format --check roboflow tests
113 files already formatted

$ mypy roboflow
Success: no issues found in 62 source files
```

## Backwards compatibility

- `RoboflowError(message)` (no status_code) still works — every call site outside the trash endpoints does this and is unaffected.
- The new helpers (`output_api_error`, `confirm_destructive`) are additive in `_output.py`. Nothing else imports them yet.
- Wire format of successful deletes is unchanged; the new `alreadyInTrash` field is additive for the previously-error-out 404 case, so any caller currently parsing a successful delete payload keeps working.

## Test plan

- [x] `pytest` / `python -m unittest` — all 526 tests pass.
- [x] `ruff check roboflow tests` — clean.
- [x] `ruff format --check roboflow tests` — clean.
- [x] `mypy roboflow` — clean.
- [ ] One reviewer sanity-check of the synthetic `alreadyInTrash` payload shape (mirrors successful delete fields verbatim — `type`, `workspace`, `project`/`workflow`, `projectId`/`workflowId`, `trash`).