### PR TITLE
Fix project search membership filter type

### DIFF
--- a/roboflow/__init__.py
+++ b/roboflow/__init__.py
@@ -21,7 +21,7 @@ except ImportError:
     CLIPModel = None  # type: ignore[assignment,misc]
     GazeModel = None  # type: ignore[assignment,misc]
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 
 
 def check_key(api_key, model, notebook, num_retries=0):

--- a/roboflow/core/project.py
+++ b/roboflow/core/project.py
@@ -672,7 +672,7 @@ class Project:
         limit: int = 100,
         tag: Optional[str] = None,
         class_name: Optional[str] = None,
-        in_dataset: Optional[str] = None,
+        in_dataset: Optional[bool] = None,
         batch: bool = False,
         batch_id: Optional[str] = None,
         fields: Optional[List[str]] = None,
@@ -690,7 +690,7 @@ class Project:
             limit (int): limit of results
             tag (str): tag that an image must have
             class_name (str): class name that an image must have
-            in_dataset (str): dataset that an image must be in
+            in_dataset (bool): whether an image must be in this project's dataset
             batch (bool): whether the image must be in a batch
             batch_id (str): batch id that an image must be in
             annotation_job (bool): whether the image must be in an annotation job
@@ -773,7 +773,7 @@ class Project:
         limit: int = 100,
         tag: Optional[str] = None,
         class_name: Optional[str] = None,
-        in_dataset: Optional[str] = None,
+        in_dataset: Optional[bool] = None,
         batch: bool = False,
         batch_id: Optional[str] = None,
         fields: Optional[List[str]] = None,
@@ -791,7 +791,7 @@ class Project:
             limit (int): limit of results
             tag (str): tag that an image must have
             class_name (str): class name that an image must have
-            in_dataset (str): dataset that an image must be in
+            in_dataset (bool): whether an image must be in this project's dataset
             batch (bool): whether the image must be in a batch
             batch_id (str): batch id that an image must be in
             annotation_job (bool): whether the image must be in an annotation job


### PR DESCRIPTION
# Description

The Python SDK typed `in_dataset` as a project name even though project image search treats it as a boolean membership filter, so this aligns `Project.search()` and `Project.search_all()` with the API contract without changing request behavior. The package version is bumped to `1.4.3`; companion documentation is in [roboflow/docs#228](https://github.com/roboflow/docs/pull/228).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

- `python -m unittest tests.test_project`
- `ruff check roboflow/core/project.py`
- `ruff format --check roboflow/core/project.py`

## Any specific deployment considerations

- Publish in the next Python SDK release.
