### PR TITLE
fix(dev): cap numpy<2.5 in dev extra to unblock mypy typecheck

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,11 @@ setuptools.setup(
     extras_require={
         "desktop": ["opencv-python==4.8.0.74"],
         "dev": [
+            # numpy 2.5.0 (2026-06-21) ships PEP 695 `type` statement stubs that
+            # mypy cannot parse under python_version = "3.10". Cap in the dev
+            # extra only so typecheck CI keeps passing; runtime installs
+            # (requirements.txt) stay unconstrained for end users. See #498.
+            "numpy<2.5",
             "mypy",
             "responses",
             "ruff",


### PR DESCRIPTION
## Summary

- numpy 2.5.0 (released 2026-06-21) ships type stubs using PEP 695 `type` statement syntax, which mypy cannot parse under `python_version = "3.10"` (set in `pyproject.toml`).
- With no upper bound on numpy in the dev extra, `pip install ".[dev]"` now resolves numpy 2.5.0, and the `mypy roboflow` step in `make check_code_quality` (run in CI via `.github/workflows/test.yml`) fails across the entire 3.10–3.13 matrix.
- This is a numpy × mypy version interaction, not a bug in roboflow code. See #498 for the full diagnosis.
- Fix: cap `numpy<2.5` in the `dev` extra in `setup.py` only. pip intersects this with the runtime requirement (`numpy>=1.18.5` in `requirements.txt`), so dev/typecheck installs get `>=1.18.5,<2.5` while end-user runtime installs stay unconstrained.
- `setup_slim.py` is untouched — the slim distribution has no numpy dependency and its CI job does not run mypy.

## Before (unpatched, numpy 2.5.0)

```
$ pip install -e ".[dev]"          # resolves numpy 2.5.0
$ mypy roboflow
numpy/__init__.pyi:737: error: Type statement is only supported in Python 3.12 and greater  [syntax]
Found 1 error in 1 file (errors prevented further checking)
exit: 2
```

## After (patched, numpy 2.4.6)

```
$ pip install -e ".[dev]"          # cap forces numpy 2.4.6
$ make check_code_quality
ruff format roboflow --check    -> 69 files already formatted
ruff check roboflow             -> All checks passed!
mypy roboflow                   -> Success: no issues found in 69 source files

$ python -m unittest
Ran 729 tests in 17.845s
OK (skipped=1)
```

The cap is enforced by pip's resolver: `pip install -e ".[dev]" "numpy>=2.5"` against the patched `setup.py` correctly fails with `ResolutionImpossible`.

## Test plan

- [x] `ruff format roboflow --check` passes (69 files)
- [x] `ruff check roboflow` passes (All checks passed!)
- [x] `mypy roboflow` passes (Success: no issues found in 69 source files)
- [x] `python -m unittest` passes (729 tests, OK skipped=1)
- [x] pip resolver enforces the cap (`numpy>=2.5` + patched dev extra -> ResolutionImpossible)
- [x] Runtime `requirements.txt` unchanged — end-user installs unaffected

Fixes #498
