### PR TITLE
feat: delete (soft) and restore training runs via SDK and CLI

### DIFF
--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -141,6 +141,57 @@ def stop_version_training(api_key: str, workspace_url: str, project_url: str, ve
     return response.json() if response.content else {"success": True}
 
 
+def delete_version_training(
+    api_key: str,
+    workspace_url: str,
+    project_url: str,
+    version: str,
+    *,
+    training_id: Optional[str] = None,
+):
+    """Move a terminal training run to the workspace Trash (soft delete).
+
+    POST /{workspace}/{project}/{version}/v2/trainings/delete. The run and
+    every model it produced disappear from listings but stay restorable for
+    30 days via ``restore_version_training`` or the Trash UI, after which
+    they are permanently deleted. The server refuses in-flight runs (stop or
+    cancel first) and the run backing the version's registered model. There
+    is no permanent-delete option on the public API.
+
+    ``training_id`` selects a specific run on the version (MMPV); omit it to
+    target the version's sole run.
+    """
+    url = f"{API_URL}/{workspace_url}/{project_url}/{version}/v2/trainings/delete?api_key={api_key}"
+    body: Dict[str, str] = {}
+    if training_id:
+        body["trainingId"] = training_id
+    response = requests.post(url, json=body)
+    if not response.ok:
+        raise RoboflowError(response.text)
+    return response.json() if response.content else {"inTrash": True}
+
+
+def restore_version_training(
+    api_key: str,
+    workspace_url: str,
+    project_url: str,
+    version: str,
+    *,
+    training_id: str,
+):
+    """Restore a trashed training run (and its models) back into listings.
+
+    POST /{workspace}/{project}/{version}/v2/trainings/restore.
+    ``training_id`` is required — a trashed run is invisible to the sole-run
+    resolver. Fails while the parent project or version is itself in Trash.
+    """
+    url = f"{API_URL}/{workspace_url}/{project_url}/{version}/v2/trainings/restore?api_key={api_key}"
+    response = requests.post(url, json={"trainingId": training_id})
+    if not response.ok:
+        raise RoboflowError(response.text)
+    return response.json() if response.content else {"restored": True}
+
+
 def get_training_results(api_key: str, workspace_url: str, project_url: str, version: str):
     """Run-level training results bundle.
 

--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -141,40 +141,35 @@ def stop_version_training(api_key: str, workspace_url: str, project_url: str, ve
     return response.json() if response.content else {"success": True}
 
 
-def delete_version_training(
+def resolve_version_training_id(
     api_key: str,
     workspace_url: str,
     project_url: str,
     version: str,
-    *,
     training_id: Optional[str] = None,
-):
-    """Move a terminal training run to the workspace Trash (soft delete).
+) -> str:
+    """Resolve the training run a version-scoped call targets.
 
-    POST /{workspace}/{project}/{version}/v2/trainings/delete. The run and
-    every model it produced disappear from listings but stay restorable for
-    30 days via ``restore_version_training`` or the Trash UI, after which
-    they are permanently deleted. The server refuses in-flight runs (stop or
-    cancel first) and the run backing the version's registered model. There
-    is no permanent-delete option on the public API.
-
-    ``training_id`` selects a specific run on the version (MMPV); omit it
-    (``None``) to target the version's sole run. A blank id is rejected — on a
-    destructive call an empty selector must not silently fall back.
+    A supplied id is returned as-is (blank → ``ValueError``). When omitted,
+    the version's sole run is resolved via ``list_trainings_for_version``;
+    zero or multiple runs raise with the run ids so the caller can pick one.
     """
-    if training_id is not None and not str(training_id).strip():
-        raise ValueError("training_id must be a non-empty string when provided")
-    url = f"{API_URL}/{workspace_url}/{project_url}/{version}/v2/trainings/delete?api_key={api_key}"
-    body: Dict[str, str] = {}
     if training_id is not None:
-        body["trainingId"] = training_id
-    response = requests.post(url, json=body)
-    if not response.ok:
-        raise RoboflowError(response.text)
-    return response.json() if response.content else {"inTrash": True}
+        if not str(training_id).strip():
+            raise ValueError("training_id must be a non-empty string when provided")
+        return training_id
+    trainings = list_trainings_for_version(api_key, workspace_url, project_url, version)
+    if not trainings:
+        raise RoboflowError(f"No training runs found for {project_url}/{version}.")
+    if len(trainings) > 1:
+        ids = ", ".join(str(t.get("trainingId") or t.get("id")) for t in trainings)
+        raise RoboflowError(
+            f"MULTIPLE_TRAININGS: version {project_url}/{version} owns several runs ({ids}); pass training_id."
+        )
+    return str(trainings[0].get("trainingId") or trainings[0].get("id"))
 
 
-def restore_version_training(
+def delete_version_training(
     api_key: str,
     workspace_url: str,
     project_url: str,
@@ -182,19 +177,27 @@ def restore_version_training(
     *,
     training_id: str,
 ):
-    """Restore a trashed training run (and its models) back into listings.
+    """Move a terminal training run to the workspace Trash (soft delete).
 
-    POST /{workspace}/{project}/{version}/v2/trainings/restore.
-    ``training_id`` is required — a trashed run is invisible to the sole-run
-    resolver. Fails while the parent project or version is itself in Trash.
+    DELETE /{workspace}/{project}/{version}/v2/trainings/{training_id} — the
+    same resource-DELETE pattern as project/version/workflow deletion, and the
+    same ``{deleted, type, ..., trash: true}`` response shape. The run and
+    every model it produced disappear from listings but stay restorable for
+    30 days via ``restore_trash_item(..., "training", ...)`` or the Trash UI,
+    after which they are permanently deleted. The server refuses in-flight
+    runs (stop or cancel first) and the run backing the version's registered
+    model. There is no permanent-delete option on the public API.
+
+    ``training_id`` is required (it is the resource path). Use
+    ``resolve_version_training_id`` to target a version's sole run.
     """
     if not training_id or not str(training_id).strip():
         raise ValueError("training_id is required")
-    url = f"{API_URL}/{workspace_url}/{project_url}/{version}/v2/trainings/restore?api_key={api_key}"
-    response = requests.post(url, json={"trainingId": training_id})
+    url = f"{API_URL}/{workspace_url}/{project_url}/{version}/v2/trainings/{training_id}?api_key={api_key}"
+    response = requests.delete(url)
     if not response.ok:
         raise RoboflowError(response.text)
-    return response.json() if response.content else {"restored": True}
+    return response.json() if response.content else {"deleted": True}
 
 
 def get_training_results(api_key: str, workspace_url: str, project_url: str, version: str):
@@ -1475,7 +1478,7 @@ def list_trash(api_key, workspace_url):
 def restore_trash_item(api_key, workspace_url, item_type, item_id, parent_id=None):
     """POST /{workspace}/trash/restore — restore an item from Trash.
 
-    `item_type` must be one of "project", "version", "workflow".
+    `item_type` must be one of "project", "version", "workflow", "training".
     `parent_id` is required when restoring a version (the parent project id).
     """
     url = f"{API_URL}/{workspace_url}/trash/restore?api_key={api_key}"

--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -162,11 +162,11 @@ def resolve_version_training_id(
     if not trainings:
         raise RoboflowError(f"No training runs found for {project_url}/{version}.")
     if len(trainings) > 1:
-        ids = ", ".join(str(t.get("trainingId") or t.get("id")) for t in trainings)
+        ids = ", ".join(str(t.get("id")) for t in trainings)
         raise RoboflowError(
             f"MULTIPLE_TRAININGS: version {project_url}/{version} owns several runs ({ids}); pass training_id."
         )
-    return str(trainings[0].get("trainingId") or trainings[0].get("id"))
+    return str(trainings[0].get("id"))
 
 
 def delete_version_training(
@@ -228,7 +228,7 @@ def list_trainings_for_version(api_key: str, workspace_url: str, project_url: st
     GET /{ws}/{proj}/{version}/v2/trainings. MMPV versions return every run;
     SMPV versions return a single entry synthesized from ``version.train``.
     Returns the raw ``trainings`` array — each entry carries
-    ``{trainingId, status, modelType, modelGroup, modelIds, start}``.
+    ``{id, versionId, status, start, end, jobType, modelType, modelGroup, modelIds}``.
     """
     url = f"{API_URL}/{workspace_url}/{project_url}/{version}/v2/trainings?api_key={api_key}"
     response = requests.get(url)

--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -158,12 +158,15 @@ def delete_version_training(
     cancel first) and the run backing the version's registered model. There
     is no permanent-delete option on the public API.
 
-    ``training_id`` selects a specific run on the version (MMPV); omit it to
-    target the version's sole run.
+    ``training_id`` selects a specific run on the version (MMPV); omit it
+    (``None``) to target the version's sole run. A blank id is rejected — on a
+    destructive call an empty selector must not silently fall back.
     """
+    if training_id is not None and not str(training_id).strip():
+        raise ValueError("training_id must be a non-empty string when provided")
     url = f"{API_URL}/{workspace_url}/{project_url}/{version}/v2/trainings/delete?api_key={api_key}"
     body: Dict[str, str] = {}
-    if training_id:
+    if training_id is not None:
         body["trainingId"] = training_id
     response = requests.post(url, json=body)
     if not response.ok:
@@ -185,6 +188,8 @@ def restore_version_training(
     ``training_id`` is required — a trashed run is invisible to the sole-run
     resolver. Fails while the parent project or version is itself in Trash.
     """
+    if not training_id or not str(training_id).strip():
+        raise ValueError("training_id is required")
     url = f"{API_URL}/{workspace_url}/{project_url}/{version}/v2/trainings/restore?api_key={api_key}"
     response = requests.post(url, json={"trainingId": training_id})
     if not response.ok:

--- a/roboflow/adapters/rfapi.py
+++ b/roboflow/adapters/rfapi.py
@@ -1481,6 +1481,8 @@ def restore_trash_item(api_key, workspace_url, item_type, item_id, parent_id=Non
     `item_type` must be one of "project", "version", "workflow", "training".
     `parent_id` is required when restoring a version (the parent project id).
     """
+    if not item_id or not str(item_id).strip():
+        raise ValueError("item_id is required")
     url = f"{API_URL}/{workspace_url}/trash/restore?api_key={api_key}"
     payload = {"type": item_type, "id": item_id}
     if parent_id is not None:

--- a/roboflow/cli/handlers/train.py
+++ b/roboflow/cli/handlers/train.py
@@ -633,12 +633,19 @@ def _delete(args):  # noqa: ANN001
     api_key, workspace_url, project_slug, version_str = resolved
 
     try:
+        training_id = rfapi.resolve_version_training_id(
+            api_key,
+            workspace_url,
+            project_slug,
+            version_str,
+            getattr(args, "training_id", None),
+        )
         result = rfapi.delete_version_training(
             api_key,
             workspace_url,
             project_slug,
             version_str,
-            training_id=getattr(args, "training_id", None),
+            training_id=training_id,
         )
     except rfapi.RoboflowError as exc:
         msg = str(exc)
@@ -672,17 +679,14 @@ def _restore(args):  # noqa: ANN001
     api_key, workspace_url, project_slug, version_str = resolved
 
     try:
-        result = rfapi.restore_version_training(
-            api_key,
-            workspace_url,
-            project_slug,
-            version_str,
-            training_id=args.training_id,
-        )
+        result = rfapi.restore_trash_item(api_key, workspace_url, "training", args.training_id)
     except rfapi.RoboflowError as exc:
         msg = str(exc)
         hint = None
-        if "not in trash" in msg.lower():
+        # The shared trash route reports a non-trashed id as "not found in
+        # trash"; the service-level guard says "not in trash". Match both
+        # before the parent-blocked case, which also mentions "in trash".
+        if "not found in trash" in msg.lower() or "not in trash" in msg.lower():
             hint = "Only trashed runs can be restored. 'roboflow trash list' shows what is trashed."
         elif "in trash" in msg.lower():
             hint = "Restore the parent project/version first ('roboflow trash list')."

--- a/roboflow/cli/handlers/train.py
+++ b/roboflow/cli/handlers/train.py
@@ -197,8 +197,10 @@ def delete_training(
     The run and every model it produced disappear from listings but stay
     restorable for 30 days ('roboflow train restore' or the web Trash view),
     after which they are permanently deleted. In-flight runs are refused —
-    stop or cancel first — as is the run backing the version's registered
-    model. Permanent deletion is only available in the web UI's Trash view.
+    stop or cancel first. The version's hosted endpoint always serves the
+    oldest remaining run's model, so deleting the serving run switches
+    serving to the next-oldest run, or stops it when none survives.
+    Permanent deletion is only available in the web UI's Trash view.
     """
     args = ctx_to_args(ctx, target=target, training_id=training_id)
     _delete(args)
@@ -655,19 +657,30 @@ def _delete(args):  # noqa: ANN001
         hint = None
         if "in progress" in msg:
             hint = "Stop or cancel the run first: 'roboflow train stop <project>/<version>'."
-        elif "registered model" in msg:
-            hint = "This run backs the version's registered model. Register another model first."
         elif "MULTIPLE_TRAININGS" in msg:
             hint = "This version owns several runs. Pass --training-id (see 'roboflow train list <project>/<version>')."
         output_error(args, msg, hint=hint, exit_code=3)
         return
 
+    alias_action = (result or {}).get("versionAliasAction")
+    if alias_action == "repointed":
+        alias_note = (
+            f" Serving for '{project_slug}/{version_str}' switched to "
+            f"'{(result or {}).get('versionAliasTarget', 'the next-oldest model')}'."
+        )
+    elif alias_action == "deleted":
+        alias_note = (
+            f" No other model remains, so '{project_slug}/{version_str}' stops serving "
+            "until a new training completes or this run is restored."
+        )
+    else:
+        alias_note = ""
     output(
         args,
         {"status": "in_trash", "project": project_slug, "version": version_str, **(result or {})},
         text=(
             f"Training moved to Trash for {project_slug} version {version_str}. "
-            "Restorable for 30 days via 'roboflow train restore'."
+            f"Restorable for 30 days via 'roboflow train restore'.{alias_note}"
         ),
     )
 

--- a/roboflow/cli/handlers/train.py
+++ b/roboflow/cli/handlers/train.py
@@ -175,6 +175,59 @@ def stop_training(
     _stop(args)
 
 
+@train_app.command("delete")
+def delete_training(
+    ctx: typer.Context,
+    target: Annotated[
+        str,
+        typer.Argument(help="Training to delete as 'project/version'"),
+    ],
+    training_id: Annotated[
+        Optional[str],
+        typer.Option(
+            "--training-id",
+            help=(
+                "Training id of the run to delete (versions can own several). Omit to target the version's sole run."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Move a terminal training run to the workspace Trash (soft delete).
+
+    The run and every model it produced disappear from listings but stay
+    restorable for 30 days ('roboflow train restore' or the web Trash view),
+    after which they are permanently deleted. In-flight runs are refused —
+    stop or cancel first — as is the run backing the version's registered
+    model. Permanent deletion is only available in the web UI's Trash view.
+    """
+    args = ctx_to_args(ctx, target=target, training_id=training_id)
+    _delete(args)
+
+
+@train_app.command("restore")
+def restore_training(
+    ctx: typer.Context,
+    target: Annotated[
+        str,
+        typer.Argument(help="Version the trashed training belongs to, as 'project/version'"),
+    ],
+    training_id: Annotated[
+        str,
+        typer.Option(
+            "--training-id",
+            help="Training id of the trashed run to restore (required).",
+        ),
+    ],
+) -> None:
+    """Restore a trashed training run (and its models) back into listings.
+
+    Fails while the parent project or version is itself in Trash — restore
+    those first ('roboflow trash list' shows what is trashed).
+    """
+    args = ctx_to_args(ctx, target=target, training_id=training_id)
+    _restore(args)
+
+
 @train_app.command("results")
 def training_results(
     ctx: typer.Context,
@@ -550,6 +603,79 @@ def _stop(args):  # noqa: ANN001
         args,
         {"status": "stop_requested", "project": project_slug, "version": version_str, **(result or {})},
         text=f"Early-stop requested for {project_slug} version {version_str}.",
+    )
+
+
+def _delete(args):  # noqa: ANN001
+    from roboflow.adapters import rfapi
+    from roboflow.cli._output import output, output_error
+
+    resolved = _resolve_train_target(args)
+    if resolved is None:
+        return
+    api_key, workspace_url, project_slug, version_str = resolved
+
+    try:
+        result = rfapi.delete_version_training(
+            api_key,
+            workspace_url,
+            project_slug,
+            version_str,
+            training_id=getattr(args, "training_id", None),
+        )
+    except rfapi.RoboflowError as exc:
+        msg = str(exc)
+        hint = None
+        if "in progress" in msg:
+            hint = "Stop or cancel the run first: 'roboflow train stop <project>/<version>'."
+        elif "registered model" in msg:
+            hint = "This run backs the version's registered model. Register another model first."
+        elif "MULTIPLE_TRAININGS" in msg:
+            hint = "This version owns several runs. Pass --training-id (see 'roboflow train results')."
+        output_error(args, msg, hint=hint, exit_code=3)
+        return
+
+    output(
+        args,
+        {"status": "in_trash", "project": project_slug, "version": version_str, **(result or {})},
+        text=(
+            f"Training moved to Trash for {project_slug} version {version_str}. "
+            "Restorable for 30 days via 'roboflow train restore'."
+        ),
+    )
+
+
+def _restore(args):  # noqa: ANN001
+    from roboflow.adapters import rfapi
+    from roboflow.cli._output import output, output_error
+
+    resolved = _resolve_train_target(args)
+    if resolved is None:
+        return
+    api_key, workspace_url, project_slug, version_str = resolved
+
+    try:
+        result = rfapi.restore_version_training(
+            api_key,
+            workspace_url,
+            project_slug,
+            version_str,
+            training_id=args.training_id,
+        )
+    except rfapi.RoboflowError as exc:
+        msg = str(exc)
+        hint = None
+        if "not in trash" in msg.lower():
+            hint = "Only trashed runs can be restored. 'roboflow trash list' shows what is trashed."
+        elif "in trash" in msg.lower():
+            hint = "Restore the parent project/version first ('roboflow trash list')."
+        output_error(args, msg, hint=hint, exit_code=3)
+        return
+
+    output(
+        args,
+        {"status": "restored", "project": project_slug, "version": version_str, **(result or {})},
+        text=f"Training restored for {project_slug} version {version_str}.",
     )
 
 

--- a/roboflow/cli/handlers/train.py
+++ b/roboflow/cli/handlers/train.py
@@ -718,7 +718,7 @@ def _list(args):  # noqa: ANN001
 
     rows = [
         {
-            "trainingId": t.get("trainingId", ""),
+            "trainingId": t.get("id", ""),
             "status": t.get("status", ""),
             "modelType": t.get("modelType", ""),
             "models": len(t.get("modelIds") or []),

--- a/roboflow/cli/handlers/train.py
+++ b/roboflow/cli/handlers/train.py
@@ -238,7 +238,7 @@ def list_trainings(
 ) -> None:
     """List a version's training runs with their ids.
 
-    An MMPV version may own several runs; use the TRAINING_ID column with
+    A version may own several training runs; use the TRAINING_ID column with
     'roboflow train delete/restore --training-id' or 'train cancel/stop'.
     """
     args = ctx_to_args(ctx, target=target)

--- a/roboflow/cli/handlers/train.py
+++ b/roboflow/cli/handlers/train.py
@@ -228,6 +228,23 @@ def restore_training(
     _restore(args)
 
 
+@train_app.command("list")
+def list_trainings(
+    ctx: typer.Context,
+    target: Annotated[
+        str,
+        typer.Argument(help="Version whose trainings to list, as 'project/version'"),
+    ],
+) -> None:
+    """List a version's training runs with their ids.
+
+    An MMPV version may own several runs; use the TRAINING_ID column with
+    'roboflow train delete/restore --training-id' or 'train cancel/stop'.
+    """
+    args = ctx_to_args(ctx, target=target)
+    _list(args)
+
+
 @train_app.command("results")
 def training_results(
     ctx: typer.Context,
@@ -631,7 +648,7 @@ def _delete(args):  # noqa: ANN001
         elif "registered model" in msg:
             hint = "This run backs the version's registered model. Register another model first."
         elif "MULTIPLE_TRAININGS" in msg:
-            hint = "This version owns several runs. Pass --training-id (see 'roboflow train results')."
+            hint = "This version owns several runs. Pass --training-id (see 'roboflow train list <project>/<version>')."
         output_error(args, msg, hint=hint, exit_code=3)
         return
 
@@ -677,6 +694,41 @@ def _restore(args):  # noqa: ANN001
         {"status": "restored", "project": project_slug, "version": version_str, **(result or {})},
         text=f"Training restored for {project_slug} version {version_str}.",
     )
+
+
+def _list(args):  # noqa: ANN001
+    from roboflow.adapters import rfapi
+    from roboflow.cli._output import output, output_error
+    from roboflow.cli._table import format_table
+
+    resolved = _resolve_train_target(args)
+    if resolved is None:
+        return
+    api_key, workspace_url, project_slug, version_str = resolved
+
+    try:
+        trainings = rfapi.list_trainings_for_version(api_key, workspace_url, project_slug, version_str)
+    except rfapi.RoboflowError as exc:
+        output_error(args, str(exc), exit_code=3)
+        return
+
+    rows = [
+        {
+            "trainingId": t.get("trainingId", ""),
+            "status": t.get("status", ""),
+            "modelType": t.get("modelType", ""),
+            "models": len(t.get("modelIds") or []),
+        }
+        for t in trainings
+    ]
+    table = format_table(
+        rows,
+        columns=["trainingId", "status", "modelType", "models"],
+        headers=["TRAINING_ID", "STATUS", "MODEL_TYPE", "MODELS"],
+    )
+    if not rows:
+        table = "(No trainings on this version)"
+    output(args, {"trainings": trainings}, text=table)
 
 
 def _results(args):  # noqa: ANN001

--- a/roboflow/cli/handlers/train.py
+++ b/roboflow/cli/handlers/train.py
@@ -647,6 +647,9 @@ def _delete(args):  # noqa: ANN001
             version_str,
             training_id=training_id,
         )
+    except ValueError as exc:
+        output_error(args, str(exc), hint="Pass a non-empty --training-id.", exit_code=2)
+        return
     except rfapi.RoboflowError as exc:
         msg = str(exc)
         hint = None
@@ -680,6 +683,9 @@ def _restore(args):  # noqa: ANN001
 
     try:
         result = rfapi.restore_trash_item(api_key, workspace_url, "training", args.training_id)
+    except ValueError as exc:
+        output_error(args, str(exc), hint="Pass a non-empty --training-id.", exit_code=2)
+        return
     except rfapi.RoboflowError as exc:
         msg = str(exc)
         hint = None

--- a/roboflow/core/training.py
+++ b/roboflow/core/training.py
@@ -261,6 +261,24 @@ class Training:
             self.__api_key, self.workspace, self.project, self.version, training_id=self.training_id
         )
 
+    def delete(self):
+        """Move this run to the workspace Trash (soft delete, DNA ``trainings.delete``).
+
+        The run and every model it produced disappear from listings but stay
+        restorable for 30 days via :meth:`restore` or the Trash UI. The server
+        refuses in-flight runs (stop or cancel first) and the run backing the
+        version's registered model.
+        """
+        return rfapi.delete_version_training(
+            self.__api_key, self.workspace, self.project, self.version, training_id=self.training_id
+        )
+
+    def restore(self):
+        """Restore this run from Trash (DNA ``trainings.restore``)."""
+        return rfapi.restore_version_training(
+            self.__api_key, self.workspace, self.project, self.version, training_id=self.training_id
+        )
+
     def __str__(self):
         return json.dumps(
             {

--- a/roboflow/core/training.py
+++ b/roboflow/core/training.py
@@ -274,10 +274,8 @@ class Training:
         )
 
     def restore(self):
-        """Restore this run from Trash (DNA ``trainings.restore``)."""
-        return rfapi.restore_version_training(
-            self.__api_key, self.workspace, self.project, self.version, training_id=self.training_id
-        )
+        """Restore this run from Trash via the shared workspace trash-restore route."""
+        return rfapi.restore_trash_item(self.__api_key, self.workspace, "training", self.training_id)
 
     def __str__(self):
         return json.dumps(

--- a/roboflow/core/training.py
+++ b/roboflow/core/training.py
@@ -266,8 +266,12 @@ class Training:
 
         The run and every model it produced disappear from listings but stay
         restorable for 30 days via :meth:`restore` or the Trash UI. The server
-        refuses in-flight runs (stop or cancel first) and the run backing the
-        version's registered model.
+        refuses in-flight runs (stop or cancel first). The version's hosted
+        endpoint always serves the oldest remaining run's model: if this run
+        was serving, serving switches to the next-oldest run (the response
+        reports ``versionAliasAction: "repointed"`` and the new target) or
+        stops when no other run survives (``"deleted"``); restoring the
+        oldest run hands serving back.
         """
         return rfapi.delete_version_training(
             self.__api_key, self.workspace, self.project, self.version, training_id=self.training_id

--- a/roboflow/core/training.py
+++ b/roboflow/core/training.py
@@ -262,7 +262,7 @@ class Training:
         )
 
     def delete(self):
-        """Move this run to the workspace Trash (soft delete, DNA ``trainings.delete``).
+        """Move this run to the workspace Trash (soft delete).
 
         The run and every model it produced disappear from listings but stay
         restorable for 30 days via :meth:`restore` or the Trash UI. The server

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -888,37 +888,45 @@ class Version:
 
         Args:
             training_id: Training id of the run to delete (MMPV versions can
-                own several). Omit to target the version's sole run.
+                own several). Omit to target the version's sole run — resolved
+                client-side; several runs raise with their ids listed.
 
         Returns:
-            dict: Server response with `{trainingId, inTrash: True, alreadyInTrash}`.
+            dict: Server response with `{deleted: True, type: "training", ..., trash: True}`
+                (the same shape as project/version/workflow deletion).
         """
+        resolved_id = rfapi.resolve_version_training_id(
+            self.__api_key,
+            self.workspace,
+            self.project,
+            self.version,
+            training_id,
+        )
         return rfapi.delete_version_training(
             self.__api_key,
             self.workspace,
             self.project,
             self.version,
-            training_id=training_id,
+            training_id=resolved_id,
         )
 
     def restore_training(self, training_id: str):
         """
         Restore one of this version's trashed training runs.
 
+        Goes through the shared workspace trash-restore route (the same one
+        project/version/workflow restores use) with `type: "training"`.
+
         Args:
             training_id: Training id of the trashed run (required — trashed
                 runs are invisible to the sole-run fallback).
 
         Returns:
-            dict: Server response with `{trainingId, restored: True}`.
+            dict: Server response from the trash restore route.
         """
-        return rfapi.restore_version_training(
-            self.__api_key,
-            self.workspace,
-            self.project,
-            self.version,
-            training_id=training_id,
-        )
+        if not training_id or not str(training_id).strip():
+            raise ValueError("training_id is required")
+        return rfapi.restore_trash_item(self.__api_key, self.workspace, "training", training_id)
 
     def __str__(self):
         """

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -876,6 +876,50 @@ class Version:
             parent_id=match.get("parentId"),
         )
 
+    def delete_training(self, training_id: Optional[str] = None):
+        """
+        Move one of this version's training runs to Trash (soft delete).
+
+        The run and every model it produced disappear from listings but stay
+        restorable for 30 days via `Version.restore_training()` or the Trash
+        UI, after which they are permanently deleted. The server refuses
+        in-flight runs (stop or cancel first) and the run backing the
+        version's registered model.
+
+        Args:
+            training_id: Training id of the run to delete (MMPV versions can
+                own several). Omit to target the version's sole run.
+
+        Returns:
+            dict: Server response with `{trainingId, inTrash: True, alreadyInTrash}`.
+        """
+        return rfapi.delete_version_training(
+            self.__api_key,
+            self.workspace,
+            self.project,
+            self.version,
+            training_id=training_id,
+        )
+
+    def restore_training(self, training_id: str):
+        """
+        Restore one of this version's trashed training runs.
+
+        Args:
+            training_id: Training id of the trashed run (required — trashed
+                runs are invisible to the sole-run fallback).
+
+        Returns:
+            dict: Server response with `{trainingId, restored: True}`.
+        """
+        return rfapi.restore_version_training(
+            self.__api_key,
+            self.workspace,
+            self.project,
+            self.version,
+            training_id=training_id,
+        )
+
     def __str__(self):
         """
         String representation of version object.

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -883,8 +883,11 @@ class Version:
         The run and every model it produced disappear from listings but stay
         restorable for 30 days via `Version.restore_training()` or the Trash
         UI, after which they are permanently deleted. The server refuses
-        in-flight runs (stop or cancel first) and the run backing the
-        version's registered model.
+        in-flight runs (stop or cancel first). The version's hosted endpoint
+        always serves the oldest remaining run's model: deleting the serving
+        run switches serving to the next-oldest run (`versionAliasAction:
+        "repointed"`) or stops it when no other run survives (`"deleted"`);
+        restoring the oldest run hands serving back.
 
         Args:
             training_id: Training id of the run to delete (a version can own

--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -887,8 +887,8 @@ class Version:
         version's registered model.
 
         Args:
-            training_id: Training id of the run to delete (MMPV versions can
-                own several). Omit to target the version's sole run — resolved
+            training_id: Training id of the run to delete (a version can own
+                several runs). Omit to target the version's sole run — resolved
                 client-side; several runs raise with their ids listed.
 
         Returns:

--- a/tests/cli/test_train_handler.py
+++ b/tests/cli/test_train_handler.py
@@ -636,6 +636,40 @@ class TestTrainCancelStopResults(unittest.TestCase):
         self.assertEqual([t["id"] for t in result["trainings"]], ["t-1", "t-2"])
         self.assertIn("t-1", out)
 
+    @patch("roboflow.adapters.rfapi.delete_version_training")
+    def test_delete_blank_training_id_is_a_structured_usage_error(self, mock_delete: MagicMock) -> None:
+        from roboflow.cli.handlers.train import _delete
+
+        buf = io.StringIO()
+        old = sys.stderr
+        sys.stderr = buf
+        try:
+            with self.assertRaises(SystemExit) as cm:
+                _delete(self._args(training_id="   "))
+        finally:
+            sys.stderr = old
+        self.assertEqual(cm.exception.code, 2)
+        mock_delete.assert_not_called()
+        err = json.loads(buf.getvalue())
+        self.assertIn("non-empty", err["error"]["message"])
+        self.assertIn("--training-id", err["error"].get("hint", ""))
+
+    def test_restore_blank_training_id_is_a_structured_usage_error(self) -> None:
+        from roboflow.cli.handlers.train import _restore
+
+        buf = io.StringIO()
+        old = sys.stderr
+        sys.stderr = buf
+        try:
+            with self.assertRaises(SystemExit) as cm:
+                _restore(self._args(training_id="   "))
+        finally:
+            sys.stderr = old
+        self.assertEqual(cm.exception.code, 2)
+        err = json.loads(buf.getvalue())
+        self.assertIn("required", err["error"]["message"])
+        self.assertIn("--training-id", err["error"].get("hint", ""))
+
     @patch("roboflow.adapters.rfapi.restore_trash_item")
     def test_restore_success(self, mock_restore: MagicMock) -> None:
         from roboflow.cli.handlers.train import _restore

--- a/tests/cli/test_train_handler.py
+++ b/tests/cli/test_train_handler.py
@@ -483,6 +483,15 @@ class TestTrainSubcommandsRegister(unittest.TestCase):
         result = runner.invoke(app, ["train", "results", "--help"])
         self.assertEqual(result.exit_code, 0)
 
+    def test_delete_help(self) -> None:
+        result = runner.invoke(app, ["train", "delete", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("trash", result.output.lower())
+
+    def test_restore_help(self) -> None:
+        result = runner.invoke(app, ["train", "restore", "--help"])
+        self.assertEqual(result.exit_code, 0)
+
 
 class TestTrainCancelStopResults(unittest.TestCase):
     """_cancel / _stop / _results business logic."""
@@ -552,6 +561,50 @@ class TestTrainCancelStopResults(unittest.TestCase):
         mock_stop.assert_called_once_with("test-key", "test-ws", "my-project", "3")
         result = json.loads(out)
         self.assertEqual(result["status"], "stop_requested")
+
+    @patch("roboflow.adapters.rfapi.delete_version_training")
+    def test_delete_success(self, mock_delete: MagicMock) -> None:
+        from roboflow.cli.handlers.train import _delete
+
+        mock_delete.return_value = {"trainingId": "t-1", "inTrash": True, "alreadyInTrash": False}
+        out = self._capture_stdout(_delete, self._args(training_id="t-1"))
+
+        mock_delete.assert_called_once_with("test-key", "test-ws", "my-project", "3", training_id="t-1")
+        result = json.loads(out)
+        self.assertEqual(result["status"], "in_trash")
+        self.assertTrue(result["inTrash"])
+
+    @patch("roboflow.adapters.rfapi.delete_version_training")
+    def test_delete_in_progress_surfaces_hint(self, mock_delete: MagicMock) -> None:
+        from roboflow.adapters import rfapi
+        from roboflow.cli.handlers.train import _delete
+
+        mock_delete.side_effect = rfapi.RoboflowError(
+            "This training is still in progress. Stop or cancel it before deleting it."
+        )
+        buf = io.StringIO()
+        old = sys.stderr
+        sys.stderr = buf
+        try:
+            with self.assertRaises(SystemExit) as cm:
+                _delete(self._args(training_id=None))
+        finally:
+            sys.stderr = old
+        self.assertEqual(cm.exception.code, 3)
+        err = json.loads(buf.getvalue())
+        self.assertIn("in progress", err["error"]["message"])
+        self.assertIn("train stop", err["error"].get("hint", ""))
+
+    @patch("roboflow.adapters.rfapi.restore_version_training")
+    def test_restore_success(self, mock_restore: MagicMock) -> None:
+        from roboflow.cli.handlers.train import _restore
+
+        mock_restore.return_value = {"trainingId": "t-1", "restored": True}
+        out = self._capture_stdout(_restore, self._args(training_id="t-1"))
+
+        mock_restore.assert_called_once_with("test-key", "test-ws", "my-project", "3", training_id="t-1")
+        result = json.loads(out)
+        self.assertEqual(result["status"], "restored")
 
     @patch("roboflow.adapters.rfapi.get_training_results")
     def test_results_nas_run(self, mock_get: MagicMock) -> None:

--- a/tests/cli/test_train_handler.py
+++ b/tests/cli/test_train_handler.py
@@ -570,13 +570,13 @@ class TestTrainCancelStopResults(unittest.TestCase):
     def test_delete_success(self, mock_delete: MagicMock) -> None:
         from roboflow.cli.handlers.train import _delete
 
-        mock_delete.return_value = {"trainingId": "t-1", "inTrash": True, "alreadyInTrash": False}
+        mock_delete.return_value = {"deleted": True, "type": "training", "trainingId": "t-1", "trash": True}
         out = self._capture_stdout(_delete, self._args(training_id="t-1"))
 
         mock_delete.assert_called_once_with("test-key", "test-ws", "my-project", "3", training_id="t-1")
         result = json.loads(out)
         self.assertEqual(result["status"], "in_trash")
-        self.assertTrue(result["inTrash"])
+        self.assertTrue(result["trash"])
 
     @patch("roboflow.adapters.rfapi.delete_version_training")
     def test_delete_in_progress_surfaces_hint(self, mock_delete: MagicMock) -> None:
@@ -591,7 +591,7 @@ class TestTrainCancelStopResults(unittest.TestCase):
         sys.stderr = buf
         try:
             with self.assertRaises(SystemExit) as cm:
-                _delete(self._args(training_id=None))
+                _delete(self._args(training_id="t-1"))
         finally:
             sys.stderr = old
         self.assertEqual(cm.exception.code, 3)
@@ -600,13 +600,15 @@ class TestTrainCancelStopResults(unittest.TestCase):
         self.assertIn("train stop", err["error"].get("hint", ""))
 
     @patch("roboflow.adapters.rfapi.delete_version_training")
-    def test_delete_multiple_trainings_hint_points_to_train_list(self, mock_delete: MagicMock) -> None:
-        from roboflow.adapters import rfapi
+    @patch("roboflow.adapters.rfapi.list_trainings_for_version")
+    def test_delete_multiple_trainings_hint_points_to_train_list(
+        self, mock_list: MagicMock, mock_delete: MagicMock
+    ) -> None:
         from roboflow.cli.handlers.train import _delete
 
-        mock_delete.side_effect = rfapi.RoboflowError(
-            '{"error":{"message":"multiple runs","code":"MULTIPLE_TRAININGS"}}'
-        )
+        # The sole-run resolution is client-side now: several runs abort the
+        # delete before any request is made, with the train-list hint.
+        mock_list.return_value = [{"trainingId": "t-1"}, {"trainingId": "t-2"}]
         buf = io.StringIO()
         old = sys.stderr
         sys.stderr = buf
@@ -615,6 +617,7 @@ class TestTrainCancelStopResults(unittest.TestCase):
                 _delete(self._args(training_id=None))
         finally:
             sys.stderr = old
+        mock_delete.assert_not_called()
         err = json.loads(buf.getvalue())
         self.assertIn("roboflow train list", err["error"].get("hint", ""))
 
@@ -632,14 +635,14 @@ class TestTrainCancelStopResults(unittest.TestCase):
         result = json.loads(out)
         self.assertEqual([t["trainingId"] for t in result["trainings"]], ["t-1", "t-2"])
 
-    @patch("roboflow.adapters.rfapi.restore_version_training")
+    @patch("roboflow.adapters.rfapi.restore_trash_item")
     def test_restore_success(self, mock_restore: MagicMock) -> None:
         from roboflow.cli.handlers.train import _restore
 
-        mock_restore.return_value = {"trainingId": "t-1", "restored": True}
+        mock_restore.return_value = {"restored": True}
         out = self._capture_stdout(_restore, self._args(training_id="t-1"))
 
-        mock_restore.assert_called_once_with("test-key", "test-ws", "my-project", "3", training_id="t-1")
+        mock_restore.assert_called_once_with("test-key", "test-ws", "training", "t-1")
         result = json.loads(out)
         self.assertEqual(result["status"], "restored")
 

--- a/tests/cli/test_train_handler.py
+++ b/tests/cli/test_train_handler.py
@@ -637,6 +637,43 @@ class TestTrainCancelStopResults(unittest.TestCase):
         self.assertIn("t-1", out)
 
     @patch("roboflow.adapters.rfapi.delete_version_training")
+    def test_delete_notes_the_serving_switch(self, mock_delete: MagicMock) -> None:
+        from roboflow.cli.handlers.train import _delete
+
+        mock_delete.return_value = {
+            "deleted": True,
+            "type": "training",
+            "trainingId": "t-1",
+            "trash": True,
+            "versionAliasAction": "repointed",
+            "versionAliasTarget": "test-ws/next-oldest-model",
+        }
+        args = self._args(training_id="t-1")
+        args.json = False
+        out = self._capture_stdout(_delete, args)
+
+        self.assertIn("switched to", out)
+        self.assertIn("next-oldest-model", out)
+
+    @patch("roboflow.adapters.rfapi.delete_version_training")
+    def test_delete_notes_the_serving_stop_when_no_model_remains(self, mock_delete: MagicMock) -> None:
+        from roboflow.cli.handlers.train import _delete
+
+        mock_delete.return_value = {
+            "deleted": True,
+            "type": "training",
+            "trainingId": "t-1",
+            "trash": True,
+            "versionAliasAction": "deleted",
+        }
+        args = self._args(training_id="t-1")
+        args.json = False
+        out = self._capture_stdout(_delete, args)
+
+        self.assertIn("stops serving", out)
+        self.assertIn("my-project/3", out)
+
+    @patch("roboflow.adapters.rfapi.delete_version_training")
     def test_delete_blank_training_id_is_a_structured_usage_error(self, mock_delete: MagicMock) -> None:
         from roboflow.cli.handlers.train import _delete
 

--- a/tests/cli/test_train_handler.py
+++ b/tests/cli/test_train_handler.py
@@ -488,6 +488,10 @@ class TestTrainSubcommandsRegister(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("trash", result.output.lower())
 
+    def test_list_help(self) -> None:
+        result = runner.invoke(app, ["train", "list", "--help"])
+        self.assertEqual(result.exit_code, 0)
+
     def test_restore_help(self) -> None:
         result = runner.invoke(app, ["train", "restore", "--help"])
         self.assertEqual(result.exit_code, 0)
@@ -594,6 +598,39 @@ class TestTrainCancelStopResults(unittest.TestCase):
         err = json.loads(buf.getvalue())
         self.assertIn("in progress", err["error"]["message"])
         self.assertIn("train stop", err["error"].get("hint", ""))
+
+    @patch("roboflow.adapters.rfapi.delete_version_training")
+    def test_delete_multiple_trainings_hint_points_to_train_list(self, mock_delete: MagicMock) -> None:
+        from roboflow.adapters import rfapi
+        from roboflow.cli.handlers.train import _delete
+
+        mock_delete.side_effect = rfapi.RoboflowError(
+            '{"error":{"message":"multiple runs","code":"MULTIPLE_TRAININGS"}}'
+        )
+        buf = io.StringIO()
+        old = sys.stderr
+        sys.stderr = buf
+        try:
+            with self.assertRaises(SystemExit):
+                _delete(self._args(training_id=None))
+        finally:
+            sys.stderr = old
+        err = json.loads(buf.getvalue())
+        self.assertIn("roboflow train list", err["error"].get("hint", ""))
+
+    @patch("roboflow.adapters.rfapi.list_trainings_for_version")
+    def test_list_enumerates_training_ids(self, mock_list: MagicMock) -> None:
+        from roboflow.cli.handlers.train import _list
+
+        mock_list.return_value = [
+            {"trainingId": "t-1", "status": "finished", "modelType": "yolo26n", "modelIds": ["m1"]},
+            {"trainingId": "t-2", "status": "stopped", "modelType": "yolo26n", "modelIds": []},
+        ]
+        out = self._capture_stdout(_list, self._args())
+
+        mock_list.assert_called_once_with("test-key", "test-ws", "my-project", "3")
+        result = json.loads(out)
+        self.assertEqual([t["trainingId"] for t in result["trainings"]], ["t-1", "t-2"])
 
     @patch("roboflow.adapters.rfapi.restore_version_training")
     def test_restore_success(self, mock_restore: MagicMock) -> None:

--- a/tests/cli/test_train_handler.py
+++ b/tests/cli/test_train_handler.py
@@ -608,7 +608,7 @@ class TestTrainCancelStopResults(unittest.TestCase):
 
         # The sole-run resolution is client-side now: several runs abort the
         # delete before any request is made, with the train-list hint.
-        mock_list.return_value = [{"trainingId": "t-1"}, {"trainingId": "t-2"}]
+        mock_list.return_value = [{"id": "t-1"}, {"id": "t-2"}]
         buf = io.StringIO()
         old = sys.stderr
         sys.stderr = buf
@@ -626,14 +626,15 @@ class TestTrainCancelStopResults(unittest.TestCase):
         from roboflow.cli.handlers.train import _list
 
         mock_list.return_value = [
-            {"trainingId": "t-1", "status": "finished", "modelType": "yolo26n", "modelIds": ["m1"]},
-            {"trainingId": "t-2", "status": "stopped", "modelType": "yolo26n", "modelIds": []},
+            {"id": "t-1", "status": "finished", "modelType": "yolo26n", "modelIds": ["m1"]},
+            {"id": "t-2", "status": "stopped", "modelType": "yolo26n", "modelIds": []},
         ]
         out = self._capture_stdout(_list, self._args())
 
         mock_list.assert_called_once_with("test-key", "test-ws", "my-project", "3")
         result = json.loads(out)
-        self.assertEqual([t["trainingId"] for t in result["trainings"]], ["t-1", "t-2"])
+        self.assertEqual([t["id"] for t in result["trainings"]], ["t-1", "t-2"])
+        self.assertIn("t-1", out)
 
     @patch("roboflow.adapters.rfapi.restore_trash_item")
     def test_restore_success(self, mock_restore: MagicMock) -> None:

--- a/tests/test_rfapi.py
+++ b/tests/test_rfapi.py
@@ -308,7 +308,7 @@ class TestV2Trainings(unittest.TestCase):
 
     @responses.activate
     def test_list_trainings_for_version_unwraps_trainings_key(self):
-        payload = {"trainings": [{"trainingId": "t-1"}, {"trainingId": "t-2"}]}
+        payload = {"trainings": [{"id": "t-1"}, {"id": "t-2"}]}
         responses.add(responses.GET, self.BASE_URL, json=payload, status=200)
 
         result = list_trainings_for_version(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION)
@@ -395,7 +395,7 @@ class TestTrainingTrash(unittest.TestCase):
     @responses.activate
     def test_resolve_version_training_id_resolves_the_sole_run(self):
         list_url = f"{API_URL}/{self.WORKSPACE}/{self.PROJECT}/{self.VERSION}/v2/trainings?api_key={self.API_KEY}"
-        responses.add(responses.GET, list_url, json={"trainings": [{"trainingId": "t-1"}]}, status=200)
+        responses.add(responses.GET, list_url, json={"trainings": [{"id": "t-1"}]}, status=200)
 
         resolved = resolve_version_training_id(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION)
 
@@ -407,7 +407,7 @@ class TestTrainingTrash(unittest.TestCase):
         responses.add(
             responses.GET,
             list_url,
-            json={"trainings": [{"trainingId": "t-1"}, {"trainingId": "t-2"}]},
+            json={"trainings": [{"id": "t-1"}, {"id": "t-2"}]},
             status=200,
         )
 

--- a/tests/test_rfapi.py
+++ b/tests/test_rfapi.py
@@ -384,6 +384,16 @@ class TestTrainingTrash(unittest.TestCase):
 
         self.assertEqual(json.loads(responses.calls[0].request.body), {})
 
+    def test_delete_version_training_rejects_blank_training_id(self):
+        for blank in ["", "   "]:
+            with self.assertRaises(ValueError):
+                delete_version_training(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION, training_id=blank)
+
+    def test_restore_version_training_rejects_blank_training_id(self):
+        for blank in ["", "   "]:
+            with self.assertRaises(ValueError):
+                restore_version_training(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION, training_id=blank)
+
     @responses.activate
     def test_restore_version_training_requires_training_id(self):
         expected_url = (

--- a/tests/test_rfapi.py
+++ b/tests/test_rfapi.py
@@ -9,9 +9,11 @@ import responses
 from roboflow.adapters.rfapi import (
     RoboflowError,
     create_training_v2,
+    delete_version_training,
     get_train_recipe,
     get_training,
     list_trainings_for_version,
+    restore_version_training,
     upload_image,
 )
 from roboflow.config import API_URL, DEFAULT_BATCH_NAME
@@ -346,6 +348,53 @@ class TestV2Trainings(unittest.TestCase):
 
         with self.assertRaises(RoboflowError):
             get_training(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION, training_id="missing")
+
+
+class TestTrainingTrash(unittest.TestCase):
+    API_KEY = "test_api_key"
+    WORKSPACE = "test-ws"
+    PROJECT = "test-project"
+    VERSION = "3"
+
+    @responses.activate
+    def test_delete_version_training_posts_training_id(self):
+        expected_url = (
+            f"{API_URL}/{self.WORKSPACE}/{self.PROJECT}/{self.VERSION}/v2/trainings/delete?api_key={self.API_KEY}"
+        )
+        responses.add(
+            responses.POST,
+            expected_url,
+            json={"trainingId": "t-1", "inTrash": True, "alreadyInTrash": False},
+            status=200,
+        )
+
+        result = delete_version_training(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION, training_id="t-1")
+
+        self.assertEqual(json.loads(responses.calls[0].request.body), {"trainingId": "t-1"})
+        self.assertEqual(result, {"trainingId": "t-1", "inTrash": True, "alreadyInTrash": False})
+
+    @responses.activate
+    def test_delete_version_training_omits_training_id_for_sole_run(self):
+        expected_url = (
+            f"{API_URL}/{self.WORKSPACE}/{self.PROJECT}/{self.VERSION}/v2/trainings/delete?api_key={self.API_KEY}"
+        )
+        responses.add(responses.POST, expected_url, json={"inTrash": True}, status=200)
+
+        delete_version_training(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION)
+
+        self.assertEqual(json.loads(responses.calls[0].request.body), {})
+
+    @responses.activate
+    def test_restore_version_training_requires_training_id(self):
+        expected_url = (
+            f"{API_URL}/{self.WORKSPACE}/{self.PROJECT}/{self.VERSION}/v2/trainings/restore?api_key={self.API_KEY}"
+        )
+        responses.add(responses.POST, expected_url, json={"trainingId": "t-1", "restored": True}, status=200)
+
+        result = restore_version_training(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION, training_id="t-1")
+
+        self.assertEqual(json.loads(responses.calls[0].request.body), {"trainingId": "t-1"})
+        self.assertEqual(result, {"trainingId": "t-1", "restored": True})
 
 
 if __name__ == "__main__":

--- a/tests/test_rfapi.py
+++ b/tests/test_rfapi.py
@@ -13,7 +13,8 @@ from roboflow.adapters.rfapi import (
     get_train_recipe,
     get_training,
     list_trainings_for_version,
-    restore_version_training,
+    resolve_version_training_id,
+    restore_trash_item,
     upload_image,
 )
 from roboflow.config import API_URL, DEFAULT_BATCH_NAME
@@ -357,54 +358,73 @@ class TestTrainingTrash(unittest.TestCase):
     VERSION = "3"
 
     @responses.activate
-    def test_delete_version_training_posts_training_id(self):
+    def test_delete_version_training_deletes_the_training_resource(self):
         expected_url = (
-            f"{API_URL}/{self.WORKSPACE}/{self.PROJECT}/{self.VERSION}/v2/trainings/delete?api_key={self.API_KEY}"
+            f"{API_URL}/{self.WORKSPACE}/{self.PROJECT}/{self.VERSION}/v2/trainings/t-1?api_key={self.API_KEY}"
         )
-        responses.add(
-            responses.POST,
-            expected_url,
-            json={"trainingId": "t-1", "inTrash": True, "alreadyInTrash": False},
-            status=200,
-        )
+        payload = {
+            "deleted": True,
+            "type": "training",
+            "workspace": self.WORKSPACE,
+            "project": self.PROJECT,
+            "projectId": "ds-1",
+            "version": self.VERSION,
+            "trainingId": "t-1",
+            "trash": True,
+        }
+        responses.add(responses.DELETE, expected_url, json=payload, status=200)
 
         result = delete_version_training(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION, training_id="t-1")
 
-        self.assertEqual(json.loads(responses.calls[0].request.body), {"trainingId": "t-1"})
-        self.assertEqual(result, {"trainingId": "t-1", "inTrash": True, "alreadyInTrash": False})
-
-    @responses.activate
-    def test_delete_version_training_omits_training_id_for_sole_run(self):
-        expected_url = (
-            f"{API_URL}/{self.WORKSPACE}/{self.PROJECT}/{self.VERSION}/v2/trainings/delete?api_key={self.API_KEY}"
-        )
-        responses.add(responses.POST, expected_url, json={"inTrash": True}, status=200)
-
-        delete_version_training(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION)
-
-        self.assertEqual(json.loads(responses.calls[0].request.body), {})
+        self.assertEqual(result, payload)
 
     def test_delete_version_training_rejects_blank_training_id(self):
         for blank in ["", "   "]:
             with self.assertRaises(ValueError):
                 delete_version_training(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION, training_id=blank)
 
-    def test_restore_version_training_rejects_blank_training_id(self):
+    def test_resolve_version_training_id_returns_supplied_id_without_listing(self):
+        resolved = resolve_version_training_id(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION, "t-9")
+        self.assertEqual(resolved, "t-9")
+
+    def test_resolve_version_training_id_rejects_blank_id(self):
         for blank in ["", "   "]:
             with self.assertRaises(ValueError):
-                restore_version_training(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION, training_id=blank)
+                resolve_version_training_id(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION, blank)
 
     @responses.activate
-    def test_restore_version_training_requires_training_id(self):
-        expected_url = (
-            f"{API_URL}/{self.WORKSPACE}/{self.PROJECT}/{self.VERSION}/v2/trainings/restore?api_key={self.API_KEY}"
+    def test_resolve_version_training_id_resolves_the_sole_run(self):
+        list_url = f"{API_URL}/{self.WORKSPACE}/{self.PROJECT}/{self.VERSION}/v2/trainings?api_key={self.API_KEY}"
+        responses.add(responses.GET, list_url, json={"trainings": [{"trainingId": "t-1"}]}, status=200)
+
+        resolved = resolve_version_training_id(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION)
+
+        self.assertEqual(resolved, "t-1")
+
+    @responses.activate
+    def test_resolve_version_training_id_raises_when_the_version_owns_several_runs(self):
+        list_url = f"{API_URL}/{self.WORKSPACE}/{self.PROJECT}/{self.VERSION}/v2/trainings?api_key={self.API_KEY}"
+        responses.add(
+            responses.GET,
+            list_url,
+            json={"trainings": [{"trainingId": "t-1"}, {"trainingId": "t-2"}]},
+            status=200,
         )
-        responses.add(responses.POST, expected_url, json={"trainingId": "t-1", "restored": True}, status=200)
 
-        result = restore_version_training(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION, training_id="t-1")
+        with self.assertRaises(RoboflowError) as ctx:
+            resolve_version_training_id(self.API_KEY, self.WORKSPACE, self.PROJECT, self.VERSION)
+        self.assertIn("MULTIPLE_TRAININGS", str(ctx.exception))
+        self.assertIn("t-2", str(ctx.exception))
 
-        self.assertEqual(json.loads(responses.calls[0].request.body), {"trainingId": "t-1"})
-        self.assertEqual(result, {"trainingId": "t-1", "restored": True})
+    @responses.activate
+    def test_restore_trash_item_restores_a_training(self):
+        expected_url = f"{API_URL}/{self.WORKSPACE}/trash/restore?api_key={self.API_KEY}"
+        responses.add(responses.POST, expected_url, json={"restored": True}, status=200)
+
+        result = restore_trash_item(self.API_KEY, self.WORKSPACE, "training", "t-1")
+
+        self.assertEqual(json.loads(responses.calls[0].request.body), {"type": "training", "id": "t-1"})
+        self.assertEqual(result, {"restored": True})
 
 
 if __name__ == "__main__":

--- a/tests/test_rfapi.py
+++ b/tests/test_rfapi.py
@@ -416,6 +416,11 @@ class TestTrainingTrash(unittest.TestCase):
         self.assertIn("MULTIPLE_TRAININGS", str(ctx.exception))
         self.assertIn("t-2", str(ctx.exception))
 
+    def test_restore_trash_item_rejects_blank_ids(self):
+        for blank in ["", "   ", None]:
+            with self.assertRaises(ValueError):
+                restore_trash_item(self.API_KEY, self.WORKSPACE, "training", blank)
+
     @responses.activate
     def test_restore_trash_item_restores_a_training(self):
         expected_url = f"{API_URL}/{self.WORKSPACE}/trash/restore?api_key={self.API_KEY}"

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -117,5 +117,31 @@ class TestTrainingModels(unittest.TestCase):
         self.assertEqual(get_training.call_count, 3)
 
 
+class TestTrainingTrash(unittest.TestCase):
+    def test_delete_moves_run_to_trash(self):
+        training = Training("key", "ws", "proj", "1", {"trainingId": "training-1"})
+
+        with patch(
+            "roboflow.core.training.rfapi.delete_version_training",
+            return_value={"trainingId": "training-1", "inTrash": True, "alreadyInTrash": False},
+        ) as delete:
+            result = training.delete()
+
+        delete.assert_called_once_with("key", "ws", "proj", "1", training_id="training-1")
+        self.assertTrue(result["inTrash"])
+
+    def test_restore_brings_run_back(self):
+        training = Training("key", "ws", "proj", "1", {"trainingId": "training-1"})
+
+        with patch(
+            "roboflow.core.training.rfapi.restore_version_training",
+            return_value={"trainingId": "training-1", "restored": True},
+        ) as restore:
+            result = training.restore()
+
+        restore.assert_called_once_with("key", "ws", "proj", "1", training_id="training-1")
+        self.assertTrue(result["restored"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -123,23 +123,23 @@ class TestTrainingTrash(unittest.TestCase):
 
         with patch(
             "roboflow.core.training.rfapi.delete_version_training",
-            return_value={"trainingId": "training-1", "inTrash": True, "alreadyInTrash": False},
+            return_value={"deleted": True, "type": "training", "trainingId": "training-1", "trash": True},
         ) as delete:
             result = training.delete()
 
         delete.assert_called_once_with("key", "ws", "proj", "1", training_id="training-1")
-        self.assertTrue(result["inTrash"])
+        self.assertTrue(result["trash"])
 
-    def test_restore_brings_run_back(self):
+    def test_restore_goes_through_the_shared_trash_route(self):
         training = Training("key", "ws", "proj", "1", {"trainingId": "training-1"})
 
         with patch(
-            "roboflow.core.training.rfapi.restore_version_training",
-            return_value={"trainingId": "training-1", "restored": True},
+            "roboflow.core.training.rfapi.restore_trash_item",
+            return_value={"restored": True},
         ) as restore:
             result = training.restore()
 
-        restore.assert_called_once_with("key", "ws", "proj", "1", training_id="training-1")
+        restore.assert_called_once_with("key", "ws", "training", "training-1")
         self.assertTrue(result["restored"])
 
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -130,6 +130,12 @@ class TestTrainingTrash(unittest.TestCase):
         delete.assert_called_once_with("key", "ws", "proj", "1", training_id="training-1")
         self.assertTrue(result["trash"])
 
+    def test_restore_rejects_a_blank_training_id(self):
+        training = Training("key", "ws", "proj", "1", {"trainingId": "   "})
+
+        with self.assertRaises(ValueError):
+            training.restore()
+
     def test_restore_goes_through_the_shared_trash_route(self):
         training = Training("key", "ws", "proj", "1", {"trainingId": "training-1"})
 


### PR DESCRIPTION
## What does this PR do?

Adds SDK and CLI support for the platform's new training deletion feature (roboflow/roboflow#13869), which is **soft-delete-first**: deleting a training moves it (and every model it produced) to the workspace Trash for 30 days, hidden from listings but restorable, before permanent cleanup.

- **`rfapi.delete_version_training(...)`** — thin wrapper for `DELETE /{ws}/{project}/{version}/v2/trainings/{training_id}` (the platform's entity trash pattern; `training_id` required). Restore goes through the existing **`rfapi.restore_trash_item(..., "training", id)`** — the same shared `POST /{ws}/trash/restore` route project/version/workflow restores use; there is no bespoke trainings restore route. **`rfapi.resolve_version_training_id(...)`** resolves an omitted id to the version's sole run client-side (several runs raise `MULTIPLE_TRAININGS` with the ids listed).
- **`Version.delete_training(training_id=None)`** / **`Version.restore_training(training_id)`** — mirror the existing `Version.delete()`/`Version.restore()` trash semantics; **`Training.delete()`/`Training.restore()`** do the same on the run object returned by the trainings APIs.
- **CLI** — `roboflow train delete <project>/<version> [--training-id ...]` and `roboflow train restore <project>/<version> --training-id ...`, with actionable hints for the refusal cases (in-flight run → stop/cancel first; multi-run version needs `--training-id`; item not in trash → `roboflow trash list`). The version's hosted endpoint always serves the oldest remaining run's model: when the deleted run was serving, the API reports `versionAliasAction: "repointed"` (+ `versionAliasTarget`) or `"deleted"` when no run survives, and `train delete` prints the switch or the stop. **`roboflow train list <project>/<version>`** enumerates a version's runs with their ids (reading the API's `id` field) so MMPV training ids are discoverable. Blank/whitespace `--training-id` values fail as structured usage errors (exit code 2) instead of raw tracebacks, and `restore_trash_item` validates its id for every trash type.

Deletion is soft-only on the public API by design — permanent deletion stays in the web UI's Trash view, consistent with the existing note in `rfapi` that permanent trash actions are never exposed to API keys.

**Related Issue(s):** Depends on roboflow/roboflow#13869 (platform endpoints) — merge/deploy that first; until then these calls return 404.

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
- [x] unit tests
- [x] e2e staging test with localapi built from https://github.com/roboflow/roboflow/pull/13869

```
> uv run roboflow train --help

 Usage: roboflow train [OPTIONS] [COMMAND] [ARGS]...

 Train a model

╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --checkpoint            TEXT     Checkpoint to resume training from                                                  │
│ --epochs                INTEGER  Number of training epochs                                                           │
│ --project       -p      TEXT     Project ID to train                                                                 │
│ --speed                 TEXT     Training speed preset                                                               │
│ --type          -t      TEXT     Model type (e.g. rfdetr-nano, yolov8n)                                              │
│ --train-recipe          TEXT     Full trainRecipe as inline JSON or @path/to/file.json (see 'roboflow train          │
│                                  recipe'); --epochs is folded into its hyperparameters unless the recipe already     │
│                                  sets epochs                                                                         │
│ --version       -v      INTEGER  Version number to train                                                             │
│ --help          -h               Show this message and exit.                                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ cancel   Cancel an in-flight training run.                                                                           │
│ delete   Move a terminal training run to the workspace Trash (soft delete).                                          │
│ list     List a version's training runs with their ids.                                                              │
│ recipe   Show the training recipe schema and template for a model type.                                              │
│ restore  Restore a trashed training run (and its models) back into listings.                                         │
│ results  Run-level training results bundle.                                                                          │
│ start    Start training for a dataset version.                                                                       │
│ stop     Request a graceful early-stop on an in-flight training run.                                                 │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

```
 > uv run roboflow train delete --help

 Usage: roboflow train delete [OPTIONS] TARGET

 Move a terminal training run to the workspace Trash (soft delete).

 The run and every model it produced disappear from listings but stay
 restorable for 30 days ('roboflow train restore' or the web Trash view),
 after which they are permanently deleted. In-flight runs are refused —
 stop or cancel first — as is the run backing the version's registered
 model. Permanent deletion is only available in the web UI's Trash view.

╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ *    target      TEXT  Training to delete as 'project/version' [required]                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --training-id          TEXT  Training id of the run to delete (versions can own several). Omit to target the         │
│                              version's sole run.                                                                     │
│ --help         -h            Show this message and exit.                                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

```
> uv run roboflow train delete chess-pieces-fmhpz/112 --training-id b704c8e6ee031f3ef563

Training moved to Trash for chess-pieces-fmhpz version 112. Restorable for 30 days via 'roboflow train restore'.
```
<img width="1824" height="1277" alt="image" src="https://github.com/user-attachments/assets/ec62f7dc-4e33-4dd6-ae3a-314d55eca964" />
<img width="1824" height="1277" alt="image" src="https://github.com/user-attachments/assets/0bef082b-a422-4be8-8c73-80973a50a630" />

```
> uv run roboflow train restore chess-pieces-fmhpz/112 --training-id b704c8e6ee031f3ef563

Training restored for chess-pieces-fmhpz version 112.
```
<img width="1824" height="1277" alt="image" src="https://github.com/user-attachments/assets/79d053aa-ab69-4890-94cb-eb29cd89ee9a" />
<img width="1824" height="1277" alt="image" src="https://github.com/user-attachments/assets/04e8ea29-f2a0-4efb-9aac-1b48253e5bba" />

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

Mirrors the existing `cancel_version_training`/`stop_version_training` adapter pattern and the `train cancel`/`train stop` CLI command pattern. The companion MCP PR (roboflow/roboflow-mcp#124) was closed by design: MCP has no trash-lifecycle tools for any entity yet, so trainings won't lead there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




