### PR TITLE
feat(sdk): public wrappers for updating image metadata (DATAMAN-337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `workspace.update_image_metadata()` and `workspace.batch_update_image_metadata()`
+  (plus a `project.update_image_metadata()` convenience alias) — public SDK
+  wrappers for updating metadata and tags on existing images, previously only
+  reachable via the internal `rfapi` adapter or the CLI. The batch method
+  accepts `wait=True` to poll the async task until completion and return
+  per-image results.
 - Upload raw rf-detr PyTorch-Lightning checkpoints (e.g. `checkpoint_best_ema.pth`):
   `upload_model` detects them and rebuilds a deploy-ready bundle via rf-detr's
   `export_for_roboflow` (requires `rfdetr>=1.8.0`)

--- a/docs/index.md
+++ b/docs/index.md
@@ -164,6 +164,44 @@ Or from the CLI:
 roboflow upload image.jpg -p my-project -M '{"camera_id":"cam001","location":"warehouse-3"}'
 ```
 
+### Update Metadata on Existing Images
+
+Update metadata and tags on images already in your workspace. Values in
+`metadata` are upserted: new keys are added, existing keys are overwritten.
+
+```python
+workspace = rf.workspace("my-workspace")
+
+# Single image (synchronous)
+workspace.update_image_metadata(
+    "IMAGE_ID",
+    metadata={"quality_score": 95, "reviewed": True},
+    remove_metadata=["old_key"],
+    add_tags=["reviewed"],
+    remove_tags=["pending"],
+)
+
+# Also available from a project object
+project.update_image_metadata("IMAGE_ID", metadata={"reviewed": True})
+
+# Batch update up to 1,000 images (asynchronous); wait=True polls until done
+final = workspace.batch_update_image_metadata(
+    [
+        {"imageId": "img1", "metadata": {"batch": "june"}, "addTags": ["processed"]},
+        {"imageId": "img2", "metadata": {"batch": "june"}, "addTags": ["processed"]},
+    ],
+    wait=True,
+)
+print(final["result"]["succeeded"], final["result"]["failedItems"])
+```
+
+Or from the CLI:
+
+```bash
+roboflow image metadata IMAGE_ID -m '{"quality_score": 95}' --tags "reviewed"
+roboflow image metadata img1,img2 --tags "processed" --poll
+```
+
 ## Library Structure
 
 The Roboflow Python library is structured using the same Workspace, Project, and Version ontology that you will see in the Roboflow application.

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -1014,6 +1014,51 @@ class Project:
 
         return response.json()
 
+    def update_image_metadata(
+        self,
+        image_id: str,
+        *,
+        metadata: Optional[Dict] = None,
+        remove_metadata: Optional[List[str]] = None,
+        add_tags: Optional[List[str]] = None,
+        remove_tags: Optional[List[str]] = None,
+    ) -> Dict:
+        """Update metadata and tags on a single image (synchronous).
+
+        Values in ``metadata`` are upserted: new keys are added, existing keys
+        are overwritten. The underlying endpoint is workspace-scoped, so the
+        image only needs to belong to this project's workspace.
+
+        Args:
+            image_id: ID of an image in this workspace.
+            metadata: Key-value pairs to set (string, number, or boolean values).
+            remove_metadata: Metadata keys to delete.
+            add_tags: Tags to add.
+            remove_tags: Tags to remove.
+
+        Returns:
+            ``{"success": True}`` on success.
+
+        Example:
+            >>> import roboflow
+            >>> rf = roboflow.Roboflow(api_key="YOUR_API_KEY")
+            >>> project = rf.workspace().project("PROJECT_ID")
+            >>> project.update_image_metadata(
+            ...     "IMAGE_ID",
+            ...     metadata={"camera_id": "cam001"},
+            ...     add_tags=["reviewed"],
+            ... )
+        """
+        return rfapi.update_image_metadata(
+            api_key=self.__api_key,
+            workspace_url=self.__workspace,
+            image_id=image_id,
+            metadata=metadata,
+            remove_metadata=remove_metadata,
+            add_tags=add_tags,
+            remove_tags=remove_tags,
+        )
+
     def delete_images(self, image_ids: List[str]):
         """
         Delete images from a project.

--- a/roboflow/core/workspace.py
+++ b/roboflow/core/workspace.py
@@ -158,6 +158,118 @@ class Workspace:
         """Return the current status of an async task owned by this workspace."""
         return rfapi.get_async_task(self.__api_key, self.url, task_id)
 
+    def update_image_metadata(
+        self,
+        image_id: str,
+        *,
+        metadata: Optional[Dict] = None,
+        remove_metadata: Optional[List[str]] = None,
+        add_tags: Optional[List[str]] = None,
+        remove_tags: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Update metadata and tags on a single image (synchronous).
+
+        Values in ``metadata`` are upserted: new keys are added, existing keys
+        are overwritten. At least one argument must be provided; validation
+        (key/tag format, mutual exclusions) is performed server-side and
+        surfaces as :class:`~roboflow.adapters.rfapi.RoboflowError`.
+
+        Args:
+            image_id: ID of an image in this workspace.
+            metadata: Key-value pairs to set (string, number, or boolean values).
+            remove_metadata: Metadata keys to delete.
+            add_tags: Tags to add.
+            remove_tags: Tags to remove.
+
+        Returns:
+            ``{"success": True}`` on success.
+
+        Example:
+            >>> import roboflow
+            >>> rf = roboflow.Roboflow(api_key="")
+            >>> workspace = rf.workspace("WORKSPACE_URL")
+            >>> workspace.update_image_metadata(
+            ...     "IMAGE_ID",
+            ...     metadata={"quality_score": 95, "reviewed": True},
+            ...     add_tags=["reviewed"],
+            ... )
+        """
+        return rfapi.update_image_metadata(
+            api_key=self.__api_key,
+            workspace_url=self.url,
+            image_id=image_id,
+            metadata=metadata,
+            remove_metadata=remove_metadata,
+            add_tags=add_tags,
+            remove_tags=remove_tags,
+        )
+
+    def batch_update_image_metadata(
+        self,
+        updates: List[Dict],
+        *,
+        wait: bool = False,
+        poll_interval: float = 4.0,
+        timeout: float = 1800.0,
+    ) -> Dict[str, Any]:
+        """Update metadata and tags on up to 1,000 images in one call (asynchronous).
+
+        Each update dict must contain ``imageId`` plus at least one of
+        ``metadata``, ``removeMetadata``, ``addTags``, ``removeTags``.
+        Validation happens server-side before anything is enqueued; an invalid
+        item rejects the whole batch with :class:`~roboflow.adapters.rfapi.RoboflowError`.
+        Missing images do not fail the task — they are reported per-item in
+        the final result's ``failedItems`` while the rest succeed.
+
+        The endpoint is workspace-scoped; to target a single project's images,
+        gather their IDs first (e.g. via ``project.search(fields=["id"])``).
+
+        Args:
+            updates: List of update dicts, e.g.
+                ``[{"imageId": "abc", "metadata": {"k": "v"}, "addTags": ["t"]}]``.
+            wait: When ``True``, poll until the task finishes and return the
+                final task status instead of the enqueue response.
+            poll_interval: Seconds between polls when ``wait`` is ``True``.
+            timeout: Max seconds to wait when ``wait`` is ``True``; raises
+                ``TimeoutError`` when exceeded. Non-positive disables the timeout.
+
+        Returns:
+            With ``wait=False``: ``{"taskId": "...", "url": "..."}`` — check later
+            with :meth:`get_async_task`. With ``wait=True``: the final task status,
+            including ``result`` (``succeeded``/``failed``/``failedItems``) when completed.
+
+        Example:
+            >>> import roboflow
+            >>> rf = roboflow.Roboflow(api_key="")
+            >>> workspace = rf.workspace("WORKSPACE_URL")
+            >>> final = workspace.batch_update_image_metadata(
+            ...     [
+            ...         {"imageId": "img1", "metadata": {"batch": "june"}},
+            ...         {"imageId": "img2", "addTags": ["processed"]},
+            ...     ],
+            ...     wait=True,
+            ... )
+            >>> final["result"]["succeeded"]
+        """
+        result = rfapi.batch_update_image_metadata(
+            api_key=self.__api_key,
+            workspace_url=self.url,
+            updates=updates,
+        )
+        if not wait:
+            return result
+
+        from roboflow.core.async_tasks import poll_until_terminal
+
+        return poll_until_terminal(
+            self.__api_key,
+            self.url,
+            result["taskId"],
+            interval=poll_interval,
+            timeout=timeout,
+            polling_url=result.get("url"),
+        )
+
     def devices(self) -> List["Device"]:
         """List v2 devices registered in this workspace.
 

--- a/tests/manual/demo_image_metadata.py
+++ b/tests/manual/demo_image_metadata.py
@@ -1,0 +1,94 @@
+"""Manual demo/smoke test for the image metadata SDK wrappers (DATAMAN-337).
+
+Usage (staging):
+    API_URL=https://api.roboflow.one ROBOFLOW_API_KEY=<staging-key> \
+        .venv/bin/python tests/manual/demo_image_metadata.py
+
+Optional env: RF_WORKSPACE (default model-evaluation-workspace),
+RF_PROJECT (default penguin-finder).
+
+Exercises workspace.update_image_metadata, project.update_image_metadata,
+batch_update_image_metadata (no-wait + wait=True with a bogus id), server-side
+validation errors, and cleans up everything it wrote.
+"""
+
+import os
+import time
+
+import roboflow
+from roboflow.adapters.rfapi import RoboflowError
+
+WORKSPACE = os.environ.get("RF_WORKSPACE", "model-evaluation-workspace")
+PROJECT = os.environ.get("RF_PROJECT", "penguin-finder")
+TAG = f"smoke-{int(time.time())}"
+
+rf = roboflow.Roboflow()
+workspace = rf.workspace(WORKSPACE)
+project = workspace.project(PROJECT)
+
+ids = [r["id"] for r in project.search(fields=["id"], limit=2)]
+assert len(ids) == 2, f"need 2 images in {WORKSPACE}/{PROJECT}, got {len(ids)}"
+print(f"image ids: {ids}, tag: {TAG}")
+
+# --- Single image (workspace) ---
+print("=== workspace.update_image_metadata ===")
+r = workspace.update_image_metadata(ids[0], metadata={"smoke_key": "v1"}, add_tags=[TAG])
+print(r)
+assert r == {"success": True}
+
+# --- Single image (project alias) ---
+print("=== project.update_image_metadata ===")
+r = project.update_image_metadata(ids[0], metadata={"smoke_project": True})
+print(r)
+assert r == {"success": True}
+
+# --- Batch, fire-and-forget ---
+print("=== batch (no wait) + get_async_task ===")
+r = workspace.batch_update_image_metadata([{"imageId": ids[0], "addTags": [TAG]}])
+print(r)
+assert "taskId" in r and "url" in r
+for _ in range(20):
+    status = workspace.get_async_task(r["taskId"])
+    if status["status"] not in ("created", "running"):
+        break
+    time.sleep(3)
+print(status)
+assert status["status"] == "completed"
+
+# --- Batch, wait=True, with one bogus id -> partial success ---
+print("=== batch (wait=True) with bogus id ===")
+updates = [{"imageId": i, "metadata": {"smoke_batch": "yes"}} for i in ids]
+updates.append({"imageId": "bogus-does-not-exist", "addTags": [TAG]})
+final = workspace.batch_update_image_metadata(updates, wait=True, timeout=300)
+print(final["status"], final["result"])
+assert final["result"]["succeeded"] == 2
+assert final["result"]["failedItems"][0]["imageId"] == "bogus-does-not-exist"
+
+# --- Server-side validation surfaces as RoboflowError ---
+print("=== validation errors ===")
+for kwargs, expect in [
+    ({"add_tags": ["bad tag spaces"]}, "Invalid tag"),
+    ({}, "At least one of"),
+]:
+    try:
+        workspace.update_image_metadata(ids[0], **kwargs)
+        raise AssertionError(f"expected RoboflowError containing {expect!r}")
+    except RoboflowError as e:
+        assert expect in str(e)
+        print(f"ok: {expect!r} surfaced")
+
+# --- Cleanup ---
+print("=== cleanup ===")
+cleanup = [
+    {
+        "imageId": i,
+        "removeMetadata": ["smoke_key", "smoke_project", "smoke_batch"],
+        "removeTags": [TAG],
+    }
+    for i in ids
+]
+final = workspace.batch_update_image_metadata(cleanup, wait=True, timeout=300)
+print(final["status"], final["result"])
+assert final["result"]["succeeded"] == 2
+
+print("\nALL CHECKS PASSED")

--- a/tests/manual/demo_image_metadata.py
+++ b/tests/manual/demo_image_metadata.py
@@ -33,36 +33,37 @@ print(f"image ids: {ids}, tag: {TAG}")
 # --- Single image (workspace) ---
 print("=== workspace.update_image_metadata ===")
 r = workspace.update_image_metadata(ids[0], metadata={"smoke_key": "v1"}, add_tags=[TAG])
-print(r)
 assert r == {"success": True}
+print("ok: single update succeeded")
 
 # --- Single image (project alias) ---
 print("=== project.update_image_metadata ===")
 r = project.update_image_metadata(ids[0], metadata={"smoke_project": True})
-print(r)
 assert r == {"success": True}
+print("ok: project alias update succeeded")
 
 # --- Batch, fire-and-forget ---
 print("=== batch (no wait) + get_async_task ===")
 r = workspace.batch_update_image_metadata([{"imageId": ids[0], "addTags": [TAG]}])
-print(r)
 assert "taskId" in r and "url" in r
+print("ok: batch enqueued (taskId + url returned)")
 for _ in range(20):
     status = workspace.get_async_task(r["taskId"])
     if status["status"] not in ("created", "running"):
         break
     time.sleep(3)
-print(status)
 assert status["status"] == "completed"
+print("ok: async task completed")
 
 # --- Batch, wait=True, with one bogus id -> partial success ---
 print("=== batch (wait=True) with bogus id ===")
 updates = [{"imageId": i, "metadata": {"smoke_batch": "yes"}} for i in ids]
 updates.append({"imageId": "bogus-does-not-exist", "addTags": [TAG]})
 final = workspace.batch_update_image_metadata(updates, wait=True, timeout=300)
-print(final["status"], final["result"])
+assert final["status"] == "completed"
 assert final["result"]["succeeded"] == 2
 assert final["result"]["failedItems"][0]["imageId"] == "bogus-does-not-exist"
+print(f"ok: partial success (succeeded={int(final['result']['succeeded'])}, failed={int(final['result']['failed'])})")
 
 # --- Server-side validation surfaces as RoboflowError ---
 print("=== validation errors ===")
@@ -88,7 +89,7 @@ cleanup = [
     for i in ids
 ]
 final = workspace.batch_update_image_metadata(cleanup, wait=True, timeout=300)
-print(final["status"], final["result"])
 assert final["result"]["succeeded"] == 2
+print("ok: cleanup batch succeeded on both images")
 
 print("\nALL CHECKS PASSED")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -643,6 +643,27 @@ class TestProject(RoboflowTest):
 
         self.assertEqual(str(context.exception), "Failed to delete images")
 
+    def test_update_image_metadata_delegates_with_workspace_slug(self):
+        with patch("roboflow.adapters.rfapi.update_image_metadata") as mock_update:
+            mock_update.return_value = {"success": True}
+
+            result = self.project.update_image_metadata(
+                "img-1",
+                metadata={"camera_id": "cam001"},
+                add_tags=["reviewed"],
+            )
+
+        self.assertEqual(result, {"success": True})
+        mock_update.assert_called_once_with(
+            api_key=ROBOFLOW_API_KEY,
+            workspace_url=WORKSPACE_NAME,
+            image_id="img-1",
+            metadata={"camera_id": "cam001"},
+            remove_metadata=None,
+            add_tags=["reviewed"],
+            remove_tags=None,
+        )
+
     def test_classification_dataset_upload(self):
         from roboflow.util import folderparser
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -90,5 +90,91 @@ class TestWorkspaceAsyncTasks(unittest.TestCase):
         mock_get.assert_called_once_with("test-key", "test-ws", "task-1")
 
 
+class TestWorkspaceImageMetadata(unittest.TestCase):
+    @patch("roboflow.adapters.rfapi.update_image_metadata")
+    def test_update_image_metadata_delegates(self, mock_update):
+        workspace = _make_workspace()
+        mock_update.return_value = {"success": True}
+
+        result = workspace.update_image_metadata(
+            "img-1",
+            metadata={"quality": 95},
+            remove_metadata=["old"],
+            add_tags=["reviewed"],
+            remove_tags=["pending"],
+        )
+
+        self.assertEqual(result, {"success": True})
+        mock_update.assert_called_once_with(
+            api_key="test-key",
+            workspace_url="test-ws",
+            image_id="img-1",
+            metadata={"quality": 95},
+            remove_metadata=["old"],
+            add_tags=["reviewed"],
+            remove_tags=["pending"],
+        )
+
+    @patch("roboflow.adapters.rfapi.update_image_metadata")
+    def test_update_image_metadata_propagates_error(self, mock_update):
+        from roboflow.adapters.rfapi import RoboflowError
+
+        workspace = _make_workspace()
+        mock_update.side_effect = RoboflowError('{"error": {"message": "Invalid tag"}}')
+
+        with self.assertRaises(RoboflowError):
+            workspace.update_image_metadata("img-1", add_tags=["bad tag"])
+
+    @patch("roboflow.adapters.rfapi.batch_update_image_metadata")
+    def test_batch_update_returns_enqueue_response_without_wait(self, mock_batch):
+        workspace = _make_workspace()
+        mock_batch.return_value = {"taskId": "task-9", "url": "https://api.test/poll"}
+        updates = [{"imageId": "img-1", "addTags": ["t"]}]
+
+        result = workspace.batch_update_image_metadata(updates)
+
+        self.assertEqual(result, {"taskId": "task-9", "url": "https://api.test/poll"})
+        mock_batch.assert_called_once_with(
+            api_key="test-key",
+            workspace_url="test-ws",
+            updates=updates,
+        )
+
+    @patch("roboflow.core.async_tasks.time.sleep", lambda *_: None)
+    @patch("roboflow.adapters.rfapi.get_async_task_at")
+    @patch("roboflow.adapters.rfapi.batch_update_image_metadata")
+    def test_batch_update_wait_polls_until_terminal(self, mock_batch, mock_poll):
+        workspace = _make_workspace()
+        mock_batch.return_value = {"taskId": "task-9", "url": "https://api.test/poll"}
+        final = {
+            "taskId": "task-9",
+            "status": "completed",
+            "result": {"totalProcessed": 2, "succeeded": 2, "failed": 0, "failedItems": []},
+        }
+        mock_poll.side_effect = [
+            {"taskId": "task-9", "status": "running"},
+            final,
+        ]
+
+        result = workspace.batch_update_image_metadata([{"imageId": "img-1", "addTags": ["t"]}], wait=True)
+
+        self.assertEqual(result, final)
+        self.assertEqual(mock_poll.call_count, 2)
+        mock_poll.assert_called_with("test-key", "https://api.test/poll")
+
+    @patch("roboflow.core.async_tasks.time.sleep", lambda *_: None)
+    @patch("roboflow.adapters.rfapi.get_async_task")
+    @patch("roboflow.adapters.rfapi.batch_update_image_metadata")
+    def test_batch_update_wait_falls_back_to_task_id_poll(self, mock_batch, mock_get):
+        workspace = _make_workspace()
+        mock_batch.return_value = {"taskId": "task-9"}  # no polling url in response
+        mock_get.return_value = {"taskId": "task-9", "status": "completed", "result": {}}
+
+        result = workspace.batch_update_image_metadata([{"imageId": "img-1", "addTags": ["t"]}], wait=True)
+
+        self.assertEqual(result["status"], "completed")
+        mock_get.assert_called_once_with("test-key", "test-ws", "task-9")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description
Source: https://roboflow.slack.com/archives/C05HRBELWVB/p1784711279761049
Public SDK wrappers for updating metadata and tags on existing images. DATAMAN-337 shipped the endpoints and the low-level `rfapi.update_image_metadata` / `batch_update_image_metadata` functions, and DATAMAN-345 added the CLI — but there was no public Python surface, so roboflow-product-docs PR 389 had to document the internal `rfapi` adapter directly.

**Fix**: thin delegation wrappers following the existing `Workspace.get_async_task` pattern:

- `workspace.update_image_metadata(image_id, *, metadata=, remove_metadata=, add_tags=, remove_tags=)` — sync single image
- `workspace.batch_update_image_metadata(updates, *, wait=False, poll_interval=4.0, timeout=1800.0)` — async batch (up to 1,000 images); `wait=True` polls via the shared `poll_until_terminal` helper (same as the CLI's `--poll`) and returns the final task status including per-image `failedItems`
- `project.update_image_metadata(...)` — convenience alias passing the project's workspace slug (the endpoint is workspace-scoped; verified against the backend that batch has no project/filter parameters, so batch stays on Workspace)

No client-side validation: the server is the source of truth and its errors (invalid tag/key, mutual exclusions, 1,000 cap, duplicate ids) surface as `RoboflowError` with the API's own message and hint. Docstrings publish automatically via mkdocstrings.

Also adds `tests/manual/demo_image_metadata.py`, a self-cleaning manual smoke script for staging.

## Type of change

- [x] New feature

## How has this change been tested?

- Full unit suite: 874 tests, OK (6 new tests covering delegation args, error propagation, no-wait enqueue response, wait=True polling via polling URL, and task-id fallback polling)
- `ruff` + `mypy` clean
- Live staging E2E (model-evaluation-workspace/penguin-finder): single update, project alias, batch no-wait + `get_async_task`, batch `wait=True` with a bogus id returning `succeeded: 2, failed: 1` with the bogus id in `failedItems`, server validation errors surfacing as `RoboflowError`, and CLI regression (`roboflow image metadata` single/batch/error paths) — all green, test data cleaned up

## Will the change affect Universe?

No

## Any specific deployment considerations

None — SDK-only, no new dependencies.

## Docs

- [x] Docs updated? Follow-up: roboflow-product-docs PR 389 will be updated to use these wrappers instead of `rfapi` imports. CHANGELOG entry included here.
