### PR TITLE
fix: rewrite the test split path for yolov5 and yolov7 downloads

### DIFF
--- a/roboflow/core/version.py
+++ b/roboflow/core/version.py
@@ -817,6 +817,9 @@ class Version:
             if format in ["yolov5pytorch", "yolov7pytorch"]:
                 content["train"] = location + content["train"].lstrip("..")
                 content["val"] = location + content["val"].lstrip("..")
+                # A version generated without a test split has no `test` key at all.
+                if "test" in content:
+                    content["test"] = location + content["test"].lstrip("..")
             try:
                 # get_wrong_dependencies_versions raises exception if ultralytics is not installed at all  # noqa: E501 // docs
                 if format == "yolov8" and not get_wrong_dependencies_versions(

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,10 +1,12 @@
 import os
+import tempfile
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import requests
 import responses
+import yaml
 
 from roboflow.adapters import rfapi
 from roboflow.config import (
@@ -470,3 +472,47 @@ class TestCreateTrainingWithRecipe(V2TrainingRecipeTestCase):
         self.version.exports = ["coco"]
         _, _, _, mock_export = self._create(model_type="rfdetr-medium")
         mock_export.assert_not_called()
+
+
+class TestReformatYaml(unittest.TestCase):
+    """`__reformat_yaml` rewrites split paths in the downloaded data.yaml."""
+
+    def setUp(self):
+        super().setUp()
+        self.version = get_version(
+            project_name="Test Dataset",
+            id="test-workspace/test-project/2",
+            version_number="3",
+        )
+        self.reformat_yaml = self.version._Version__reformat_yaml
+
+    def _write_and_reformat(self, content, format):
+        with tempfile.TemporaryDirectory() as location:
+            with open(os.path.join(location, "data.yaml"), "w") as handle:
+                yaml.dump(content, handle)
+            self.reformat_yaml(location, format)
+            with open(os.path.join(location, "data.yaml")) as handle:
+                return yaml.safe_load(handle), location
+
+    def test_yolov7_rewrites_test_alongside_train_and_val(self):
+        content, location = self._write_and_reformat(
+            {"train": "../train/images", "val": "../valid/images", "test": "../test/images", "nc": 1},
+            "yolov7pytorch",
+        )
+        self.assertEqual(content["train"], location + "/train/images")
+        self.assertEqual(content["val"], location + "/valid/images")
+        self.assertEqual(content["test"], location + "/test/images")
+
+    def test_yolov5_rewrites_test_alongside_train_and_val(self):
+        content, location = self._write_and_reformat(
+            {"train": "../train/images", "val": "../valid/images", "test": "../test/images", "nc": 1},
+            "yolov5pytorch",
+        )
+        self.assertEqual(content["test"], location + "/test/images")
+
+    def test_missing_test_split_is_left_alone(self):
+        content, _ = self._write_and_reformat(
+            {"train": "../train/images", "val": "../valid/images", "nc": 1},
+            "yolov7pytorch",
+        )
+        self.assertNotIn("test", content)


### PR DESCRIPTION
## Description

Closes #156.

`Version.__reformat_yaml` prefixes the split paths in a downloaded `data.yaml` with the dataset location. For `yolov5pytorch` and `yolov7pytorch` it does this for `train` and `val` but not `test`:

```python
if format in ["yolov5pytorch", "yolov7pytorch"]:
    content["train"] = location + content["train"].lstrip("..")
    content["val"] = location + content["val"].lstrip("..")
```

So the file that lands on disk carries two rewritten paths and one untouched one:

```yaml
train: my-dataset-3/train/images
val:   my-dataset-3/valid/images
test:  ../test/images            # relative to the wrong directory
```

The `mt-yolov6` branch directly above already rewrites all three.

## Type of Change

- 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `roboflow/core/version.py` — rewrite `test` alongside `train` and `val` for the yolov5/yolov7 branch.
- Guard it with `if "test" in content`. A version generated without a test split has no `test` key at all, and an unguarded assignment would turn a working download into a `KeyError`.
- `tests/test_version.py` — a `TestReformatYaml` case class covering yolov7 and yolov5, plus the no-test-split case.

## Motivation and Context

I want to flag a decision rather than quietly make it.

#334 ("bugfix - downloading yolov8 files incorrectly amends data.yaml") took the position that this rewriting is itself the mistake — that the server's `../train/images` is already correct and roboflow-python should leave it alone. That reasoning applies just as well to the yolov5/yolov7 branch, and removing the rewrite entirely is a defensible reading of this issue.

I did not do that, because it changes behaviour for every existing yolov5/yolov7 user and relitigates a decision that is yours rather than mine. What is not defensible under either reading is the current state, where one of three splits is treated differently from the other two within the same file. This PR makes the branch internally consistent and nothing more.

If you would rather delete the yolov5/yolov7 rewrite altogether, I am happy to send that instead — say the word and I will swap it.

Two other things I noticed and deliberately left alone:

- The `mt-yolov6` branch indexes `content["test"]` unguarded, so it raises `KeyError` on a dataset with no test split. Same latent bug, different format; out of scope here.
- `.lstrip("..")` strips a *set* of characters, not a prefix, so it is equivalent to the `.lstrip(".")` used two lines above. Harmless for these inputs, but the two branches read as if they differ when they do not.

## Testing

- [x] I have tested this code locally
- [x] I have added unit tests that prove my fix is effective
- [x] All new and existing tests pass

Against unmodified `main`, two of the three new tests fail on exactly the reported symptom:

```
- ../test/images
+ /var/folders/.../tmpx2c0ibkb/test/images
FAILED (failures=2)
```

The third (no test split present) passes either way by design — it exists to pin the guard, so that a future change cannot reintroduce a `KeyError`.

```
python -m unittest     before: 970 tests, OK (skipped=1)
python -m unittest     after:  973 tests, OK (skipped=1)
ruff check roboflow/ tests/     All checks passed!
ruff format --check             2 files already formatted
```

## Google Colab (optional)

Not applicable; the change is in local post-download file handling and is covered by unit tests that write and re-read a `data.yaml` in a temporary directory, with no API key or network access needed.
