### PR TITLE
Add project dataset health check

### DIFF
--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -925,6 +925,17 @@ def _raise_for_trash_response(response):
     raise RoboflowError(msg or response.text)
 
 
+def get_project_health(api_key, workspace_url, project_url, regenerate=False):
+    """GET /{workspace}/{project}/health — dataset health check statistics."""
+    url = f"{API_URL}/{workspace_url}/{project_url}/health?api_key={api_key}"
+    if regenerate:
+        url += "&regenerate=true"
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise RoboflowError(response.text)
+    return response.json()
+
+
 def delete_project(api_key, workspace_url, project_url):
     """DELETE /{workspace}/{project} — move a project to Trash (30-day retention).
 

--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -49,6 +49,17 @@ def get_project(api_key, workspace_url, project_url):
     return result
 
 
+def get_project_health(api_key, workspace_url, project_url, regenerate=False):
+    """GET /{workspace}/{project}/health — dataset health check statistics."""
+    url = f"{API_URL}/{workspace_url}/{project_url}/health?api_key={api_key}"
+    if regenerate:
+        url += "&regenerate=true"
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise RoboflowError(response.text)
+    return response.json()
+
+
 def start_version_training(
     api_key: str,
     workspace_url: str,
@@ -923,17 +934,6 @@ def _raise_for_trash_response(response):
         # Body wasn't JSON — fall through to response.text.
         pass
     raise RoboflowError(msg or response.text)
-
-
-def get_project_health(api_key, workspace_url, project_url, regenerate=False):
-    """GET /{workspace}/{project}/health — dataset health check statistics."""
-    url = f"{API_URL}/{workspace_url}/{project_url}/health?api_key={api_key}"
-    if regenerate:
-        url += "&regenerate=true"
-    response = requests.get(url)
-    if response.status_code != 200:
-        raise RoboflowError(response.text)
-    return response.json()
 
 
 def delete_project(api_key, workspace_url, project_url):

--- a/roboflow/cli/handlers/project.py
+++ b/roboflow/cli/handlers/project.py
@@ -1,4 +1,4 @@
-"""Project management commands: list, get, create."""
+"""Project management commands: list, get, create, health."""
 
 from __future__ import annotations
 
@@ -76,6 +76,19 @@ def restore_project(
     """Restore a project from Trash."""
     args = ctx_to_args(ctx, project_id=project_id)
     _restore_project(args)
+
+
+@project_app.command("health")
+def health_project(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID or shorthand (e.g. my-ws/my-project)")],
+    regenerate: Annotated[
+        bool, typer.Option("--regenerate", "-r", help="Force regeneration of health check data.")
+    ] = False,
+) -> None:
+    """Show dataset health check for a project (class balance, dimensions, splits)."""
+    args = ctx_to_args(ctx, project_id=project_id, regenerate=regenerate)
+    _health_project(args)
 
 
 # ---------------------------------------------------------------------------
@@ -337,3 +350,26 @@ def _restore_project(args):  # noqa: ANN001
         return
 
     output(args, data, text=f"Restored {workspace_url}/{project_slug} from Trash.")
+
+
+def _health_project(args):  # noqa: ANN001
+    import json
+
+    import roboflow
+    from roboflow.cli._output import output, output_error, suppress_sdk_output
+
+    with suppress_sdk_output(args):
+        try:
+            rf = roboflow.Roboflow(api_key=args.api_key)
+            project = rf.workspace(args.workspace).project(args.project_id)
+        except Exception as exc:
+            output_error(args, str(exc))
+            return
+
+    try:
+        data = project.health(regenerate=args.regenerate)
+    except Exception as exc:
+        output_error(args, str(exc), exit_code=3)
+        return
+
+    output(args, data, text=json.dumps(data, indent=2))

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -1084,3 +1084,31 @@ class Project:
         if not match:
             raise RuntimeError(f"Project '{self.__project_name}' is not in Trash — nothing to restore.")
         return rfapi.restore_trash_item(self.__api_key, self.__workspace, "project", match["id"])
+
+    def health(self, regenerate: bool = False) -> Dict:
+        """Get health check statistics for this project.
+
+        Args:
+            regenerate: If True, force regeneration of health check data.
+
+        Returns:
+            Dict: Health check statistics including class balance,
+                image dimensions, annotation counts, and split distribution.
+
+        Example:
+            >>> import roboflow
+            >>> rf = roboflow.Roboflow(api_key="YOUR_API_KEY")
+            >>> project = rf.workspace().project("PROJECT_ID")
+            >>> health = project.health()
+        """
+        url = f"{API_URL}/{self.__workspace}/{self.__project_name}/health?api_key={self.__api_key}"
+        if regenerate:
+            url += "&regenerate=true"
+
+        response = requests.get(url)
+        data = response.json()
+
+        if "error" in data:
+            raise RuntimeError(data["error"])
+
+        return data

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -1101,14 +1101,4 @@ class Project:
             >>> project = rf.workspace().project("PROJECT_ID")
             >>> health = project.health()
         """
-        url = f"{API_URL}/{self.__workspace}/{self.__project_name}/health?api_key={self.__api_key}"
-        if regenerate:
-            url += "&regenerate=true"
-
-        response = requests.get(url)
-        data = response.json()
-
-        if "error" in data:
-            raise RuntimeError(data["error"])
-
-        return data
+        return rfapi.get_project_health(self.__api_key, self.__workspace, self.__project_name, regenerate=regenerate)

--- a/tests/cli/test_project_handler.py
+++ b/tests/cli/test_project_handler.py
@@ -124,5 +124,56 @@ class TestProjectRestoreHandler(unittest.TestCase):
             mock_restore.assert_not_called()
 
 
+class TestProjectHealthHandler(unittest.TestCase):
+    """project health calls project.health() via SDK."""
+
+    def _args(self, project_id="my-project", regenerate=False):
+        from argparse import Namespace
+
+        return Namespace(
+            json=False,
+            workspace="my-ws",
+            api_key="fake-key",
+            quiet=False,
+            project_id=project_id,
+            regenerate=regenerate,
+        )
+
+    def test_health_exists(self) -> None:
+        result = runner.invoke(app, ["project", "health", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("regenerate", result.output.lower())
+
+    def test_health_calls_sdk(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from roboflow.cli.handlers.project import _health_project
+
+        mock_project = MagicMock()
+        mock_project.health.return_value = {"images": 100, "classes": {"cat": 50, "dog": 50}}
+
+        mock_rf = MagicMock()
+        mock_rf.workspace.return_value.project.return_value = mock_project
+
+        with patch("roboflow.Roboflow", return_value=mock_rf):
+            _health_project(self._args())
+            mock_project.health.assert_called_once_with(regenerate=False)
+
+    def test_health_regenerate(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from roboflow.cli.handlers.project import _health_project
+
+        mock_project = MagicMock()
+        mock_project.health.return_value = {"images": 100}
+
+        mock_rf = MagicMock()
+        mock_rf.workspace.return_value.project.return_value = mock_project
+
+        with patch("roboflow.Roboflow", return_value=mock_rf):
+            _health_project(self._args(regenerate=True))
+            mock_project.health.assert_called_once_with(regenerate=True)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What does this PR do?

Exposes dataset health check seen in UI to SDK and CLI.

`roboflow project health [-r] <project_slug>`

options: `-r: regenerate`

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
```
export ROBOFLOW_MCP_URL=http://localhost:8000/mcp
export ROBOFLOW_API_KEY=...
export API_URL=https://localapi.roboflow.one
export APP_URL=https://localapp.roboflow.one
export REQUESTS_CA_BUNDLE="$(mkcert -CAROOT)/rootCA.pem"
export RF_WORKSPACE=sergiistaging
```
`roboflow project health bagatelle-staging`


```
{
  "generated": 1778159771149,
  "version": 3,
  "stats": {
    "annotated": 897,
    "unannotated": 0,
    "empty": 0,
    "labels": 23957,
    "images": 897,
    "average": "26.7",
    "singleClass": 0,
    "multiClass": 0,
    "numClasses": 9,
    "classes": [
      {
        "count": 7827,
        "percent": "100.0",
        "cls": "fair",
        "description": "",
        "name": "ball"
      },
      {
        "count": 4473,
        "percent": "57.1",
        "cls": "fair",
        "description": "",
        "name": "100"
      },
      {
        "count": 2690,
        "percent": "34.4",
        "cls": "fair",
        "description": "",
        "name": "40"
      },
      {
        "count": 1794,
        "percent": "22.9",
        "cls": "under",
        "description": "Under Represented",
        "name": "30"
      },
      {
        "count": 1794,
        "percent": "22.9",
        "cls": "under",
        "description": "Under Represented",
        "name": "50"
      },
      {
        "count": 1794,
        "percent": "22.9",
        "cls": "under",
        "description": "Under Represented",
        "name": "70"
      },
      {
        "count": 1792,
        "percent": "22.9",
        "cls": "under",
        "description": "Under Represented",
        "name": "The following pre-processing was applied to each image:"
      },
      {
        "count": 897,
        "percent": "11.5",
        "cls": "under",
        "description": "Under Represented",
        "name": "500"
      },
      {
        "count": 896,
        "percent": "11.4",
        "cls": "under",
        "description": "Under Represented",
        "name": "20"
      }
    ],
    "classesBySplit": {
      "train": [
        {
          "count": 5455,
          "percent": "100.0",
          "cls": "fair",
          "description": "",
          "name": "ball"
        },
        {
          "count": 3127,
          "percent": "57.3",
          "cls": "fair",
          "description": "",
          "name": "100"
        },
        {
          "count": 1880,
          "percent": "34.5",
          "cls": "fair",
          "description": "",
          "name": "40"
        },
        {
          "count": 1254,
          "percent": "23.0",
          "cls": "under",
          "description": "Under Represented",
          "name": "30"
        },
        {
          "count": 1254,
          "percent": "23.0",
          "cls": "under",
          "description": "Under Represented",
          "name": "50"
        },
        {
          "count": 1254,
          "percent": "23.0",
          "cls": "under",
          "description": "Under Represented",
          "name": "70"
        },
        {
          "count": 1252,
          "percent": "23.0",
          "cls": "under",
          "description": "Under Represented",
          "name": "The following pre-processing was applied to each image:"
        },
        {
          "count": 627,
          "percent": "11.5",
          "cls": "under",
          "description": "Under Represented",
          "name": "500"
        },
        {
          "count": 626,
          "percent": "11.5",
          "cls": "under",
          "description": "Under Represented",
          "name": "20"
        }
      ],
      "valid": [
        {
          "count": 1574,
          "percent": "100.0",
          "cls": "fair",
          "description": "",
          "name": "ball"
        },
        {
          "count": 899,
          "percent": "57.1",
          "cls": "fair",
          "description": "",
          "name": "100"
        },
        {
          "count": 540,
          "percent": "34.3",
          "cls": "fair",
          "description": "",
          "name": "40"
        },
        {
          "count": 360,
          "percent": "22.9",
          "cls": "under",
          "description": "Under Represented",
          "name": "30"
        },
        {
          "count": 360,
          "percent": "22.9",
          "cls": "under",
          "description": "Under Represented",
          "name": "50"
        },
        {
          "count": 360,
          "percent": "22.9",
          "cls": "under",
          "description": "Under Represented",
          "name": "70"
        },
        {
          "count": 360,
          "percent": "22.9",
          "cls": "under",
          "description": "Under Represented",
          "name": "The following pre-processing was applied to each image:"
        },
        {
          "count": 180,
          "percent": "11.4",
          "cls": "under",
          "description": "Under Represented",
          "name": "500"
        },
        {
          "count": 180,
          "percent": "11.4",
          "cls": "under",
          "description": "Under Represented",
          "name": "20"
        }
      ],
      "test": [
        {
          "count": 798,
          "percent": "100.0",
          "cls": "fair",
          "description": "",
          "name": "ball"
        },
        {
          "count": 447,
          "percent": "56.0",
          "cls": "fair",
          "description": "",
          "name": "100"
        },
        {
          "count": 270,
          "percent": "33.8",
          "cls": "fair",
          "description": "",
          "name": "40"
        },
        {
          "count": 180,
          "percent": "22.6",
          "cls": "under",
          "description": "Under Represented",
          "name": "30"
        },
        {
          "count": 180,
          "percent": "22.6",
          "cls": "under",
          "description": "Under Represented",
          "name": "50"
        },
        {
          "count": 180,
          "percent": "22.6",
          "cls": "under",
          "description": "Under Represented",
          "name": "70"
        },
        {
          "count": 180,
          "percent": "22.6",
          "cls": "under",
          "description": "Under Represented",
          "name": "The following pre-processing was applied to each image:"
        },
        {
          "count": 90,
          "percent": "11.3",
          "cls": "under",
          "description": "Under Represented",
          "name": "500"
        },
        {
          "count": 90,
          "percent": "11.3",
          "cls": "under",
          "description": "Under Represented",
          "name": "20"
        }
      ]
    },
    "histogram": {
      "20": {
        "1": 896
      },
      "30": {
        "2": 897
      },
      "40": {
        "2": 1,
        "3": 896
      },
      "50": {
        "2": 897
      },
      "70": {
        "2": 897
      },
      "100": {
        "4": 12,
        "5": 885
      },
      "500": {
        "1": 897
      },
      "all": {
        "17": 4,
        "18": 61,
        "19": 13,
        "20": 6,
        "21": 8,
        "22": 4,
        "23": 115,
        "24": 4,
        "25": 3,
        "26": 9,
        "27": 52,
        "28": 209,
        "29": 408,
        "30": 1
      },
      "The following pre-processing was applied to each image:": {
        "1": 2,
        "2": 895
      },
      "ball": {
        "1": 14,
        "2": 4,
        "3": 8,
        "4": 3,
        "5": 117,
        "6": 4,
        "7": 4,
        "8": 9,
        "9": 51,
        "10": 209,
        "11": 409,
        "12": 1
      }
    }
  }
}

```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
