### PR TITLE
fix: ignore ruff CPY rules (ruff 0.16.0 broke CI repo-wide)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ ignore = [
     "BLE",
     "C",
     "COM",
+    "CPY",
     "D",
     "DTZ",
     "EM",


### PR DESCRIPTION
## What does this PR do?

Unblocks CI for every branch. CI installs unpinned `ruff`; **0.16.0** ([published 2026-07-23](https://github.com/astral-sh/ruff/releases)) starts enforcing `CPY001` (missing copyright notice) under our `select = ["ALL"]`, failing all 72 files at `1:1`. Main's own latest test run is red for this reason (first failing run: the #510 merge, which happened to land right after the ruff release — the commit itself is innocent).

Adds `"CPY"` to the existing family-level ignore list, matching how the config already excludes rule families wholesale.

**Related Issue(s):** n/a — CI infrastructure fix.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
With `ruff==0.16.0` locally: `make check_code_quality` passes end to end (ruff format --check, ruff check, mypy — "Success: no issues found in 72 source files"). No test changes; config-only.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

Alternative considered: pinning `ruff` in the dev extras — declined since the repo deliberately floats dev tools; family-ignore matches the existing config idiom. Note the test workflow checks out the PR **head ref** (not the merge ref), so open PRs stay red until they rebase over this or carry the same one-liner (#512 carries it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)