### PR TITLE
fix(cli): scope 'image search -p' to the project

### DIFF
--- a/roboflow/cli/handlers/image.py
+++ b/roboflow/cli/handlers/image.py
@@ -81,7 +81,8 @@ def search_images(
     ctx: typer.Context,
     query: Annotated[str, typer.Argument(help="RoboQL search query (e.g. 'tag:review' or '*')")],
     project: Annotated[
-        Optional[str], typer.Option("-p", "--project", help="Project ID (omit to search entire workspace)")
+        Optional[str],
+        typer.Option("-p", "--project", help="Project slug to scope results (omit to search entire workspace)"),
     ] = None,
     limit: Annotated[int, typer.Option(help="Number of results")] = 50,
     cursor: Annotated[Optional[str], typer.Option(help="Continuation token for pagination")] = None,
@@ -103,12 +104,10 @@ def search_images(
     With -p/--project, searches within a specific project.
     Use --export to download matching results as a dataset.
     """
-    if project:
-        # _handle_search scopes by injecting a `project:<slug>` RoboQL filter.
-        args = ctx_to_args(ctx, query=query, project=project, limit=limit, cursor=cursor)
-        _handle_search(args)
-    elif export:
-        # Workspace-level export
+    if export:
+        # Export scopes to a project via the `dataset` (project slug) body param,
+        # so route -p through as the dataset. Check export before project so
+        # `-p ... --export` exports the project instead of silently ignoring --export.
         from roboflow.cli.handlers.search import _search
 
         args = ctx_to_args(
@@ -119,12 +118,16 @@ def search_images(
             export=True,
             format=format,
             location=location,
-            dataset=dataset,
+            dataset=dataset or project,
             annotation_group=annotation_group,
             name=name,
             no_extract=no_extract,
         )
         _search(args)
+    elif project:
+        # _handle_search scopes by injecting a `project:<slug>` RoboQL filter.
+        args = ctx_to_args(ctx, query=query, project=project, limit=limit, cursor=cursor)
+        _handle_search(args)
     else:
         # Workspace-level search
         from roboflow.cli.handlers.search import _search

--- a/roboflow/cli/handlers/image.py
+++ b/roboflow/cli/handlers/image.py
@@ -104,7 +104,7 @@ def search_images(
     Use --export to download matching results as a dataset.
     """
     if project:
-        # Project-scoped search: _handle_search injects a `project:<slug>` RoboQL filter.
+        # _handle_search scopes by injecting a `project:<slug>` RoboQL filter.
         args = ctx_to_args(ctx, query=query, project=project, limit=limit, cursor=cursor)
         _handle_search(args)
     elif export:
@@ -422,12 +422,8 @@ def _handle_search(args):  # noqa: ANN001
         output_error(args, "No workspace specified", hint="Use --workspace or run 'roboflow auth login'")
         return
 
-    # Scope the search to a single project when -p/--project is given. The search/v1
-    # endpoint only honors a project filter expressed inside the RoboQL query
-    # (`project:<slug>`, which the API resolves to a project id) — body params like
-    # `project`/`dataset` are ignored. We prepend it with a leading space so it ANDs
-    # with the user's query while staying compatible with free-text/semantic queries
-    # (an explicit `AND (...)` wrapper 500s on free text).
+    # search/v1 only scopes via a `project:<slug>` RoboQL filter (body params are
+    # ignored). Leading space = implicit AND; `AND (...)` 500s on free-text queries.
     query = args.query
     project = getattr(args, "project", None)
     if project:

--- a/roboflow/cli/handlers/image.py
+++ b/roboflow/cli/handlers/image.py
@@ -104,7 +104,7 @@ def search_images(
     Use --export to download matching results as a dataset.
     """
     if project:
-        # Project-scoped search (legacy behavior)
+        # Project-scoped search: _handle_search injects a `project:<slug>` RoboQL filter.
         args = ctx_to_args(ctx, query=query, project=project, limit=limit, cursor=cursor)
         _handle_search(args)
     elif export:
@@ -422,10 +422,21 @@ def _handle_search(args):  # noqa: ANN001
         output_error(args, "No workspace specified", hint="Use --workspace or run 'roboflow auth login'")
         return
 
+    # Scope the search to a single project when -p/--project is given. The search/v1
+    # endpoint only honors a project filter expressed inside the RoboQL query
+    # (`project:<slug>`, which the API resolves to a project id) — body params like
+    # `project`/`dataset` are ignored. We prepend it with a leading space so it ANDs
+    # with the user's query while staying compatible with free-text/semantic queries
+    # (an explicit `AND (...)` wrapper 500s on free text).
+    query = args.query
+    project = getattr(args, "project", None)
+    if project:
+        query = f"project:{project} {args.query}"
+
     result = rfapi.workspace_search(
         api_key=api_key,
         workspace_url=workspace_url,
-        query=args.query,
+        query=query,
         page_size=args.limit,
         continuation_token=args.cursor,
     )

--- a/roboflow/cli/handlers/search.py
+++ b/roboflow/cli/handlers/search.py
@@ -56,7 +56,8 @@ def _search(args):  # noqa: ANN001
 
     try:
         with suppress_sdk_output():
-            rf = roboflow.Roboflow()
+            # Forward the CLI --api-key; Roboflow() falls back to saved/env creds when None.
+            rf = roboflow.Roboflow(api_key=args.api_key)
             workspace = rf.workspace(args.workspace)
     except Exception as exc:
         output_error(args, str(exc), exit_code=2)

--- a/tests/cli/test_image_handler.py
+++ b/tests/cli/test_image_handler.py
@@ -486,6 +486,35 @@ class TestImageSearch(unittest.TestCase):
         called_query = mock_workspace_search.call_args.kwargs["query"]
         self.assertEqual(called_query, "tag:test")
 
+    @patch("roboflow.cli.handlers.search._search")
+    @patch("roboflow.cli.handlers.image._handle_search")
+    def test_search_with_project_and_export_scopes_the_export(self, mock_handle_search, mock_search):
+        # `-p ... --export` must export the project, not silently drop --export.
+        result = runner.invoke(
+            app,
+            ["--workspace", "ws", "--api-key", "k", "image", "search", "tag:test", "-p", "proj", "--export"],
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handle_search.assert_not_called()
+        mock_search.assert_called_once()
+        export_args = mock_search.call_args.args[0]
+        self.assertTrue(export_args.export)
+        # Export scopes by the `dataset` (project slug) body param.
+        self.assertEqual(export_args.dataset, "proj")
+
+    @patch("roboflow.cli.handlers.search._search")
+    @patch("roboflow.cli.handlers.image._handle_search")
+    def test_search_with_project_no_export_uses_roboql_filter(self, mock_handle_search, mock_search):
+        result = runner.invoke(
+            app,
+            ["--workspace", "ws", "--api-key", "k", "image", "search", "tag:test", "-p", "proj"],
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        mock_search.assert_not_called()
+        mock_handle_search.assert_called_once()
+
 
 class TestImageAnnotate(unittest.TestCase):
     """Test the annotate handler."""

--- a/tests/cli/test_image_handler.py
+++ b/tests/cli/test_image_handler.py
@@ -462,8 +462,30 @@ class TestImageSearch(unittest.TestCase):
             sys.stdout = old
 
         mock_workspace_search.assert_called_once()
+        # -p/--project must scope the search via a `project:<slug>` RoboQL filter,
+        # combined with the user's query (the API ignores body-level project params).
+        called_query = mock_workspace_search.call_args.kwargs["query"]
+        self.assertEqual(called_query, "project:proj tag:test")
         result = json.loads(buf.getvalue())
         self.assertEqual(result["total"], 0)
+
+    @patch("roboflow.adapters.rfapi.workspace_search")
+    def test_search_without_project_is_unscoped(self, mock_workspace_search):
+        from roboflow.cli.handlers.image import _handle_search
+
+        mock_workspace_search.return_value = {"results": [], "total": 0}
+        args = _make_args(json=True, query="tag:test", project=None, limit=10, cursor=None)
+
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.stdout = buf
+        try:
+            _handle_search(args)
+        finally:
+            sys.stdout = old
+
+        called_query = mock_workspace_search.call_args.kwargs["query"]
+        self.assertEqual(called_query, "tag:test")
 
 
 class TestImageAnnotate(unittest.TestCase):

--- a/tests/cli/test_image_handler.py
+++ b/tests/cli/test_image_handler.py
@@ -462,8 +462,7 @@ class TestImageSearch(unittest.TestCase):
             sys.stdout = old
 
         mock_workspace_search.assert_called_once()
-        # -p/--project must scope the search via a `project:<slug>` RoboQL filter,
-        # combined with the user's query (the API ignores body-level project params).
+        # -p must scope via a `project:<slug>` filter prepended to the query.
         called_query = mock_workspace_search.call_args.kwargs["query"]
         self.assertEqual(called_query, "project:proj tag:test")
         result = json.loads(buf.getvalue())

--- a/tests/cli/test_image_handler.py
+++ b/tests/cli/test_image_handler.py
@@ -503,6 +503,20 @@ class TestImageSearch(unittest.TestCase):
         # Export scopes by the `dataset` (project slug) body param.
         self.assertEqual(export_args.dataset, "proj")
 
+    @patch("roboflow.Roboflow")
+    def test_search_export_forwards_cli_api_key_to_sdk(self, mock_roboflow):
+        # The export path must honor an explicitly supplied --api-key, not only
+        # saved/env credentials (CI/agent workflows pass the key directly).
+        mock_roboflow.return_value = MagicMock()
+        result = runner.invoke(
+            app,
+            ["--workspace", "ws", "--api-key", "MY_KEY", "image", "search", "tag:test", "-p", "proj", "--export"],
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        mock_roboflow.assert_called_once()
+        self.assertEqual(mock_roboflow.call_args.kwargs.get("api_key"), "MY_KEY")
+
     @patch("roboflow.cli.handlers.search._search")
     @patch("roboflow.cli.handlers.image._handle_search")
     def test_search_with_project_no_export_uses_roboql_filter(self, mock_handle_search, mock_search):


### PR DESCRIPTION
## Description

`roboflow image search "<query>" -p <project>` silently ignored `-p` and returned **workspace-wide** results — so IDs could come from other projects, and a follow-up `image get -p <project> <id>` would 404.

**Root cause**: `_handle_search` built its args with `project=...` but never used it — it called `rfapi.workspace_search` with only the raw query, so nothing scoped the result to the project.

| `image search` | Before (bug) | After (fix) |
|---|---|---|
| `"*" -p penguin-finder` | 117,275 (whole workspace) | 26,804 (project) |
| `"class:penguin" -p penguin-finder` | 646 (workspace) | 515 (project) |

## Type of change

- [x] Bug fix

## How has this change been tested?

- Live: ran the commands above against staging and confirmed scoped totals.
- Unit: strengthened `test_search` to assert the scoped query `project:proj tag:test`; added `test_search_without_project_is_unscoped`. Full suite passes (`python -m unittest`), `ruff check`/`format` clean.

## Will the change affect Universe?

No.

## Any specific deployment considerations

N/A (Python SDK / CLI package).

## Docs

- [x] Docs updated? N/A