### PR TITLE
fix(deps): relax idna pin to >=3.7,<4 for CVE-2026-45409

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi
-idna==3.7
+idna>=3.7,<4  # CVE-2026-45409 fix ships in 3.15; allow security patches (#481)
 cycler
 kiwisolver>=1.3.1
 matplotlib


### PR DESCRIPTION
## Summary
- Relaxes the exact `idna==3.7` pin in `requirements.txt` to `idna>=3.7,<4`, unblocking consumers from receiving the CVE-2026-45409 fix (shipped in idna 3.15).
- `requirements-slim.txt` already ships an unpinned `idna`; this brings the full SDK in line.
- `setup.py` reads `install_requires` from `requirements.txt`, so no other files need changes.

Closes #481.

#### Test plan
- [x] `git diff` shows only the one-line requirements change
- [x] `python -m unittest` passes — 729 tests, OK (skipped=1) on Python 3.14.6 with idna 3.18
- [x] `pip install -e .` resolves idna to 3.18 (>= 3.15, the CVE fix version)
- [x] `pip-audit` reports `No known vulnerabilities found` — CVE-2026-45409 cleared