### PR TITLE
feat: support rfdetr-keypoint-preview custom weights upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Weight upload support for `rfdetr-keypoint-preview` keypoint detection models
+  via `version.deploy()`, `workspace.deploy_model()`, and the `upload_model` CLI
 - Upload raw rf-detr PyTorch-Lightning checkpoints (e.g. `checkpoint_best_ema.pth`):
   `upload_model` detects them and rebuilds a deploy-ready bundle via rf-detr's
   `export_for_roboflow` (requires `rfdetr>=1.8.0`)

--- a/roboflow/util/model_processor.py
+++ b/roboflow/util/model_processor.py
@@ -107,6 +107,8 @@ _RFDETR_MODEL_TYPE_TO_CLASS = {
     "rfdetr-seg-large": "RFDETRSegLarge",
     "rfdetr-seg-xlarge": "RFDETRSegXLarge",
     "rfdetr-seg-2xlarge": "RFDETRSeg2XLarge",
+    # Keypoint detection
+    "rfdetr-keypoint-preview": "RFDETRKeypointPreview",
 }
 
 SUPPORTED_RFDETR_TYPES = tuple(_RFDETR_MODEL_TYPE_TO_CLASS)
@@ -149,6 +151,7 @@ RFDETR_POSITIONAL_ENCODING_SIZE = {
     "rfdetr-seg-large": 42,
     "rfdetr-seg-xlarge": 52,
     "rfdetr-seg-2xlarge": 64,
+    "rfdetr-keypoint-preview": 48,
 }
 
 
@@ -239,9 +242,13 @@ def task_of_model_type(model_type: str) -> str:
     """Canonical task for a deploy model_type string.
 
     Non-detect tasks double as the model_type suffix token
-    (e.g. 'yolov11-seg' -> TASK_SEG). Plain 'yolov11' / 'rfdetr-base' -> TASK_DET.
+    (e.g. 'yolov11-seg' -> TASK_SEG). RF-DETR keypoint types spell the task out
+    instead ('rfdetr-keypoint-preview' -> TASK_POSE). Plain 'yolov11' /
+    'rfdetr-base' -> TASK_DET.
     """
     s = model_type.lower()
+    if "keypoint" in s:
+        return TASK_POSE
     for task in (TASK_SEM, TASK_SEG, TASK_POSE, TASK_CLS, TASK_OBB):
         if task in s:
             return task
@@ -813,20 +820,17 @@ def _process_yolo(
 def _detect_rfdetr_task(checkpoint: Any) -> str | None:
     """Detect the training task of an rf-detr checkpoint.
 
-    rf-detr currently only supports weight upload for detection and instance
-    segmentation. Modern checkpoints (rf-detr v1.7+) store the Python class
-    name at `checkpoint["model_name"]` (e.g. 'RFDETRNano' vs 'RFDETRSegNano');
-    older checkpoints — including those downloaded from Roboflow — lack that
-    field but always carry `args.segmentation_head: bool`.
+    Modern checkpoints (rf-detr v1.7+) store the Python class name at
+    `checkpoint["model_name"]` (e.g. 'RFDETRNano' vs 'RFDETRSegNano' vs
+    'RFDETRKeypointPreview'); older checkpoints — including those downloaded
+    from Roboflow — lack that field but carry the head flags in `args`
+    (`keypoint_head` / `segmentation_head`, both False on detection models).
     """
     if not isinstance(checkpoint, dict):
         return None
     model_name = checkpoint.get("model_name")
     if isinstance(model_name, str):
         name = model_name.lower()
-        # Keypoint rf-detr checkpoints (e.g. 'RFDETRKeypointPreview') are not a
-        # supported upload type; classify them as pose so the task check rejects
-        # them instead of silently uploading a keypoint model as detection.
         if "keypoint" in name:
             return TASK_POSE
         return TASK_SEG if TASK_SEG in name else TASK_DET
@@ -834,6 +838,10 @@ def _detect_rfdetr_task(checkpoint: Any) -> str | None:
     if raw_args is None:
         return None
     args = _checkpoint_args_as_dict(raw_args)
+    # Keypoint configs also carry segmentation_head=False, so check the
+    # keypoint flag first.
+    if args.get("keypoint_head") is True:
+        return TASK_POSE
     segmentation_head = args.get("segmentation_head")
     if segmentation_head is True:
         return TASK_SEG
@@ -1050,8 +1058,8 @@ def _process_rfdetr(
     checkpoint_path = _find_rfdetr_checkpoint(model_path, filename, warnings)
     checkpoint = _load_checkpoint(torch, checkpoint_path, map_location="cpu")
 
-    # Task detection + mismatch runs for every checkpoint shape (it also rejects
-    # keypoint rf-detr, which is not a supported upload type).
+    # Task detection + mismatch runs for every checkpoint shape (e.g. it rejects
+    # a keypoint checkpoint uploaded under a detection model_type and vice versa).
     detected_task = _detect_rfdetr_task(checkpoint)
     if detected_task and detected_task != task_of_model_type(model_type):
         raise TaskMismatchError(

--- a/tests/util/test_model_processor.py
+++ b/tests/util/test_model_processor.py
@@ -62,6 +62,7 @@ class TaskOfModelTypeTest(unittest.TestCase):
 
     def test_pose(self):
         self.assertEqual(task_of_model_type("yolov11-pose"), TASK_POSE)
+        self.assertEqual(task_of_model_type("rfdetr-keypoint-preview"), TASK_POSE)
 
     def test_classify(self):
         self.assertEqual(task_of_model_type("yolov11-cls"), TASK_CLS)
@@ -103,8 +104,6 @@ class DetectRfdetrTaskTest(unittest.TestCase):
             self.assertEqual(_detect_rfdetr_task({"model_name": name}), TASK_DET, name)
 
     def test_keypoint_model_name_returns_pose(self):
-        # Keypoint checkpoints are unsupported; classifying them as pose lets the
-        # model_type task check reject them instead of uploading them as detection.
         self.assertEqual(_detect_rfdetr_task({"model_name": "RFDETRKeypointPreview"}), TASK_POSE)
 
     def test_segmentation_head_fallback(self):
@@ -114,6 +113,14 @@ class DetectRfdetrTaskTest(unittest.TestCase):
         self.assertEqual(_detect_rfdetr_task({"args": SimpleNamespace(segmentation_head=False)}), TASK_DET)
         self.assertEqual(_detect_rfdetr_task({"args": {"segmentation_head": True}}), TASK_SEG)
         self.assertEqual(_detect_rfdetr_task({"args": {"segmentation_head": False}}), TASK_DET)
+
+    def test_keypoint_head_fallback(self):
+        # Keypoint training checkpoints from rf-detr-internal lack `model_name` and
+        # carry segmentation_head=False alongside keypoint_head=True; the keypoint
+        # flag must win so they are not misdetected as detection.
+        args = {"keypoint_head": True, "segmentation_head": False}
+        self.assertEqual(_detect_rfdetr_task({"args": args}), TASK_POSE)
+        self.assertEqual(_detect_rfdetr_task({"args": SimpleNamespace(**args)}), TASK_POSE)
 
     def test_model_name_preferred_over_args(self):
         # When both are present, model_name wins (matches rf-detr's loader).
@@ -185,6 +192,14 @@ class ValidateModelTypeForProjectTest(unittest.TestCase):
 
     def test_unknown_project_type_is_ignored(self):
         validate_model_type_for_project("yolov8", "some-new-type", "widgets")
+
+    def test_accepts_keypoint_model_for_keypoint_project(self):
+        validate_model_type_for_project("rfdetr-keypoint-preview", "keypoint-detection", "widgets")
+
+    def test_rejects_keypoint_model_for_detection_project(self):
+        with self.assertRaises(TaskMismatchError) as ctx:
+            validate_model_type_for_project("rfdetr-keypoint-preview", "object-detection", "widgets")
+        self.assertIn("task 'pose'", str(ctx.exception))
 
 
 class LegacyYoloArgsTest(unittest.TestCase):
@@ -306,6 +321,14 @@ class ResolveRfdetrVariantTest(unittest.TestCase):
         resolved = _resolve_rfdetr_variant("rfdetr-seg-nano", {"args": {"positional_encoding_size": 99}}, warnings)
         self.assertEqual(resolved, "rfdetr-seg-nano")
         self.assertTrue(warnings and "matches no known RF-DETR variant" in warnings[0])
+
+    def test_keypoint_preview_grid_matches_without_warning(self):
+        # RFDETRKeypointPreviewConfig: resolution 576, patch_size 12 -> grid 48.
+        warnings: list = []
+        checkpoint = {"args": {"resolution": 576, "patch_size": 12}}
+        resolved = _resolve_rfdetr_variant("rfdetr-keypoint-preview", checkpoint, warnings)
+        self.assertEqual(resolved, "rfdetr-keypoint-preview")
+        self.assertEqual(warnings, [])
 
     def test_pe_size_derived_from_position_embeddings_tensor(self):
         class FakeTensor:
@@ -499,6 +522,56 @@ class PackageCustomWeightsTest(unittest.TestCase):
             with _import_patch({"torch": torch}):
                 with self.assertRaises(MissingFileError):
                     package_custom_weights("rfdetr-base", str(model_dir), filename="checkpoint_epoch50.pth")
+
+    def test_rfdetr_keypoint_preview_full_flow(self):
+        # A keypoint training checkpoint (rf-detr-internal style: no model_name,
+        # keypoint_head=True in args) packages under 'rfdetr-keypoint-preview'.
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = Path(tmp)
+            (model_dir / "weights.pt").write_bytes(b"checkpoint")
+            torch = _fake_torch(
+                {
+                    "args": {
+                        "keypoint_head": True,
+                        "segmentation_head": False,
+                        "resolution": 576,
+                        "patch_size": 12,
+                        "num_keypoints_per_class": [17],
+                        "class_names": ["person"],
+                    }
+                }
+            )
+            with _import_patch({"torch": torch}):
+                bundle = package_custom_weights("rfdetr-keypoint-preview", str(model_dir), filename="weights.pt")
+            try:
+                self.assertEqual(bundle.model_type, "rfdetr-keypoint-preview")
+                self.assertEqual(bundle.warnings, ())
+                with zipfile.ZipFile(bundle.archive_path) as archive:
+                    self.assertIn("weights.pt", archive.namelist())
+                    class_names = archive.read("class_names.txt").decode().splitlines()
+                self.assertEqual(class_names, ["background_class83422", "person"])
+            finally:
+                bundle.cleanup()
+
+    def test_rfdetr_keypoint_checkpoint_rejected_for_detection_type(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = Path(tmp)
+            (model_dir / "weights.pt").write_bytes(b"checkpoint")
+            torch = _fake_torch({"args": {"keypoint_head": True, "segmentation_head": False}})
+            with _import_patch({"torch": torch}):
+                with self.assertRaises(TaskMismatchError) as ctx:
+                    package_custom_weights("rfdetr-base", str(model_dir), filename="weights.pt")
+        self.assertIn("'pose'", str(ctx.exception))
+
+    def test_rfdetr_detection_checkpoint_rejected_for_keypoint_type(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = Path(tmp)
+            (model_dir / "weights.pt").write_bytes(b"checkpoint")
+            torch = _fake_torch({"args": {"segmentation_head": False, "class_names": ["widget"]}})
+            with _import_patch({"torch": torch}):
+                with self.assertRaises(TaskMismatchError) as ctx:
+                    package_custom_weights("rfdetr-keypoint-preview", str(model_dir), filename="weights.pt")
+        self.assertIn("'det'", str(ctx.exception))
 
     def test_rfdetr_legacy_deploy_layout_does_not_self_copy(self):
         # Legacy deploy passes build_dir=model_path with a top-level weights.pt;


### PR DESCRIPTION
> [!NOTE]
> _Code and PR description are LLM-written. Code has been reviewed and tested in staging by Kai_

## What

Enables uploading **RF-DETR Keypoint Preview** (`rfdetr-keypoint-preview`) models to the Roboflow platform through the existing custom-weights flows: `version.deploy()`, `workspace.deploy_model()`, and the `roboflow upload_model` CLI.

The platform side already supports this model type: the model registry (`packages/shared/models/modelRegistry/rfdetrModels.js` in `roboflow`) registers `rfdetr-keypoint-preview` as a keypoint-detection model, and the export job (`train/export/rfdetr/export.py` in `roboflow-train`, PR in flight) converts uploaded keypoint checkpoints — deriving `keypoints_metadata.json` from the checkpoint's `args.num_keypoints_per_class`, so the existing bundle format (`weights.pt` + `class_names.txt`) needs no changes. This PR removes the client-side gate that rejected the model type.

## Changes (all in `roboflow/util/model_processor.py`)

- **Register the type**: `rfdetr-keypoint-preview` → `RFDETRKeypointPreview` in `_RFDETR_MODEL_TYPE_TO_CLASS`. The class ships in public `rfdetr>=1.8.0`, which is already the required minimum (`RFDETR_MIN_VERSION`) for the raw PyTorch-Lightning checkpoint path, so no dependency bump is needed.
- **Task mapping**: `task_of_model_type` now maps model types containing `keypoint` to `TASK_POSE` (the type string spells the task out instead of using the `-pose` suffix token). This makes project-type validation accept keypoint-detection projects and reject others.
- **Checkpoint task detection**: keypoint training checkpoints from `rf-detr-internal` carry `args` but no `model_name`, and their config sets `segmentation_head=False` alongside `keypoint_head=True` — `_detect_rfdetr_task` previously misdetected them as detection. It now checks `args.keypoint_head` first. Checkpoints *with* `model_name` (`RFDETRKeypointPreview`) were already classified as pose; they are now accepted rather than rejected.
- **Variant grid check**: added the keypoint-preview position-encoding grid (`576 // 12 = 48`, mirroring `RFDETRKeypointPreviewConfig` in `rf-detr-internal`/public `rfdetr`) to `RFDETR_POSITIONAL_ENCODING_SIZE`.

Cross-task mislabels stay rejected in both directions: a keypoint checkpoint uploaded as `rfdetr-base` and a detection checkpoint uploaded as `rfdetr-keypoint-preview` both raise `TaskMismatchError` before anything is uploaded.

## Testing

- New unit tests: task mapping, `keypoint_head` args fallback (dict + namespace), project-type validation accept/reject, PE-grid match, full packaging flow, and both cross-task rejection directions.
- Full suite: `871 passed, 1 skipped` locally.
- Manually exercised packaging with a real `torch.save`d keypoint-style checkpoint (`args` including `keypoint_head`, `num_keypoints_per_class`, `class_names`): produces `roboflow_deploy.zip` with `weights.pt` + background-prefixed `class_names.txt`, no warnings; uploading the same checkpoint as `rfdetr-nano` is rejected with an actionable `TaskMismatchError`.

## How to test an upload

```bash
roboflow upload_model -p <keypoint-project> -v <version> -t rfdetr-keypoint-preview -m <dir-with-checkpoint> -f checkpoint_best_total.pth
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)