### PR TITLE
feat(ci): Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: ⬆️
+    target-branch: "develop"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
       default-days: 7
     commit-message:
       prefix: ⬆️
-    target-branch: "develop"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## What does this PR do?

Noticed the actions used in the workflows here are outdated, proposing a Dependabot configuration to update - reference https://docs.github.com/en/actions/security-guides/using-githubs-security-features-to-secure-your-use-of-github-actions#keeping-the-actions-in-your-workflows-secure-and-up-to-date

Resolves warnings on workflow runs e.g. https://github.com/roboflow/roboflow-python/actions/runs/33541969237

> `The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-python@v5`

Suggest enabling https://docs.github.com/en/code-security/dependabot/working-with-dependabot/about-dependabot-on-github-actions-runners#enabling-or-disabling-for-your-repository as well

## Type of Change

- New feature (non-breaking change that adds functionality)

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

Copied from https://github.com/roboflow/supervision/blob/develop/.github/dependabot.yml#L1-L16.
