### PR TITLE
fix(deps): relax opencv-python-headless pin to >=4.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cycler
 kiwisolver>=1.3.1
 matplotlib
 numpy>=1.18.5,<2.5  # 2.5.0 ships type stubs using 3.12+ `type` syntax that mypy (pinned to 3.10) rejects
-opencv-python-headless==4.10.0.84
+opencv-python-headless>=4.10.0  # relax exact pin to avoid downstream conflicts (#349)
 Pillow>=7.1.2
 # https://github.com/roboflow/roboflow-python/issues/390
 # pi-heif 1.x requires Python 3.10+


### PR DESCRIPTION
## Summary
- Relaxes the exact `opencv-python-headless==4.10.0.84` pin in `requirements.txt` to `opencv-python-headless>=4.10.0`, unblocking downstream consumers from using a different opencv version without resolver conflicts.
- `setup.py` reads `install_requires` from `requirements.txt`, so no other files need changes.
- The `desktop` extra in `setup.py` (`opencv-python==4.8.0.74`) is intentionally left as-is — it's an opt-in extra, not the default install path.

Closes #349. Related to #365 (consumers requesting full opencv instead of headless — this pin relaxation reduces the conflict surface for that use case).

#### Test plan
- [x] `git diff` shows only the one-line requirements change
- [x] `python -m unittest` passes — 729 tests, OK (skipped=1) with opencv-python-headless 4.10.0.84
- [x] `python -m unittest` passes — 729 tests, OK (skipped=1) with opencv-python-headless 4.13.0.92 (latest)
- [x] `pip install -e .` resolves successfully under the relaxed range
