### PR TITLE
bump version to 1.3.8

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -21,7 +21,7 @@ except ImportError:
     CLIPModel = None  # type: ignore[assignment,misc]
     GazeModel = None  # type: ignore[assignment,misc]
 
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 
 
 def check_key(api_key, model, notebook, num_retries=0):


### PR DESCRIPTION
## Summary
- Patch bump from 1.3.7 to 1.3.8 in `roboflow/__init__.py`.

## Test plan
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)