### PR TITLE
bump version to 1.3.9

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -21,7 +21,7 @@ except ImportError:
     CLIPModel = None  # type: ignore[assignment,misc]
     GazeModel = None  # type: ignore[assignment,misc]
 
-__version__ = "1.3.8"
+__version__ = "1.3.9"
 
 
 def check_key(api_key, model, notebook, num_retries=0):


### PR DESCRIPTION
## Description

Bumps the package version from `1.3.8` to `1.3.9`.

## Changes since 1.3.8

### New features

- **Universe project fork CLI** (#473) — Adds SDK and CLI support for asynchronously forking public Universe projects into a workspace. New commands: `roboflow project fork`, `roboflow asynctasks get`, `roboflow asynctasks wait`. Includes new SDK methods for project fork/task status, a shared polling helper, docs, and tests.
- **Project dataset health check** (#472) — Exposes the dataset health check seen in the UI to the SDK and CLI. New command: `roboflow project health [-r] <project_slug>` (`-r` to regenerate).
- **Shell autocompletion install command** (#471) — Adds a command that installs shell autocompletion automatically (instead of requiring users to copy the script into place manually) and prints a hint about it after login.

### Internal

- Refactor: dataset health now uses `rfapi`, with reordering inside `rfapi` for consistency (part of #472).

## Type of change

- [x] Chore (version bump)

## How has this change been tested?

- All underlying changes were tested and merged independently in their respective PRs.
- `python -m unittest`

## Will the change affect Universe?

No.

## Any specific deployment considerations

Standard PyPI release once merged.

## Docs

- [x] No docs change required for the bump itself; per-feature docs were updated in their respective PRs.
