### PR TITLE
docs: give the Quickstart and Changelog nav entries real pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ rf = roboflow.Roboflow(api_key="")
 
 </details>
 
+<!-- --8<-- [start:quickstart] -->
 ## Quickstart
 
 Below are some common methods used with the Roboflow Python package, presented concisely for reference. For a full library reference, refer to the [Roboflow API reference documentation](https://docs.roboflow.com/api-reference).
@@ -154,6 +155,8 @@ predictions = model.predict(img_url, hosted=True).json()
 
 print(predictions)
 ```
+
+<!-- --8<-- [end:quickstart] -->
 
 ### Search and Export
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+--8<-- "CHANGELOG.md"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,1 @@
+--8<-- "README.md:quickstart"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,9 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.superfences
+  - pymdownx.snippets:
+      base_path: ['.']
+      check_paths: true
   - attr_list
   - md_in_html
   - pymdownx.tabbed:


### PR DESCRIPTION
## Description

Closes #380.

`mkdocs.yml` listed two nav entries whose files do not exist under `docs/`:

```
nav:
  - Quickstart: quickstart.md      # docs/quickstart.md never existed
  ...
  - Changelog: changelog.md        # docs/changelog.md never existed
```

`docs/` contains only `index.md`, `core/`, `models/` and `styles.css`, so both sidebar links published as 404s. mkdocs says so on every build:

```
WARNING - A reference to 'quickstart.md' is included in the 'nav' configuration, which is not found in the documentation files.
WARNING - A reference to 'changelog.md' is included in the 'nav' configuration, which is not found in the documentation files.
```

Both pages now exist and pull their content from the canonical copy that already lives in the repository, so neither can drift.

## Changes Made

- `docs/quickstart.md` — includes the README's Quickstart section through `pymdownx.snippets`. The section is delimited in `README.md` with `--8<-- [start:quickstart]` / `[end:quickstart]` HTML comments, which render as nothing on GitHub.
- `docs/changelog.md` — includes the root `CHANGELOG.md` the same way.
- `mkdocs.yml` — enable `pymdownx.snippets` with `base_path: ['.']` and `check_paths: true`, so a future missing include fails the build rather than rendering an empty page.

I chose includes over new hand-written pages because `docs/index.md` is already a copy of `README.md`; a third copy of the quickstart would be one more thing to keep in sync. The nav entry could also simply have been deleted, but a Python SDK reasonably has a Quickstart in its sidebar, and the content already existed — it just was not reachable.

## Testing

- [x] I have tested this code locally
- [x] All new and existing tests pass

```
mkdocs build     before: 50 warnings, including the two above
mkdocs build     after:  48 warnings, neither of the two present
```

The 48 remaining warnings are pre-existing `griffe` docstring warnings in `roboflow/core/` and `roboflow/models/`, untouched by this change.

Rendered output checked, not just the build exit code: `site/quickstart/index.html` contains the Quickstart body, and `site/changelog/index.html` contains the changelog entries.

```
python -m unittest    970 tests, OK (skipped=1)   — unchanged from before the edit
ruff check .          All checks passed!
```

`ruff format --check` reports 3 files (`CONTRIBUTING.md`, `README.md`, `docs/index.md`); it reports the same 3 on the parent commit, so that drift is pre-existing and not introduced here. The two files this PR adds both pass.

## Google Colab (optional)

Not applicable; documentation build change.
