### PR TITLE
feat: support weight upload for yolo26-sem semantic segmentation models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## 1.3.10
 
-### Added — Weight upload for yolo26-sem semantic segmentation models
+### Added
 
-Adds `TASK_SEM` task constant and wires it through the weight upload
-pipeline so yolo26-sem checkpoints (ultralytics `SemanticSegmentationModel`,
-new in ultralytics 8.4.55) are recognised, auto-suffixed, and validated
-against semantic-segmentation projects.
-
-- `task_of_model_type()` recognises the `-sem` suffix
-- `_detect_yolo_task()` maps `SemanticSegmentationModel` checkpoints to `TASK_SEM`
-- `validate_model_type_for_project()` enforces that `-sem` models match
-  semantic-segmentation projects (and rejects mismatches in both directions)
-- Auto-suffix: declaring plain `"yolo26"` with a semantic-seg checkpoint
-  auto-corrects to `"yolo26-sem"`
+- Weight upload support for yolo26-sem semantic segmentation models via
+  `version.deploy()` and `workspace.deploy_model()`
 
 ## 1.3.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.3.10
+
+### Added — Weight upload for yolo26-sem semantic segmentation models
+
+Adds `TASK_SEM` task constant and wires it through the weight upload
+pipeline so yolo26-sem checkpoints (ultralytics `SemanticSegmentationModel`,
+new in ultralytics 8.4.55) are recognised, auto-suffixed, and validated
+against semantic-segmentation projects.
+
+- `task_of_model_type()` recognises the `-sem` suffix
+- `_detect_yolo_task()` maps `SemanticSegmentationModel` checkpoints to `TASK_SEM`
+- `validate_model_type_for_project()` enforces that `-sem` models match
+  semantic-segmentation projects (and rejects mismatches in both directions)
+- Auto-suffix: declaring plain `"yolo26"` with a semantic-seg checkpoint
+  auto-corrects to `"yolo26-sem"`
+
 ## 1.3.9
 
 ### Added — Model evaluations SDK & CLI

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -21,7 +21,7 @@ except ImportError:
     CLIPModel = None  # type: ignore[assignment,misc]
     GazeModel = None  # type: ignore[assignment,misc]
 
-__version__ = "1.3.9"
+__version__ = "1.3.10"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/config.py
+++ b/roboflow/config.py
@@ -76,6 +76,7 @@ TYPE_TEXT_IMAGE_PAIRS = "text-image-pairs"
 
 TASK_DET = "det"
 TASK_SEG = "seg"
+TASK_SEM = "sem"
 TASK_POSE = "pose"
 TASK_CLS = "cls"
 TASK_OBB = "obb"

--- a/roboflow/util/model_processor.py
+++ b/roboflow/util/model_processor.py
@@ -12,10 +12,12 @@ from roboflow.config import (
     TASK_OBB,
     TASK_POSE,
     TASK_SEG,
+    TASK_SEM,
     TYPE_CLASSICATION,
     TYPE_INSTANCE_SEGMENTATION,
     TYPE_KEYPOINT_DETECTION,
     TYPE_OBJECT_DETECTION,
+    TYPE_SEMANTIC_SEGMENTATION,
 )
 from roboflow.util.versions import print_warn_for_wrong_dependencies_versions
 
@@ -27,21 +29,18 @@ def task_of_model_type(model_type: str) -> str:
     (e.g. 'yolov11-seg' -> TASK_SEG). Plain 'yolov11' / 'rfdetr-base' -> TASK_DET.
     """
     s = model_type.lower()
-    for task in (TASK_SEG, TASK_POSE, TASK_CLS, TASK_OBB):
+    for task in (TASK_SEM, TASK_SEG, TASK_POSE, TASK_CLS, TASK_OBB):
         if task in s:
             return task
     return TASK_DET
 
 
 def validate_model_type_for_project(model_type: str, project_type: str, project_id: str) -> None:
-    """Raise ValueError if model_type's task doesn't match the Roboflow project type.
-
-    No-op when project_type has no uploader-relevant task (e.g. semantic-segmentation).
-    """
-    # TYPE_SEMANTIC_SEGMENTATION intentionally omitted — no uploader emits it.
+    """Raise ValueError if model_type's task doesn't match the Roboflow project type."""
     expected = {
         TYPE_OBJECT_DETECTION: TASK_DET,
         TYPE_INSTANCE_SEGMENTATION: TASK_SEG,
+        TYPE_SEMANTIC_SEGMENTATION: TASK_SEM,
         TYPE_KEYPOINT_DETECTION: TASK_POSE,
         TYPE_CLASSICATION: TASK_CLS,
     }.get(project_type)
@@ -119,6 +118,7 @@ def _detect_yolo_task(model_instance) -> Optional[str]:
     return {
         "DetectionModel": TASK_DET,
         "SegmentationModel": TASK_SEG,
+        "SemanticSegmentationModel": TASK_SEM,
         "PoseModel": TASK_POSE,
         "ClassificationModel": TASK_CLS,
         "OBBModel": TASK_OBB,

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,6 +10,7 @@ from roboflow.config import (
     TYPE_INSTANCE_SEGMENTATION,
     TYPE_KEYPOINT_DETECTION,
     TYPE_OBJECT_DETECTION,
+    TYPE_SEMANTIC_SEGMENTATION,
 )
 from roboflow.core.version import Version, unwrap_version_id
 from tests.helpers import get_version
@@ -242,6 +243,25 @@ class TestValidateAgainstProjectType(unittest.TestCase):
 
     def test_classification_project_accepts_cls(self):
         self._version(TYPE_CLASSICATION)._validate_against_project_type("yolov11-cls")
+
+    def test_semantic_seg_project_accepts_sem_model(self):
+        self._version(TYPE_SEMANTIC_SEGMENTATION)._validate_against_project_type("yolo26-sem")
+
+    def test_semantic_seg_project_rejects_detection(self):
+        with self.assertRaises(ValueError):
+            self._version(TYPE_SEMANTIC_SEGMENTATION)._validate_against_project_type("yolov11")
+
+    def test_semantic_seg_project_rejects_instance_seg(self):
+        with self.assertRaises(ValueError):
+            self._version(TYPE_SEMANTIC_SEGMENTATION)._validate_against_project_type("yolov11-seg")
+
+    def test_instance_seg_project_rejects_sem_model(self):
+        with self.assertRaises(ValueError):
+            self._version(TYPE_INSTANCE_SEGMENTATION)._validate_against_project_type("yolo26-sem")
+
+    def test_detection_project_rejects_sem_model(self):
+        with self.assertRaises(ValueError):
+            self._version(TYPE_OBJECT_DETECTION)._validate_against_project_type("yolo26-sem")
 
     def test_classification_project_rejects_detection(self):
         with self.assertRaises(ValueError):

--- a/tests/util/test_model_processor.py
+++ b/tests/util/test_model_processor.py
@@ -3,7 +3,7 @@ import tempfile
 import unittest
 from types import SimpleNamespace
 
-from roboflow.config import TASK_CLS, TASK_DET, TASK_OBB, TASK_POSE, TASK_SEG
+from roboflow.config import TASK_CLS, TASK_DET, TASK_OBB, TASK_POSE, TASK_SEG, TASK_SEM
 from roboflow.util.model_processor import (
     _detect_rfdetr_task,
     _detect_yolo_task,
@@ -38,6 +38,9 @@ class TaskOfModelTypeTest(unittest.TestCase):
     def test_classify(self):
         self.assertEqual(task_of_model_type("yolov11-cls"), TASK_CLS)
 
+    def test_semantic(self):
+        self.assertEqual(task_of_model_type("yolo26-sem"), TASK_SEM)
+
     def test_obb(self):
         self.assertEqual(task_of_model_type("yolov11-obb"), TASK_OBB)
 
@@ -53,6 +56,9 @@ class DetectYoloTaskTest(unittest.TestCase):
         }
         for cls_name, expected in cases.items():
             self.assertEqual(_detect_yolo_task(_make_fake(cls_name)), expected, cls_name)
+
+    def test_semantic_segmentation_model(self):
+        self.assertEqual(_detect_yolo_task(_make_fake("SemanticSegmentationModel")), TASK_SEM)
 
     def test_unrecognized_returns_none(self):
         self.assertIsNone(_detect_yolo_task(_make_fake("SomeOtherModel")))


### PR DESCRIPTION
# Description

**Prior behavior:** The SDK had no awareness of semantic segmentation as a
distinct task. `TYPE_SEMANTIC_SEGMENTATION` projects were explicitly skipped
in upload validation, and `SemanticSegmentationModel` checkpoints (new in
ultralytics 8.4.55) were unrecognised.

**New behavior:** A new `TASK_SEM = "sem"` constant is wired through the
weight upload pipeline:
- `task_of_model_type("yolo26-sem")` → `TASK_SEM`
- `_detect_yolo_task()` recognises `SemanticSegmentationModel` checkpoints
- `validate_model_type_for_project()` enforces that `-sem` models match
  semantic-segmentation projects (and rejects mismatches in both directions)
- Auto-suffix: declaring plain `"yolo26"` with a semantic-seg checkpoint
  auto-corrects to `"yolo26-sem"`

No changes needed to `supported_models`, dependency checks, or artifact
extraction — `"yolo26" in "yolo26-sem"` passes all existing gates.

**Motivation:** roboflow-train and roboflow-model-conversion already support
yolo26-sem; the SDK was the missing link for user-side weight upload.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- [x] unit tests
- [x] versionless weight upload (pre-trained cityscales yolo26n-sem) succeeds on prod
<img width="1832" height="1267" alt="image" src="https://github.com/user-attachments/assets/12b41117-2d04-46bd-8564-d67f4f17a8f5" />
- [x] versioned weight upload (same model) succeeds on staging with https://github.com/roboflow/roboflow/pull/12297
<img width="1832" height="1267" alt="image" src="https://github.com/user-attachments/assets/955bea66-d9d3-427e-805e-7c4dc2fd4fb8" />


## Will the change affect Universe? If so was this change tested in universe?

_n/a_

## Github Actions Required to Deploy

_n/a_ — SDK package, no deployment needed.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
- [ ] This change requires updates to secrets
- [ ] This change materially impacts cloud costs (explain briefly)

## Docs

- [ ] This change requires a documentation update
- [ ] Docs updated? What were the changes: