### PR TITLE
Relax idna pin from ==3.7 to >=3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi
-idna==3.7
+idna>=3.7
 cycler
 kiwisolver>=1.3.1
 matplotlib

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -21,7 +21,7 @@ except ImportError:
     CLIPModel = None  # type: ignore[assignment,misc]
     GazeModel = None  # type: ignore[assignment,misc]
 
-__version__ = "1.3.11"
+__version__ = "1.3.12"
 
 
 def check_key(api_key, model, notebook, num_retries=0):


### PR DESCRIPTION
## What

Relax the `idna` requirement from an exact pin `==3.7` to a floor `>=3.7`.

## Why

`idna` is a **transitive dependency** (pulled in via `requests`) and is not imported anywhere in the SDK. The line exists solely to enforce the security floor from **CVE-2024-3651** (fixed in idna 3.7, originally added by Dependabot).

Because `setup.py` reads `requirements.txt` line-by-line into `install_requires`, the exact `==3.7` propagates to **every project that installs `roboflow`**. Any downstream environment that also depends on a package requiring a newer `idna` (e.g. the `google-cloud-*` stack) hits resolver backtracking or an outright conflict, since `idna` is nailed to exactly `3.7`.

Relaxing to `>=3.7`:
- **Keeps** the CVE-2024-3651 security floor.
- **Unblocks** dependency resolution — `requests` caps `idna<4`, so this resolves to the latest `3.x`.
- Matches `requirements-slim.txt`, which already leaves `idna` unpinned.

## Notes

`idna` is not referenced in application code, so there is no runtime behavior change — this only affects dependency resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)