### PR TITLE
Keep NumPy type-check cap out of runtime metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,7 @@ idna>=3.7
 cycler
 kiwisolver>=1.3.1
 matplotlib
-# numpy 2.4 ships PEP 695 `type` statements in its stubs, which mypy rejects
-# under python_version=3.10 (see [tool.mypy] in pyproject.toml). Cap below 2.4,
-# matching rf-detr's typing constraint.
-numpy>=1.18.5,<2.4
+numpy>=1.18.5
 opencv-python-headless>=4.10.0  # relax exact pin to avoid downstream conflicts (#349)
 Pillow>=7.1.2
 # https://github.com/roboflow/roboflow-python/issues/390

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ setuptools.setup(
         "desktop": ["opencv-python==4.8.0.74"],
         "dev": [
             "mypy",
+            # Keep NumPy's PEP 695 stubs out of the Python 3.10 mypy target
+            # without constraining SDK users at runtime.
+            "numpy<2.4",
             "responses",
             "ruff",
             "types-pyyaml",


### PR DESCRIPTION
## Summary

- remove the NumPy `<2.4` cap from runtime requirements
- retain the cap in the `dev` extra, where it protects the Python 3.10 mypy target

## Motivation

`setup.py` uses `requirements.txt` as `install_requires`, so the current type-check workaround is also published as runtime metadata. It prevents SDK users from resolving newer NumPy releases even though the incompatibility is in mypy parsing NumPy's newer stubs, not in the SDK runtime.

This follows the original dev-only intent discussed in #498 and #499. Moving the cap to the `dev` extra keeps the Python 3.10 type-check environment stable without constraining users of the SDK.

## Test plan

- Python 3.14.6 with NumPy 2.5.2: `python -m unittest` — 970 passed, 1 skipped
- Python 3.10 with NumPy 2.2.6: Ruff format/lint and mypy over 72 source files pass
- built runtime metadata requires `numpy>=1.18.5`; installing the `dev` extra applies `numpy<2.4`
- `git diff --check origin/main...HEAD`
