### PR TITLE
fix(rfdetr): accept dict-form checkpoint args in classname extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 1.3.9
 
 ### Added — Model evaluations SDK & CLI
 
@@ -44,6 +44,12 @@ structured output.
 The endpoints require the `model-eval:read` scope. The base URL is
 configurable via `API_URL` (set to `https://localapi.roboflow.one` to
 test against a local API server).
+
+### Fixed
+- rf-detr model upload: accept checkpoints whose `args` is a plain dict (e.g. EMA checkpoints) when extracting class names, instead of raising `TypeError` from `vars()`.
+
+### Changed
+- Pin `typer<0.26` and declare `click` explicitly: typer 0.26 vendors its own click and drops the external dependency, which broke the CLI and its type checks.
 
 ## 1.3.7
 

--- a/requirements-slim.txt
+++ b/requirements-slim.txt
@@ -6,10 +6,7 @@ tqdm>=4.41.0
 PyYAML>=5.3.1
 requests_toolbelt
 filetype
-# typer 0.26 vendors click as typer._click and drops the external click dep, breaking
-# roboflow.cli imports (test_slim_compat imports it). 0.25.x still uses external click.
-typer>=0.12.0,<0.26
-# CLI imports click directly; declare it explicitly rather than relying on typer's transitive dep.
+typer>=0.12.0,<0.26  # 0.26 vendors click, dropping the external dep the CLI imports
 click>=8.0
 python-dateutil
 python-dotenv

--- a/requirements-slim.txt
+++ b/requirements-slim.txt
@@ -6,7 +6,11 @@ tqdm>=4.41.0
 PyYAML>=5.3.1
 requests_toolbelt
 filetype
-typer>=0.12.0
+# typer 0.26 vendors click as typer._click and drops the external click dep, breaking
+# roboflow.cli imports (test_slim_compat imports it). 0.25.x still uses external click.
+typer>=0.12.0,<0.26
+# CLI imports click directly; declare it explicitly rather than relying on typer's transitive dep.
+click>=8.0
 python-dateutil
 python-dotenv
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,5 @@ tqdm>=4.41.0
 PyYAML>=5.3.1
 requests_toolbelt
 filetype
-# typer 0.26 vendors its own click as typer._click and drops the external click dep, which
-# breaks roboflow/cli/_compat.py's SortedGroup (it subclasses TyperGroup using external click
-# types). 0.25.x still depends on external click and type-checks; pin below 0.26.
-typer>=0.12.0,<0.26
-# CLI imports click directly; declare it explicitly rather than relying on typer's transitive dep.
+typer>=0.12.0,<0.26  # 0.26 vendors click, dropping the external dep the CLI imports
 click>=8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,9 @@ tqdm>=4.41.0
 PyYAML>=5.3.1
 requests_toolbelt
 filetype
-typer>=0.12.0
+# typer 0.26 vendors its own click as typer._click and drops the external click dep, which
+# breaks roboflow/cli/_compat.py's SortedGroup (it subclasses TyperGroup using external click
+# types). 0.25.x still depends on external click and type-checks; pin below 0.26.
+typer>=0.12.0,<0.26
+# CLI imports click directly; declare it explicitly rather than relying on typer's transitive dep.
+click>=8.0

--- a/roboflow/util/model_processor.py
+++ b/roboflow/util/model_processor.py
@@ -414,7 +414,9 @@ def get_classnames_txt_for_rfdetr(model_path: str, pt_file: str, checkpoint=None
         import torch
 
         checkpoint = torch.load(os.path.join(model_path, pt_file), map_location="cpu", weights_only=False)
-    args = vars(checkpoint["args"])
+    raw_args = checkpoint["args"]
+    # args may be a plain dict in some checkpoints
+    args = raw_args if isinstance(raw_args, dict) else vars(raw_args)
     if "class_names" in args:
         with open(class_names_path, "w") as f:
             for class_name in args["class_names"]:

--- a/tests/util/test_model_processor.py
+++ b/tests/util/test_model_processor.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import unittest
 from types import SimpleNamespace
 
@@ -5,6 +7,7 @@ from roboflow.config import TASK_CLS, TASK_DET, TASK_OBB, TASK_POSE, TASK_SEG
 from roboflow.util.model_processor import (
     _detect_rfdetr_task,
     _detect_yolo_task,
+    get_classnames_txt_for_rfdetr,
     task_of_model_type,
 )
 
@@ -82,6 +85,23 @@ class DetectRfdetrTaskTest(unittest.TestCase):
         self.assertIsNone(_detect_rfdetr_task({}))
         self.assertIsNone(_detect_rfdetr_task({"model_name": None}))
         self.assertIsNone(_detect_rfdetr_task({"args": SimpleNamespace(other=1)}))
+
+
+class GetClassnamesTxtForRfdetrTest(unittest.TestCase):
+    def _classnames(self, args):
+        with tempfile.TemporaryDirectory() as model_path:
+            get_classnames_txt_for_rfdetr(model_path, "weights.pt", checkpoint={"args": args})
+            with open(os.path.join(model_path, "class_names.txt")) as f:
+                return f.read().splitlines()
+
+    def test_dict_args(self):
+        self.assertEqual(self._classnames({"class_names": ["cat", "dog"]}), ["background_class83422", "cat", "dog"])
+
+    def test_namespace_args(self):
+        self.assertEqual(
+            self._classnames(SimpleNamespace(class_names=["cat", "dog"])),
+            ["background_class83422", "cat", "dog"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

In `get_classnames_txt_for_rfdetr`, normalizes `checkpoint["args"]` to a dict instead of calling `vars()` on it directly, and adds tests for both dict and `Namespace` shapes.

`vars(checkpoint["args"])` raises `TypeError: vars() argument must have __dict__ attribute` when `args` is a plain dict rather than an `argparse.Namespace`. rf-detr EMA checkpoints (e.g. `checkpoint_best_ema.pth`) store `args` as a dict.

Today this is masked when a `class_names.txt` already exists in the upload dir (the function short-circuits before reaching `vars()`), but it breaks for any rf-detr checkpoint with dict-form args that relies on extracting class names from the checkpoint.

**Related Issue(s):** Companion to the server-side conversion fix roboflow/roboflow-model-conversion#93, which hit the same dict-vs-Namespace assumption on `args.resolution` and caused real prod upload failures (Medra workspace, `rfdetr-seg-medium`).

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

`python -m unittest tests.util.test_model_processor` → 14 tests pass, including new `GetClassnamesTxtForRfdetrTest` covering both `args` shapes. The `test_dict_args` case reproduces the `vars()` TypeError against the old code. `ruff format --check` and `ruff check` clean on the changed files; pre-commit hooks passed on push.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

The two normalizations point opposite directions on purpose: this site needs a **dict** (downstream does `args["class_names"]`), while the conversion site needs a **Namespace** (downstream does `args.resolution`). Each normalizes toward what its own caller expects.