### PR TITLE
Fix CI: ignore ruff CPY rules stabilized in today's ruff 0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ ignore = [
     "BLE",
     "C",
     "COM",
+    "CPY",
     "D",
     "DTZ",
     "EM",


### PR DESCRIPTION
## Description

Main's `check_code_quality` went red today with `CPY001 Missing copyright notice` on all 72 source files (first failing run: c731b4e; the prior run passed this morning).

Cause: **ruff 0.16.0 released today** stabilized the `flake8-copyright` (`CPY`) rules, and this repo's config uses `select = ["ALL"]` with unpinned ruff in CI — so the new rule became enforced overnight. The repo doesn't use copyright headers, so this adds `CPY` to the existing ignore list (one line).

Verified locally on ruff 0.16.0 + mypy 2.3.0: `make check_code_quality` → no issues in 72 files.

Alternative if preferred: pin `ruff`/`mypy` versions in the `dev` extra so toolchain releases can't break CI mid-day — happy to switch this PR to that (or do both).