### PR TITLE
Release v1.4.1

### DIFF
--- a/CLI-COMMANDS.md
+++ b/CLI-COMMANDS.md
@@ -181,6 +181,8 @@ roboflow annotation job admin-list -p my-project --limit 50
 roboflow annotation job admin-get <job-id> -p my-project
 roboflow annotation job admin-create -p my-project --batch <batch-id> \
   --labeler a@co.com --reviewer b@co.com --name "Label round 1"
+roboflow annotation job reassign-images -p my-project --image-id <image-id> \
+  --labeler a@co.com --yes
 roboflow annotation job create -p my-project --name "Label round 1" \
   --batch <batch-id> --num-images 100 --labeler a@co.com --reviewer b@co.com
 roboflow annotation job images <job-id> -p my-project

--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -21,7 +21,7 @@ except ImportError:
     CLIPModel = None  # type: ignore[assignment,misc]
     GazeModel = None  # type: ignore[assignment,misc]
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/cli/handlers/annotation.py
+++ b/roboflow/cli/handlers/annotation.py
@@ -268,18 +268,21 @@ def job_reassign_images(
     reviewer: Annotated[Optional[str], typer.Option(help="Reviewer email")] = None,
     instructions: Annotated[Optional[str], typer.Option(help="Labeling instructions")] = None,
     name: Annotated[Optional[str], typer.Option(help="Optional job name")] = None,
+    yes: Annotated[bool, typer.Option("-y", "--yes", help="Confirm reassignment of the images")] = False,
 ) -> None:
     """Create a job by explicitly reassigning images."""
-    _simple_command(
-        ctx_to_args(ctx, project=project),
-        "reassign_annotation_job_images",
-        image_ids=image_ids,
-        labeler_email=labeler,
-        reviewer_email=reviewer,
-        instructions=instructions,
-        name=name,
-        success="Reassigned images to a new annotation job.",
-    )
+    args = ctx_to_args(ctx, project=project, yes=yes)
+    if _confirm(args, "Remove these images from their current assignments and reassign them to a new job?"):
+        _simple_command(
+            args,
+            "reassign_annotation_job_images",
+            image_ids=image_ids,
+            labeler_email=labeler,
+            reviewer_email=reviewer,
+            instructions=instructions,
+            name=name,
+            success="Reassigned images to a new annotation job.",
+        )
 
 
 @job_app.command("add-images")

--- a/tests/cli/test_annotation_handler.py
+++ b/tests/cli/test_annotation_handler.py
@@ -422,6 +422,38 @@ class TestAnnotationAdministrationCommands(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         mock_api.assert_called_once_with("key", "ws", "proj", "job-1", image_ids=["image-1"])
 
+    @patch("roboflow.adapters.rfapi.reassign_annotation_job_images")
+    @patch(_RESOLVE, return_value=("key", "ws", "proj"))
+    def test_job_reassign_images_requires_yes_non_interactively(self, _resolve, mock_api):
+        command = [
+            "annotation",
+            "job",
+            "reassign-images",
+            "-p",
+            "ws/proj",
+            "--image-id",
+            "image-1",
+            "--labeler",
+            "labeler@example.com",
+        ]
+        result = runner.invoke(app, command)
+        self.assertEqual(result.exit_code, 1)
+        mock_api.assert_not_called()
+
+        mock_api.return_value = {"jobId": "job-1"}
+        result = runner.invoke(app, [*command, "--yes"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_api.assert_called_once_with(
+            "key",
+            "ws",
+            "proj",
+            image_ids=["image-1"],
+            labeler_email="labeler@example.com",
+            reviewer_email=None,
+            instructions=None,
+            name=None,
+        )
+
     @patch("roboflow.adapters.rfapi.accept_annotation_job_images")
     @patch(_RESOLVE, return_value=("key", "ws", "proj"))
     def test_job_accept_maps_lists_and_split_counts(self, _resolve, mock_api):


### PR DESCRIPTION
# Description

Prepares the `v1.4.1` release for the annotation administration SDK and CLI added in #516.

This bumps the package version from `1.4.0` to `1.4.1` and adds an explicit `--yes` or interactive confirmation gate to `roboflow annotation job reassign-images`, preventing non-interactive callers from silently removing images from their prior assignments. The CLI documentation and regression coverage are updated accordingly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Ran 29 annotation CLI handler tests
- Ran 10 annotation administration adapter tests
- Ran 88 legacy RFAPI phase-2 adapter tests
- Ran Ruff and mypy on the affected implementation and test files
- Verified both full and slim package metadata report version `1.4.1`
- Ran `git diff --check`

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- No deployment occurs on merge
- After merge, publish the GitHub release/tag `v1.4.1` to trigger publishing of `roboflow` and `roboflow-slim` to PyPI

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
