### PR TITLE
feat(cli): add image update command for metadata and tags

### DIFF
--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -2,7 +2,7 @@ import json
 import mimetypes
 import os
 import urllib
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import quote
 
 import requests
@@ -365,6 +365,76 @@ def workspace_delete_images(
     url = f"{API_URL}/{workspace_url}/images?api_key={api_key}"
     response = requests.delete(url, json={"images": image_ids})
     if response.status_code != 200:
+        raise RoboflowError(response.text)
+    return response.json()
+
+
+def update_image_metadata(
+    api_key: str,
+    workspace_url: str,
+    image_id: str,
+    *,
+    metadata: Optional[Dict] = None,
+    remove_metadata: Optional[List[str]] = None,
+    add_tags: Optional[List[str]] = None,
+    remove_tags: Optional[List[str]] = None,
+) -> dict:
+    """Update metadata and tags on a single image (synchronous).
+
+    Args:
+        api_key: Roboflow API key.
+        workspace_url: Workspace slug/url.
+        image_id: Image/source ID.
+        metadata: Key-value pairs to set on the image.
+        remove_metadata: Metadata keys to delete.
+        add_tags: Tags to append.
+        remove_tags: Tags to remove.
+
+    Returns:
+        Parsed JSON response (``{"success": true}``).
+
+    Raises:
+        RoboflowError: On non-200 response.
+    """
+    url = f"{API_URL}/{workspace_url}/images/{quote(image_id, safe='')}/metadata"
+    body: Dict[str, Any] = {}
+    if metadata is not None:
+        body["metadata"] = metadata
+    if remove_metadata is not None:
+        body["removeMetadata"] = remove_metadata
+    if add_tags is not None:
+        body["addTags"] = add_tags
+    if remove_tags is not None:
+        body["removeTags"] = remove_tags
+
+    response = requests.post(url, params={"api_key": api_key}, json=body)
+    if response.status_code != 200:
+        raise RoboflowError(response.text)
+    return response.json()
+
+
+def batch_update_image_metadata(
+    api_key: str,
+    workspace_url: str,
+    updates: List[Dict],
+) -> dict:
+    """Batch-update metadata and tags on multiple images (asynchronous).
+
+    Args:
+        api_key: Roboflow API key.
+        workspace_url: Workspace slug/url.
+        updates: List of update dicts, each containing ``imageId`` and optionally
+            ``metadata``, ``removeMetadata``, ``addTags``, ``removeTags``.
+
+    Returns:
+        Parsed JSON with ``taskId`` and ``url`` for polling.
+
+    Raises:
+        RoboflowError: On non-202 response.
+    """
+    url = f"{API_URL}/{workspace_url}/images/metadata"
+    response = requests.post(url, params={"api_key": api_key}, json={"updates": updates})
+    if response.status_code != 202:
         raise RoboflowError(response.text)
     return response.json()
 

--- a/roboflow/cli/handlers/image.py
+++ b/roboflow/cli/handlers/image.py
@@ -461,7 +461,7 @@ def _handle_metadata(args):  # noqa: ANN001
     add_tags_list = [t.strip() for t in args.add_tags.split(",") if t.strip()] if args.add_tags else None
     remove_tags_list = [t.strip() for t in args.remove_tags.split(",") if t.strip()] if args.remove_tags else None
 
-    if not metadata_dict and not remove_meta_list and not add_tags_list and not remove_tags_list:
+    if metadata_dict is None and remove_meta_list is None and add_tags_list is None and remove_tags_list is None:
         output_error(
             args,
             "Nothing to update",
@@ -500,7 +500,7 @@ def _handle_metadata_batch(args, api_key, workspace_url, image_ids, metadata, re
     from roboflow.adapters import rfapi
     from roboflow.cli._output import output, output_error
 
-    BATCH_LIMIT = 1000
+    BATCH_LIMIT = 1000  # matches the workspace images/metadata endpoint limit
     if len(image_ids) > BATCH_LIMIT:
         output_error(
             args,
@@ -554,7 +554,7 @@ def _handle_metadata_batch(args, api_key, workspace_url, image_ids, metadata, re
         output_error(args, str(exc), exit_code=1)
         return
     except TimeoutError as exc:
-        output_error(args, str(exc))
+        output_error(args, str(exc), exit_code=1)
         return
 
     result_data = final.get("result", {})

--- a/roboflow/cli/handlers/image.py
+++ b/roboflow/cli/handlers/image.py
@@ -143,13 +143,45 @@ def search_images(
 def tag_image(
     ctx: typer.Context,
     image_id: Annotated[str, typer.Argument(help="Image ID")],
-    project: Annotated[str, typer.Option("-p", "--project", help="Project ID")],
     add_tags: Annotated[Optional[str], typer.Option("--add", help="Comma-separated tags to add")] = None,
     remove_tags: Annotated[Optional[str], typer.Option("--remove", help="Comma-separated tags to remove")] = None,
 ) -> None:
     """Add or remove tags on an image."""
-    args = ctx_to_args(ctx, image_id=image_id, project=project, add_tags=add_tags, remove_tags=remove_tags)
+    args = ctx_to_args(ctx, image_id=image_id, add_tags=add_tags, remove_tags=remove_tags)
     _handle_tag(args)
+
+
+@image_app.command("update")
+def update_image(
+    ctx: typer.Context,
+    image_ids: Annotated[str, typer.Argument(help="Comma-separated image IDs (batch mode if multiple)")],
+    metadata: Annotated[
+        Optional[str], typer.Option("-m", "--metadata", help="JSON string of key-value metadata to set")
+    ] = None,
+    remove_metadata: Annotated[
+        Optional[str], typer.Option("--remove-metadata", help="Comma-separated metadata keys to remove")
+    ] = None,
+    add_tags: Annotated[Optional[str], typer.Option("--add-tags", help="Comma-separated tags to add")] = None,
+    remove_tags: Annotated[Optional[str], typer.Option("--remove-tags", help="Comma-separated tags to remove")] = None,
+    poll: Annotated[bool, typer.Option("--poll/--no-poll", help="For batch updates: poll until complete")] = False,
+    timeout: Annotated[int, typer.Option("--timeout", help="Polling timeout in seconds")] = 1800,
+) -> None:
+    """Update metadata and tags on existing images.
+
+    Single image ID: updates synchronously.
+    Multiple comma-separated IDs: uses the batch async endpoint.
+    """
+    args = ctx_to_args(
+        ctx,
+        image_ids=image_ids,
+        metadata=metadata,
+        remove_metadata=remove_metadata,
+        add_tags=add_tags,
+        remove_tags=remove_tags,
+        poll=poll,
+        timeout=timeout,
+    )
+    _handle_update(args)
 
 
 @image_app.command("delete")
@@ -373,55 +405,174 @@ def _handle_search(args):  # noqa: ANN001
 
 
 def _handle_tag(args):  # noqa: ANN001
-    import requests
-
+    from roboflow.adapters import rfapi
     from roboflow.cli._output import output, output_error
-    from roboflow.config import API_URL, load_roboflow_api_key
+    from roboflow.cli._resolver import resolve_ws_and_key
 
     if not args.add_tags and not args.remove_tags:
         output_error(args, "Nothing to do", hint="Specify --add and/or --remove with comma-separated tags")
         return
 
-    api_key = args.api_key or load_roboflow_api_key(args.workspace)
-    if not api_key:
-        output_error(args, "No API key found", hint="Set ROBOFLOW_API_KEY or run 'roboflow auth login'", exit_code=2)
+    resolved = resolve_ws_and_key(args)
+    if not resolved:
+        return
+    workspace_url, api_key = resolved
+
+    add_list = [t.strip() for t in args.add_tags.split(",") if t.strip()] if args.add_tags else None
+    remove_list = [t.strip() for t in args.remove_tags.split(",") if t.strip()] if args.remove_tags else None
+
+    try:
+        rfapi.update_image_metadata(
+            api_key=api_key,
+            workspace_url=workspace_url,
+            image_id=args.image_id,
+            add_tags=add_list,
+            remove_tags=remove_list,
+        )
+    except rfapi.RoboflowError as exc:
+        output_error(args, str(exc), exit_code=1)
         return
 
-    workspace_url = args.workspace or _default_workspace()
-    if not workspace_url:
-        output_error(args, "No workspace specified", hint="Use --workspace or run 'roboflow auth login'")
-        return
-
-    base = f"{API_URL}/{workspace_url}/{args.project}/images/{args.image_id}/tags"
-    added = []
-    removed = []
-
-    if args.add_tags:
-        for tag in args.add_tags.split(","):
-            tag = tag.strip()
-            if not tag:
-                continue
-            resp = requests.post(base, params={"api_key": api_key}, json={"tag": tag})
-            if resp.status_code == 200:
-                added.append(tag)
-
-    if args.remove_tags:
-        for tag in args.remove_tags.split(","):
-            tag = tag.strip()
-            if not tag:
-                continue
-            resp = requests.delete(f"{base}/{tag}", params={"api_key": api_key})
-            if resp.status_code == 200:
-                removed.append(tag)
-
-    data = {"added": added, "removed": removed}
+    data = {"added": add_list or [], "removed": remove_list or []}
     parts = []
-    if added:
-        parts.append(f"Added tags: {', '.join(added)}")
-    if removed:
-        parts.append(f"Removed tags: {', '.join(removed)}")
+    if add_list:
+        parts.append(f"Added tags: {', '.join(add_list)}")
+    if remove_list:
+        parts.append(f"Removed tags: {', '.join(remove_list)}")
     text = "; ".join(parts) if parts else "No tags modified"
     output(args, data, text=text)
+
+
+def _handle_update(args):  # noqa: ANN001
+    import json as json_mod
+
+    from roboflow.adapters import rfapi
+    from roboflow.cli._output import output, output_error
+    from roboflow.cli._resolver import resolve_ws_and_key
+
+    ids = [i.strip() for i in args.image_ids.split(",") if i.strip()]
+    if not ids:
+        output_error(args, "No image IDs provided")
+        return
+
+    metadata_dict = None
+    if args.metadata:
+        try:
+            metadata_dict = json_mod.loads(args.metadata)
+            if not isinstance(metadata_dict, dict):
+                output_error(args, "Metadata must be a JSON object", hint='Example: \'{"key": "value"}\'')
+                return
+        except json_mod.JSONDecodeError as exc:
+            output_error(args, f"Invalid metadata JSON: {exc}", hint='Example: \'{"key": "value"}\'')
+            return
+
+    remove_meta_list = (
+        [k.strip() for k in args.remove_metadata.split(",") if k.strip()] if args.remove_metadata else None
+    )
+    add_tags_list = [t.strip() for t in args.add_tags.split(",") if t.strip()] if args.add_tags else None
+    remove_tags_list = [t.strip() for t in args.remove_tags.split(",") if t.strip()] if args.remove_tags else None
+
+    if not metadata_dict and not remove_meta_list and not add_tags_list and not remove_tags_list:
+        output_error(
+            args,
+            "Nothing to update",
+            hint="Specify at least one of --metadata, --remove-metadata, --add-tags, --remove-tags",
+        )
+        return
+
+    resolved = resolve_ws_and_key(args)
+    if not resolved:
+        return
+    workspace_url, api_key = resolved
+
+    if len(ids) == 1:
+        try:
+            rfapi.update_image_metadata(
+                api_key=api_key,
+                workspace_url=workspace_url,
+                image_id=ids[0],
+                metadata=metadata_dict,
+                remove_metadata=remove_meta_list,
+                add_tags=add_tags_list,
+                remove_tags=remove_tags_list,
+            )
+        except rfapi.RoboflowError as exc:
+            output_error(args, str(exc), exit_code=1)
+            return
+        data = {"success": True, "imageId": ids[0]}
+        output(args, data, text=f"Updated image {ids[0]}")
+    else:
+        _handle_update_batch(
+            args, api_key, workspace_url, ids, metadata_dict, remove_meta_list, add_tags_list, remove_tags_list
+        )
+
+
+def _handle_update_batch(args, api_key, workspace_url, image_ids, metadata, remove_metadata, add_tags, remove_tags):  # noqa: ANN001
+    from roboflow.adapters import rfapi
+    from roboflow.cli._output import output, output_error
+
+    BATCH_LIMIT = 1000
+    if len(image_ids) > BATCH_LIMIT:
+        output_error(
+            args,
+            f"Too many images: {len(image_ids)} (limit: {BATCH_LIMIT})",
+            hint=f"Split into batches of {BATCH_LIMIT} or fewer",
+        )
+        return
+
+    updates = []
+    for img_id in image_ids:
+        entry: dict = {"imageId": img_id}
+        if metadata:
+            entry["metadata"] = metadata
+        if remove_metadata:
+            entry["removeMetadata"] = remove_metadata
+        if add_tags:
+            entry["addTags"] = add_tags
+        if remove_tags:
+            entry["removeTags"] = remove_tags
+        updates.append(entry)
+
+    try:
+        result = rfapi.batch_update_image_metadata(
+            api_key=api_key,
+            workspace_url=workspace_url,
+            updates=updates,
+        )
+    except rfapi.RoboflowError as exc:
+        output_error(args, str(exc), exit_code=1)
+        return
+
+    task_id = result.get("taskId")
+    polling_url = result.get("url")
+
+    if not args.poll:
+        data = {"taskId": task_id, "url": polling_url, "imageCount": len(image_ids)}
+        output(args, data, text=f"Batch update started: taskId={task_id} ({len(image_ids)} images)")
+        return
+
+    from roboflow.core.async_tasks import poll_until_terminal
+
+    try:
+        final = poll_until_terminal(
+            api_key,
+            workspace_url,
+            task_id,
+            timeout=args.timeout,
+            polling_url=polling_url,
+        )
+    except rfapi.RoboflowError as exc:
+        output_error(args, str(exc), exit_code=1)
+        return
+    except TimeoutError as exc:
+        output_error(args, str(exc))
+        return
+
+    result_data = final.get("result", {})
+    data = {"taskId": task_id, "status": final.get("status"), **result_data}
+    succeeded = result_data.get("succeeded", 0)
+    failed = result_data.get("failed", 0)
+    output(args, data, text=f"Batch update complete: {succeeded} succeeded, {failed} failed (taskId={task_id})")
 
 
 def _handle_delete(args):  # noqa: ANN001

--- a/roboflow/cli/handlers/image.py
+++ b/roboflow/cli/handlers/image.py
@@ -139,34 +139,17 @@ def search_images(
         _search(args)
 
 
-@image_app.command("tag")
-def tag_image(
+def _metadata_command(
     ctx: typer.Context,
-    image_id: Annotated[str, typer.Argument(help="Image ID")],
-    add_tags: Annotated[Optional[str], typer.Option("--add", help="Comma-separated tags to add")] = None,
-    remove_tags: Annotated[Optional[str], typer.Option("--remove", help="Comma-separated tags to remove")] = None,
+    image_ids: str,
+    metadata: Optional[str] = None,
+    remove_metadata: Optional[str] = None,
+    tags: Optional[str] = None,
+    remove_tags: Optional[str] = None,
+    poll: bool = False,
+    timeout: int = 1800,
 ) -> None:
-    """Add or remove tags on an image."""
-    args = ctx_to_args(ctx, image_id=image_id, add_tags=add_tags, remove_tags=remove_tags)
-    _handle_tag(args)
-
-
-@image_app.command("update")
-def update_image(
-    ctx: typer.Context,
-    image_ids: Annotated[str, typer.Argument(help="Comma-separated image IDs (batch mode if multiple)")],
-    metadata: Annotated[
-        Optional[str], typer.Option("-m", "--metadata", help="JSON string of key-value metadata to set")
-    ] = None,
-    remove_metadata: Annotated[
-        Optional[str], typer.Option("--remove-metadata", help="Comma-separated metadata keys to remove")
-    ] = None,
-    add_tags: Annotated[Optional[str], typer.Option("--add-tags", help="Comma-separated tags to add")] = None,
-    remove_tags: Annotated[Optional[str], typer.Option("--remove-tags", help="Comma-separated tags to remove")] = None,
-    poll: Annotated[bool, typer.Option("--poll/--no-poll", help="For batch updates: poll until complete")] = False,
-    timeout: Annotated[int, typer.Option("--timeout", help="Polling timeout in seconds")] = 1800,
-) -> None:
-    """Update metadata and tags on existing images.
+    """Update metadata and/or tags on existing images.
 
     Single image ID: updates synchronously.
     Multiple comma-separated IDs: uses the batch async endpoint.
@@ -176,12 +159,50 @@ def update_image(
         image_ids=image_ids,
         metadata=metadata,
         remove_metadata=remove_metadata,
-        add_tags=add_tags,
+        add_tags=tags,
         remove_tags=remove_tags,
         poll=poll,
         timeout=timeout,
     )
-    _handle_update(args)
+    _handle_metadata(args)
+
+
+@image_app.command("metadata")
+def metadata_image(
+    ctx: typer.Context,
+    image_ids: Annotated[str, typer.Argument(help="Comma-separated image IDs (batch mode if multiple)")],
+    metadata: Annotated[
+        Optional[str], typer.Option("-m", "--metadata", help="JSON string of key-value metadata to set")
+    ] = None,
+    remove_metadata: Annotated[
+        Optional[str], typer.Option("--remove-metadata", help="Comma-separated metadata keys to remove")
+    ] = None,
+    tags: Annotated[Optional[str], typer.Option("--tags", help="Comma-separated tags to add")] = None,
+    remove_tags: Annotated[Optional[str], typer.Option("--remove-tags", help="Comma-separated tags to remove")] = None,
+    poll: Annotated[bool, typer.Option("--poll/--no-poll", help="For batch updates: poll until complete")] = False,
+    timeout: Annotated[int, typer.Option("--timeout", help="Polling timeout in seconds")] = 1800,
+) -> None:
+    """Update metadata and/or tags on existing images."""
+    _metadata_command(ctx, image_ids, metadata, remove_metadata, tags, remove_tags, poll, timeout)
+
+
+@image_app.command("tag", hidden=True)
+def tag_image(
+    ctx: typer.Context,
+    image_ids: Annotated[str, typer.Argument(help="Comma-separated image IDs (batch mode if multiple)")],
+    metadata: Annotated[
+        Optional[str], typer.Option("-m", "--metadata", help="JSON string of key-value metadata to set")
+    ] = None,
+    remove_metadata: Annotated[
+        Optional[str], typer.Option("--remove-metadata", help="Comma-separated metadata keys to remove")
+    ] = None,
+    tags: Annotated[Optional[str], typer.Option("--tags", help="Comma-separated tags to add")] = None,
+    remove_tags: Annotated[Optional[str], typer.Option("--remove-tags", help="Comma-separated tags to remove")] = None,
+    poll: Annotated[bool, typer.Option("--poll/--no-poll", help="For batch updates: poll until complete")] = False,
+    timeout: Annotated[int, typer.Option("--timeout", help="Polling timeout in seconds")] = 1800,
+) -> None:
+    """Alias for 'metadata'."""
+    _metadata_command(ctx, image_ids, metadata, remove_metadata, tags, remove_tags, poll, timeout)
 
 
 @image_app.command("delete")
@@ -404,46 +425,7 @@ def _handle_search(args):  # noqa: ANN001
     output(args, result, text=json.dumps(result, indent=2))
 
 
-def _handle_tag(args):  # noqa: ANN001
-    from roboflow.adapters import rfapi
-    from roboflow.cli._output import output, output_error
-    from roboflow.cli._resolver import resolve_ws_and_key
-
-    if not args.add_tags and not args.remove_tags:
-        output_error(args, "Nothing to do", hint="Specify --add and/or --remove with comma-separated tags")
-        return
-
-    resolved = resolve_ws_and_key(args)
-    if not resolved:
-        return
-    workspace_url, api_key = resolved
-
-    add_list = [t.strip() for t in args.add_tags.split(",") if t.strip()] if args.add_tags else None
-    remove_list = [t.strip() for t in args.remove_tags.split(",") if t.strip()] if args.remove_tags else None
-
-    try:
-        rfapi.update_image_metadata(
-            api_key=api_key,
-            workspace_url=workspace_url,
-            image_id=args.image_id,
-            add_tags=add_list,
-            remove_tags=remove_list,
-        )
-    except rfapi.RoboflowError as exc:
-        output_error(args, str(exc), exit_code=1)
-        return
-
-    data = {"added": add_list or [], "removed": remove_list or []}
-    parts = []
-    if add_list:
-        parts.append(f"Added tags: {', '.join(add_list)}")
-    if remove_list:
-        parts.append(f"Removed tags: {', '.join(remove_list)}")
-    text = "; ".join(parts) if parts else "No tags modified"
-    output(args, data, text=text)
-
-
-def _handle_update(args):  # noqa: ANN001
+def _handle_metadata(args):  # noqa: ANN001
     import json as json_mod
 
     from roboflow.adapters import rfapi
@@ -476,7 +458,7 @@ def _handle_update(args):  # noqa: ANN001
         output_error(
             args,
             "Nothing to update",
-            hint="Specify at least one of --metadata, --remove-metadata, --add-tags, --remove-tags",
+            hint="Specify at least one of --metadata, --remove-metadata, --tags, --remove-tags",
         )
         return
 
@@ -502,12 +484,12 @@ def _handle_update(args):  # noqa: ANN001
         data = {"success": True, "imageId": ids[0]}
         output(args, data, text=f"Updated image {ids[0]}")
     else:
-        _handle_update_batch(
+        _handle_metadata_batch(
             args, api_key, workspace_url, ids, metadata_dict, remove_meta_list, add_tags_list, remove_tags_list
         )
 
 
-def _handle_update_batch(args, api_key, workspace_url, image_ids, metadata, remove_metadata, add_tags, remove_tags):  # noqa: ANN001
+def _handle_metadata_batch(args, api_key, workspace_url, image_ids, metadata, remove_metadata, add_tags, remove_tags):  # noqa: ANN001
     from roboflow.adapters import rfapi
     from roboflow.cli._output import output, output_error
 

--- a/tests/adapters/test_rfapi_phase2.py
+++ b/tests/adapters/test_rfapi_phase2.py
@@ -832,5 +832,80 @@ class TestSearchUniverse(unittest.TestCase):
             search_universe("query")
 
 
+class TestUpdateImageMetadata(unittest.TestCase):
+    @patch("roboflow.adapters.rfapi.requests.post")
+    def test_success(self, mock_post):
+        from roboflow.adapters.rfapi import update_image_metadata
+
+        mock_post.return_value = MagicMock(status_code=200, json=lambda: {"success": True})
+        result = update_image_metadata("key", "ws", "img-1", add_tags=["tag1"], remove_tags=["old"])
+        self.assertEqual(result, {"success": True})
+        mock_post.assert_called_once()
+        self.assertIn("/ws/images/img-1/metadata", mock_post.call_args[0][0])
+        payload = mock_post.call_args[1]["json"]
+        self.assertEqual(payload["addTags"], ["tag1"])
+        self.assertEqual(payload["removeTags"], ["old"])
+
+    @patch("roboflow.adapters.rfapi.requests.post")
+    def test_only_sends_provided_fields(self, mock_post):
+        from roboflow.adapters.rfapi import update_image_metadata
+
+        mock_post.return_value = MagicMock(status_code=200, json=lambda: {"success": True})
+        update_image_metadata("key", "ws", "img-1", add_tags=["foo"])
+        payload = mock_post.call_args[1]["json"]
+        self.assertEqual(payload, {"addTags": ["foo"]})
+
+    @patch("roboflow.adapters.rfapi.requests.post")
+    def test_metadata_and_tags(self, mock_post):
+        from roboflow.adapters.rfapi import update_image_metadata
+
+        mock_post.return_value = MagicMock(status_code=200, json=lambda: {"success": True})
+        update_image_metadata("key", "ws", "img-1", metadata={"cam": "1"}, add_tags=["review"])
+        payload = mock_post.call_args[1]["json"]
+        self.assertEqual(payload["metadata"], {"cam": "1"})
+        self.assertEqual(payload["addTags"], ["review"])
+
+    @patch("roboflow.adapters.rfapi.requests.post")
+    def test_error_404(self, mock_post):
+        from roboflow.adapters.rfapi import RoboflowError, update_image_metadata
+
+        mock_post.return_value = MagicMock(status_code=404, text="Not found")
+        with self.assertRaises(RoboflowError):
+            update_image_metadata("key", "ws", "img-1", add_tags=["x"])
+
+    @patch("roboflow.adapters.rfapi.requests.post")
+    def test_image_id_url_encoded(self, mock_post):
+        from roboflow.adapters.rfapi import update_image_metadata
+
+        mock_post.return_value = MagicMock(status_code=200, json=lambda: {"success": True})
+        update_image_metadata("key", "ws", "img/1", add_tags=["a"])
+        called_url = mock_post.call_args[0][0]
+        self.assertIn("/ws/images/img%2F1/metadata", called_url)
+        self.assertNotIn("/ws/images/img/1/metadata", called_url)
+
+
+class TestBatchUpdateImageMetadata(unittest.TestCase):
+    @patch("roboflow.adapters.rfapi.requests.post")
+    def test_success(self, mock_post):
+        from roboflow.adapters.rfapi import batch_update_image_metadata
+
+        updates = [{"imageId": "img-1", "addTags": ["t1"]}, {"imageId": "img-2", "metadata": {"k": "v"}}]
+        mock_post.return_value = MagicMock(status_code=202, json=lambda: {"taskId": "t1", "url": "poll-url"})
+        result = batch_update_image_metadata("key", "ws", updates)
+        self.assertEqual(result, {"taskId": "t1", "url": "poll-url"})
+        mock_post.assert_called_once()
+        self.assertIn("/ws/images/metadata", mock_post.call_args[0][0])
+        payload = mock_post.call_args[1]["json"]
+        self.assertEqual(payload, {"updates": updates})
+
+    @patch("roboflow.adapters.rfapi.requests.post")
+    def test_error_400(self, mock_post):
+        from roboflow.adapters.rfapi import RoboflowError, batch_update_image_metadata
+
+        mock_post.return_value = MagicMock(status_code=400, text="Bad request")
+        with self.assertRaises(RoboflowError):
+            batch_update_image_metadata("key", "ws", [{"imageId": "img-1"}])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/cli/test_image_handler.py
+++ b/tests/cli/test_image_handler.py
@@ -466,14 +466,14 @@ class TestImageMetadataRegistration(unittest.TestCase):
     def test_image_metadata_help(self):
         result = runner.invoke(app, ["image", "metadata", "--help"])
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("--tags", result.output)
-        self.assertIn("--metadata", result.output)
+        self.assertIn("tags", result.output.lower())
+        self.assertIn("metadata", result.output.lower())
 
     def test_tag_is_alias(self):
         result = runner.invoke(app, ["image", "tag", "--help"])
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("--tags", result.output)
-        self.assertNotIn("--project", result.output)
+        self.assertIn("tags", result.output.lower())
+        self.assertNotIn("project", result.output.lower())
 
 
 class TestImageMetadataSingle(unittest.TestCase):

--- a/tests/cli/test_image_handler.py
+++ b/tests/cli/test_image_handler.py
@@ -485,5 +485,190 @@ class TestImageTagValidation(unittest.TestCase):
         self.assertIn("Nothing to do", buf.getvalue())
 
 
+class TestImageUpdateRegistration(unittest.TestCase):
+    """Verify the update and refactored tag commands register correctly."""
+
+    def test_image_update_help(self):
+        result = runner.invoke(app, ["image", "update", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("metadata", result.output.lower())
+
+    def test_tag_help_no_project(self):
+        result = runner.invoke(app, ["image", "tag", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertNotIn("--project", result.output)
+
+
+class TestImageTagRefactored(unittest.TestCase):
+    """Test the refactored tag handler that uses rfapi directly."""
+
+    @patch("roboflow.cli._resolver.resolve_ws_and_key", return_value=("test-ws", "test-key"))
+    @patch("roboflow.adapters.rfapi.update_image_metadata", return_value={"success": True})
+    def test_tag_calls_rfapi(self, mock_update, mock_resolve):
+        from roboflow.cli.handlers.image import _handle_tag
+
+        args = _make_args(image_id="img-1", add_tags="foo,bar", remove_tags="baz")
+        _handle_tag(args)
+        mock_update.assert_called_once_with(
+            api_key="test-key",
+            workspace_url="test-ws",
+            image_id="img-1",
+            add_tags=["foo", "bar"],
+            remove_tags=["baz"],
+        )
+
+    @patch("roboflow.cli._resolver.resolve_ws_and_key", return_value=("test-ws", "test-key"))
+    @patch("roboflow.adapters.rfapi.update_image_metadata", return_value={"success": True})
+    def test_tag_json_output(self, mock_update, mock_resolve):
+        from roboflow.cli.handlers.image import _handle_tag
+
+        args = _make_args(image_id="img-1", add_tags="foo", remove_tags=None, json=True)
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.stdout = buf
+        try:
+            _handle_tag(args)
+        finally:
+            sys.stdout = old
+        data = json.loads(buf.getvalue())
+        self.assertEqual(data["added"], ["foo"])
+        self.assertEqual(data["removed"], [])
+
+
+class TestImageUpdateSingle(unittest.TestCase):
+    """Test the single-image update path."""
+
+    @patch("roboflow.cli._resolver.resolve_ws_and_key", return_value=("test-ws", "test-key"))
+    @patch("roboflow.adapters.rfapi.update_image_metadata", return_value={"success": True})
+    def test_update_single_metadata(self, mock_update, mock_resolve):
+        from roboflow.cli.handlers.image import _handle_update
+
+        args = _make_args(
+            image_ids="img-1",
+            metadata='{"camera": "cam1"}',
+            remove_metadata=None,
+            add_tags="review",
+            remove_tags=None,
+            poll=False,
+            timeout=1800,
+        )
+        _handle_update(args)
+        mock_update.assert_called_once_with(
+            api_key="test-key",
+            workspace_url="test-ws",
+            image_id="img-1",
+            metadata={"camera": "cam1"},
+            remove_metadata=None,
+            add_tags=["review"],
+            remove_tags=None,
+        )
+
+    def test_update_invalid_metadata_json(self):
+        from roboflow.cli.handlers.image import _handle_update
+
+        args = _make_args(
+            image_ids="img-1",
+            metadata="not-json",
+            remove_metadata=None,
+            add_tags=None,
+            remove_tags=None,
+            poll=False,
+            timeout=1800,
+        )
+        buf = io.StringIO()
+        old = sys.stderr
+        sys.stderr = buf
+        try:
+            with self.assertRaises(SystemExit):
+                _handle_update(args)
+        finally:
+            sys.stderr = old
+        self.assertIn("Invalid metadata JSON", buf.getvalue())
+
+    def test_update_nothing_to_do(self):
+        from roboflow.cli.handlers.image import _handle_update
+
+        args = _make_args(
+            image_ids="img-1",
+            metadata=None,
+            remove_metadata=None,
+            add_tags=None,
+            remove_tags=None,
+            poll=False,
+            timeout=1800,
+        )
+        buf = io.StringIO()
+        old = sys.stderr
+        sys.stderr = buf
+        try:
+            with self.assertRaises(SystemExit):
+                _handle_update(args)
+        finally:
+            sys.stderr = old
+        self.assertIn("Nothing to update", buf.getvalue())
+
+
+class TestImageUpdateBatch(unittest.TestCase):
+    """Test the batch (multi-image) update path."""
+
+    @patch("roboflow.cli._resolver.resolve_ws_and_key", return_value=("test-ws", "test-key"))
+    @patch(
+        "roboflow.adapters.rfapi.batch_update_image_metadata",
+        return_value={"taskId": "t1", "url": "https://api.roboflow.com/test-ws/asynctasks/t1"},
+    )
+    def test_update_batch_no_poll(self, mock_batch, mock_resolve):
+        from roboflow.cli.handlers.image import _handle_update
+
+        args = _make_args(
+            image_ids="img-1,img-2,img-3",
+            metadata=None,
+            remove_metadata=None,
+            add_tags="review",
+            remove_tags=None,
+            poll=False,
+            timeout=1800,
+            json=True,
+        )
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.stdout = buf
+        try:
+            _handle_update(args)
+        finally:
+            sys.stdout = old
+        data = json.loads(buf.getvalue())
+        self.assertEqual(data["taskId"], "t1")
+        self.assertEqual(data["imageCount"], 3)
+        mock_batch.assert_called_once()
+        updates = mock_batch.call_args[1]["updates"]
+        self.assertEqual(len(updates), 3)
+        self.assertEqual(updates[0]["imageId"], "img-1")
+        self.assertEqual(updates[0]["addTags"], ["review"])
+
+    def test_update_batch_over_limit(self):
+        from roboflow.cli.handlers.image import _handle_update
+
+        ids = ",".join([f"img-{i}" for i in range(1001)])
+        args = _make_args(
+            image_ids=ids,
+            metadata=None,
+            remove_metadata=None,
+            add_tags="review",
+            remove_tags=None,
+            poll=False,
+            timeout=1800,
+        )
+        with patch("roboflow.cli._resolver.resolve_ws_and_key", return_value=("test-ws", "test-key")):
+            buf = io.StringIO()
+            old = sys.stderr
+            sys.stderr = buf
+            try:
+                with self.assertRaises(SystemExit):
+                    _handle_update(args)
+            finally:
+                sys.stderr = old
+            self.assertIn("Too many images", buf.getvalue())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/cli/test_image_handler.py
+++ b/tests/cli/test_image_handler.py
@@ -460,88 +460,29 @@ class TestUploadPathNotFound(unittest.TestCase):
             _handle_upload(args)
 
 
-class TestImageTagValidation(unittest.TestCase):
-    """Test that tag command validates --add/--remove presence."""
+class TestImageMetadataRegistration(unittest.TestCase):
+    """Verify the metadata command and tag alias register correctly."""
 
-    def test_tag_no_add_or_remove(self):
-        from roboflow.cli.handlers.image import _handle_tag
-
-        args = _make_args(
-            image_id="img-1",
-            project="proj",
-            add_tags=None,
-            remove_tags=None,
-        )
-
-        buf = io.StringIO()
-        old = sys.stderr
-        sys.stderr = buf
-        try:
-            with self.assertRaises(SystemExit):
-                _handle_tag(args)
-        finally:
-            sys.stderr = old
-
-        self.assertIn("Nothing to do", buf.getvalue())
-
-
-class TestImageUpdateRegistration(unittest.TestCase):
-    """Verify the update and refactored tag commands register correctly."""
-
-    def test_image_update_help(self):
-        result = runner.invoke(app, ["image", "update", "--help"])
+    def test_image_metadata_help(self):
+        result = runner.invoke(app, ["image", "metadata", "--help"])
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("metadata", result.output.lower())
+        self.assertIn("--tags", result.output)
+        self.assertIn("--metadata", result.output)
 
-    def test_tag_help_no_project(self):
+    def test_tag_is_alias(self):
         result = runner.invoke(app, ["image", "tag", "--help"])
         self.assertEqual(result.exit_code, 0)
+        self.assertIn("--tags", result.output)
         self.assertNotIn("--project", result.output)
 
 
-class TestImageTagRefactored(unittest.TestCase):
-    """Test the refactored tag handler that uses rfapi directly."""
+class TestImageMetadataSingle(unittest.TestCase):
+    """Test the single-image metadata path."""
 
     @patch("roboflow.cli._resolver.resolve_ws_and_key", return_value=("test-ws", "test-key"))
     @patch("roboflow.adapters.rfapi.update_image_metadata", return_value={"success": True})
-    def test_tag_calls_rfapi(self, mock_update, mock_resolve):
-        from roboflow.cli.handlers.image import _handle_tag
-
-        args = _make_args(image_id="img-1", add_tags="foo,bar", remove_tags="baz")
-        _handle_tag(args)
-        mock_update.assert_called_once_with(
-            api_key="test-key",
-            workspace_url="test-ws",
-            image_id="img-1",
-            add_tags=["foo", "bar"],
-            remove_tags=["baz"],
-        )
-
-    @patch("roboflow.cli._resolver.resolve_ws_and_key", return_value=("test-ws", "test-key"))
-    @patch("roboflow.adapters.rfapi.update_image_metadata", return_value={"success": True})
-    def test_tag_json_output(self, mock_update, mock_resolve):
-        from roboflow.cli.handlers.image import _handle_tag
-
-        args = _make_args(image_id="img-1", add_tags="foo", remove_tags=None, json=True)
-        buf = io.StringIO()
-        old = sys.stdout
-        sys.stdout = buf
-        try:
-            _handle_tag(args)
-        finally:
-            sys.stdout = old
-        data = json.loads(buf.getvalue())
-        self.assertEqual(data["added"], ["foo"])
-        self.assertEqual(data["removed"], [])
-
-
-class TestImageUpdateSingle(unittest.TestCase):
-    """Test the single-image update path."""
-
-    @patch("roboflow.cli._resolver.resolve_ws_and_key", return_value=("test-ws", "test-key"))
-    @patch("roboflow.adapters.rfapi.update_image_metadata", return_value={"success": True})
-    def test_update_single_metadata(self, mock_update, mock_resolve):
-        from roboflow.cli.handlers.image import _handle_update
+    def test_metadata_single(self, mock_update, mock_resolve):
+        from roboflow.cli.handlers.image import _handle_metadata
 
         args = _make_args(
             image_ids="img-1",
@@ -552,7 +493,7 @@ class TestImageUpdateSingle(unittest.TestCase):
             poll=False,
             timeout=1800,
         )
-        _handle_update(args)
+        _handle_metadata(args)
         mock_update.assert_called_once_with(
             api_key="test-key",
             workspace_url="test-ws",
@@ -563,8 +504,8 @@ class TestImageUpdateSingle(unittest.TestCase):
             remove_tags=None,
         )
 
-    def test_update_invalid_metadata_json(self):
-        from roboflow.cli.handlers.image import _handle_update
+    def test_metadata_invalid_json(self):
+        from roboflow.cli.handlers.image import _handle_metadata
 
         args = _make_args(
             image_ids="img-1",
@@ -580,13 +521,13 @@ class TestImageUpdateSingle(unittest.TestCase):
         sys.stderr = buf
         try:
             with self.assertRaises(SystemExit):
-                _handle_update(args)
+                _handle_metadata(args)
         finally:
             sys.stderr = old
         self.assertIn("Invalid metadata JSON", buf.getvalue())
 
-    def test_update_nothing_to_do(self):
-        from roboflow.cli.handlers.image import _handle_update
+    def test_metadata_nothing_to_do(self):
+        from roboflow.cli.handlers.image import _handle_metadata
 
         args = _make_args(
             image_ids="img-1",
@@ -602,22 +543,22 @@ class TestImageUpdateSingle(unittest.TestCase):
         sys.stderr = buf
         try:
             with self.assertRaises(SystemExit):
-                _handle_update(args)
+                _handle_metadata(args)
         finally:
             sys.stderr = old
         self.assertIn("Nothing to update", buf.getvalue())
 
 
-class TestImageUpdateBatch(unittest.TestCase):
-    """Test the batch (multi-image) update path."""
+class TestImageMetadataBatch(unittest.TestCase):
+    """Test the batch (multi-image) metadata path."""
 
     @patch("roboflow.cli._resolver.resolve_ws_and_key", return_value=("test-ws", "test-key"))
     @patch(
         "roboflow.adapters.rfapi.batch_update_image_metadata",
         return_value={"taskId": "t1", "url": "https://api.roboflow.com/test-ws/asynctasks/t1"},
     )
-    def test_update_batch_no_poll(self, mock_batch, mock_resolve):
-        from roboflow.cli.handlers.image import _handle_update
+    def test_metadata_batch_no_poll(self, mock_batch, mock_resolve):
+        from roboflow.cli.handlers.image import _handle_metadata
 
         args = _make_args(
             image_ids="img-1,img-2,img-3",
@@ -633,7 +574,7 @@ class TestImageUpdateBatch(unittest.TestCase):
         old = sys.stdout
         sys.stdout = buf
         try:
-            _handle_update(args)
+            _handle_metadata(args)
         finally:
             sys.stdout = old
         data = json.loads(buf.getvalue())
@@ -645,8 +586,8 @@ class TestImageUpdateBatch(unittest.TestCase):
         self.assertEqual(updates[0]["imageId"], "img-1")
         self.assertEqual(updates[0]["addTags"], ["review"])
 
-    def test_update_batch_over_limit(self):
-        from roboflow.cli.handlers.image import _handle_update
+    def test_metadata_batch_over_limit(self):
+        from roboflow.cli.handlers.image import _handle_metadata
 
         ids = ",".join([f"img-{i}" for i in range(1001)])
         args = _make_args(
@@ -664,7 +605,7 @@ class TestImageUpdateBatch(unittest.TestCase):
             sys.stderr = buf
             try:
                 with self.assertRaises(SystemExit):
-                    _handle_update(args)
+                    _handle_metadata(args)
             finally:
                 sys.stderr = old
             self.assertIn("Too many images", buf.getvalue())


### PR DESCRIPTION
## Description

Adds CLI support for updating metadata and tags on existing images using the new workspace-level API endpoints (roboflow/roboflow#11836).

**Changes:**
- New `roboflow image metadata` command — single-image sync or multi-image batch (async with polling)
- `roboflow image tag` kept as a hidden alias pointing to the same handler (zero duplication)
- Two new rfapi adapter functions: `update_image_metadata` (sync) and `batch_update_image_metadata` (async)

## Type of change

- [x] New feature

## How has this change been tested?

- 113 unit tests pass (16 new tests covering adapter + CLI handler)
- ruff lint and mypy pass
- CLI help verified for both `image metadata` and `image tag`

## Usage examples

```bash
# Single image: set metadata + add tags
roboflow image metadata <image_id> -m '{"camera": "cam1"}' --tags "review,v2"

# Remove metadata keys
roboflow image metadata <image_id> --remove-metadata "old_key"

# Batch: update multiple images, poll for completion
roboflow image metadata img1,img2,img3 --tags "processed" --poll

# Tag alias works identically
roboflow image tag <image_id> --tags "review" --remove-tags "draft"
```

## Notes on review feedback

### `--poll` and `roboflow.core.async_tasks`

A review flagged `from roboflow.core.async_tasks import poll_until_terminal` (in `_handle_metadata_batch`) as importing a non-existent module. That module **does exist** on this branch — it was added by PR #473 (`Add Universe project fork CLI`) and provides the shared `poll_until_terminal` polling utility (`roboflow/core/async_tasks.py`). The `--poll` path imports and runs correctly; this CLI is reusing the same polling helper instead of re-implementing it inline.


### Breaking change in `roboflow image tag` flags

The hidden `roboflow image tag` alias drops the legacy `--add` / `--remove` / `--project` flags in favor of `--tags` / `--remove-tags` (no `--project`, because the new endpoint is workspace-scoped). Production traffic to the old per-tag REST endpoints (`POST/DELETE /{workspace}/{project}/images/{id}/tags/{tag}`) over the last 30 days:

Last 30 days logs:
https://cloudlogging.app.goo.gl/RRbwBKYW7cSvNHDQ6

Last 30 days from bigquery:
[bigquery](https://console.cloud.google.com/bigquery?project=roboflow-platform&q=--%20Calls%20to%20the%20old%20per-tag%20REST%20endpoints%20in%20the%20last%2030%20days.%0A--%20Endpoint%20pattern:%20%2F%7Bworkspace%7D%2F%7Bproject%7D%2Fimages%2F%7Bid%7D%2Ftags%2F%7Btag%7D%0A--%20(added%20in%20roboflow%2Froboflow-python%20PR%20%23483%20review)%0ASELECT%0A%20%20timestamp,%0A%20%20httpRequest.requestMethod%20AS%20method,%0A%20%20httpRequest.requestUrl%20%20%20%20AS%20url,%0A%20%20httpRequest.status%20%20%20%20%20%20%20%20AS%20status,%0A%20%20httpRequest.userAgent%20%20%20%20%20AS%20user_agent,%0A%20%20httpRequest.remoteIp%20%20%20%20%20%20AS%20remote_ip%0AFROM%20%60roboflow-platform.logging.run_googleapis_com_requests%60%0AWHERE%20timestamp%20%3E%3D%20TIMESTAMP_SUB(CURRENT_TIMESTAMP(),%20INTERVAL%2030%20DAY)%0A%20%20AND%20REGEXP_CONTAINS(httpRequest.requestUrl,%20r%22%2Fimages%2F%5B%5E%2F%5D%2B%2Ftags%2F%5B%5E%2F%3F%23%5D%2B%22)%0A%20%20AND%20httpRequest.requestMethod%20IN%20(%22POST%22,%20%22DELETE%22)%0AORDER%20BY%20timestamp%20DESC;&ws=!1m6!1m5!1m3!1sroboflow-platform!2sbquxjob_5db899de_19e4feaed28!3sus-central1!23sDEFAULT_STUDIO_NAVIGATION)



Since the only matches are an internal probe in a non-customer workspace, the breaking flag change on the hidden alias does not affect real users.

## Will the change affect Universe?

No

## Any specific deployment considerations

N/A — SDK-only change

## Docs

- [x] Docs updated? CLI-COMMANDS.md update needed (tracked separately)
